### PR TITLE
ci: add claude reusable workflow

### DIFF
--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -1,0 +1,32 @@
+name: Claude Code
+
+on:
+  workflow_call:
+    secrets:
+      anthropic-api-key:
+        description: 'Anthropic API key for Claude Code agent'
+        required: true
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@88c168b39e7e64da0286d812b6e9fbebb6708185 # v1
+        with:
+          anthropic_api_key: ${{ secrets.anthropic-api-key }} # zizmor: ignore[secrets-outside-env] -- API key passed via workflow_call, not a repo secret


### PR DESCRIPTION
## Summary

- Extracts the Claude Code agent workflow as a reusable `workflow_call` workflow
- Source: identical workflow in `loft-enterprise` and `vcluster-pro` (triggered by `@claude` mentions in PRs and reviews)
- Scoped to PR events only: `issue_comment`, `pull_request_review_comment`, `pull_request_review`
- SHA-pinned `actions/checkout@v6.0.2` and `anthropics/claude-code-action@v1`
- Added `persist-credentials: false` on checkout
- Parameterized `ANTHROPIC_API_KEY` as a `workflow_call` secret (`anthropic-api-key`)
- Write permissions for `contents` and `pull-requests` so Claude can respond and push
- No fork guard needed — `claude-code-action` validates actor has write access before running

## Caller example

```yaml
name: Claude Code

on:
  issue_comment:
    types: [created]
  pull_request_review_comment:
    types: [created]
  pull_request_review:
    types: [submitted]

jobs:
  claude:
    uses: loft-sh/github-actions/.github/workflows/claude.yaml@claude/v1
    secrets:
      anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
```

## Test plan

- [x] actionlint passes
- [x] zizmor passes (secret suppression matches existing pattern in backport.yaml)
- [ ] CI green
- [ ] Tag `claude/v1` after merge
- [ ] Migration PRs in loft-enterprise and vcluster-pro

Part of the Phase 3 GitHub Actions centralization effort.