### PR TITLE
ci: add reusable auto-approve workflow for bot prs

### DIFF
--- a/.github/workflows/auto-approve-bot-prs.yaml
+++ b/.github/workflows/auto-approve-bot-prs.yaml
@@ -1,0 +1,105 @@
+name: Auto-approve bot PRs
+
+on:
+  workflow_call:
+    inputs:
+      trusted-authors:
+        description: 'Comma-separated list of trusted bot logins'
+        type: string
+        default: 'renovate[bot],loft-bot,github-actions[bot]'
+      merge-method:
+        description: 'Merge method for auto-merge (squash, merge, rebase)'
+        type: string
+        default: 'squash'
+      auto-merge:
+        description: 'Enable auto-merge after approval'
+        type: boolean
+        default: true
+    secrets:
+      gh-access-token:
+        description: 'GitHub PAT for approving PRs (must be different identity from PR author)'
+        required: true
+
+jobs:
+  auto-approve:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check eligibility
+        id: check
+        env:
+          TRUSTED_AUTHORS: ${{ inputs.trusted-authors }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BRANCH: ${{ github.event.pull_request.head.ref }}
+        run: |
+          # Exact-match author against trusted list
+          IFS=',' read -ra AUTHORS <<< "${TRUSTED_AUTHORS}"
+          author_trusted=false
+          for author in "${AUTHORS[@]}"; do
+            if [ "${author}" = "${PR_AUTHOR}" ]; then
+              author_trusted=true
+              break
+            fi
+          done
+
+          if [ "${author_trusted}" != "true" ]; then
+            echo "Author '${PR_AUTHOR}' not in trusted list, skipping"
+            echo "eligible=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          eligible=false
+          reason=""
+          if [[ "${PR_TITLE}" =~ ^chore(\(|:) ]]; then eligible=true; reason="chore PR"; fi
+          if [[ "${PR_TITLE}" =~ ^fix\(deps\) ]]; then eligible=true; reason="dependency fix PR"; fi
+          if [[ "${PR_BRANCH}" =~ ^backport/ ]]; then eligible=true; reason="backport PR"; fi
+          if [[ "${PR_BRANCH}" =~ ^renovate/ ]]; then eligible=true; reason="renovate PR"; fi
+          if [[ "${PR_BRANCH}" =~ ^update-platform-version- ]]; then eligible=true; reason="platform version update PR"; fi
+
+          echo "eligible=${eligible}" >> "${GITHUB_OUTPUT}"
+          echo "reason=${reason}" >> "${GITHUB_OUTPUT}"
+
+          if [ "${eligible}" != "true" ]; then
+            echo "PR does not match auto-approve patterns (title: ${PR_TITLE}, branch: ${PR_BRANCH})"
+          fi
+
+      - name: Check for merge conflicts
+        if: steps.check.outputs.eligible == 'true'
+        id: conflicts
+        env:
+          GH_TOKEN: ${{ secrets.gh-access-token }}
+        run: |
+          for i in 1 2 3; do
+            MERGEABLE=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${{ github.event.pull_request.number }}" --jq '.mergeable // "null"')
+            if [ "${MERGEABLE}" != "null" ]; then break; fi
+            sleep 3
+          done
+
+          if [ "${MERGEABLE}" = "false" ]; then
+            echo "::warning::PR has merge conflicts, skipping auto-approve"
+            echo "clean=false" >> "${GITHUB_OUTPUT}"
+          else
+            echo "clean=true" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Approve PR
+        if: steps.check.outputs.eligible == 'true' && steps.conflicts.outputs.clean == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.gh-access-token }}
+        run: |
+          gh pr review "${{ github.event.pull_request.number }}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --approve \
+            --body "Auto-approved: ${{ steps.check.outputs.reason }} from trusted bot with no merge conflicts. CI must pass before merge."
+
+      - name: Enable auto-merge
+        if: steps.check.outputs.eligible == 'true' && steps.conflicts.outputs.clean == 'true' && inputs.auto-merge
+        env:
+          GH_TOKEN: ${{ secrets.gh-access-token }}
+        run: |
+          gh pr merge "${{ github.event.pull_request.number }}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --auto \
+            --${{ inputs.merge-method }}

--- a/.github/workflows/auto-approve-bot-prs.yaml
+++ b/.github/workflows/auto-approve-bot-prs.yaml
@@ -69,10 +69,11 @@ jobs:
         if: steps.check.outputs.eligible == 'true'
         id: conflicts
         env:
-          GH_TOKEN: ${{ secrets.gh-access-token }}
+          GH_TOKEN: ${{ secrets.gh-access-token }} # zizmor: ignore[secrets-outside-env] -- PAT passed via workflow_call, not a repo secret
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           for i in 1 2 3; do
-            MERGEABLE=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${{ github.event.pull_request.number }}" --jq '.mergeable // "null"')
+            MERGEABLE=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.mergeable // "null"')
             if [ "${MERGEABLE}" != "null" ]; then break; fi
             sleep 3
           done
@@ -87,19 +88,27 @@ jobs:
       - name: Approve PR
         if: steps.check.outputs.eligible == 'true' && steps.conflicts.outputs.clean == 'true'
         env:
-          GH_TOKEN: ${{ secrets.gh-access-token }}
+          GH_TOKEN: ${{ secrets.gh-access-token }} # zizmor: ignore[secrets-outside-env] -- PAT passed via workflow_call, not a repo secret
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REASON: ${{ steps.check.outputs.reason }}
         run: |
-          gh pr review "${{ github.event.pull_request.number }}" \
+          gh pr review "${PR_NUMBER}" \
             --repo "${GITHUB_REPOSITORY}" \
             --approve \
-            --body "Auto-approved: ${{ steps.check.outputs.reason }} from trusted bot with no merge conflicts. CI must pass before merge."
+            --body "Auto-approved: ${REASON} from trusted bot with no merge conflicts. CI must pass before merge."
 
       - name: Enable auto-merge
         if: steps.check.outputs.eligible == 'true' && steps.conflicts.outputs.clean == 'true' && inputs.auto-merge
         env:
-          GH_TOKEN: ${{ secrets.gh-access-token }}
+          GH_TOKEN: ${{ secrets.gh-access-token }} # zizmor: ignore[secrets-outside-env] -- PAT passed via workflow_call, not a repo secret
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          MERGE_METHOD: ${{ inputs.merge-method }}
         run: |
-          gh pr merge "${{ github.event.pull_request.number }}" \
+          case "${MERGE_METHOD}" in
+            squash|merge|rebase) ;;
+            *) echo "::error::Invalid merge method: ${MERGE_METHOD}"; exit 1 ;;
+          esac
+          gh pr merge "${PR_NUMBER}" \
             --repo "${GITHUB_REPOSITORY}" \
             --auto \
-            --${{ inputs.merge-method }}
+            --"${MERGE_METHOD}"

--- a/.github/workflows/auto-approve-bot-prs.yaml
+++ b/.github/workflows/auto-approve-bot-prs.yaml
@@ -23,6 +23,8 @@ on:
 jobs:
   auto-approve:
     runs-on: ubuntu-latest
+    # Skip fork PRs — secrets are not available
+    if: github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: read
     steps:
@@ -52,11 +54,12 @@ jobs:
 
           eligible=false
           reason=""
-          if [[ "${PR_TITLE}" =~ ^chore(\(|:) ]]; then eligible=true; reason="chore PR"; fi
-          if [[ "${PR_TITLE}" =~ ^fix\(deps\) ]]; then eligible=true; reason="dependency fix PR"; fi
-          if [[ "${PR_BRANCH}" =~ ^backport/ ]]; then eligible=true; reason="backport PR"; fi
-          if [[ "${PR_BRANCH}" =~ ^renovate/ ]]; then eligible=true; reason="renovate PR"; fi
-          if [[ "${PR_BRANCH}" =~ ^update-platform-version- ]]; then eligible=true; reason="platform version update PR"; fi
+          if [[ "${PR_TITLE}" =~ ^chore(\(|:) ]]; then eligible=true; reason="chore PR"
+          elif [[ "${PR_TITLE}" =~ ^fix\(deps\) ]]; then eligible=true; reason="dependency fix PR"
+          elif [[ "${PR_BRANCH}" =~ ^backport/ ]]; then eligible=true; reason="backport PR"
+          elif [[ "${PR_BRANCH}" =~ ^renovate/ ]]; then eligible=true; reason="renovate PR"
+          elif [[ "${PR_BRANCH}" =~ ^update-platform-version- ]]; then eligible=true; reason="platform version update PR"
+          fi
 
           echo "eligible=${eligible}" >> "${GITHUB_OUTPUT}"
           echo "reason=${reason}" >> "${GITHUB_OUTPUT}"
@@ -78,11 +81,11 @@ jobs:
             sleep 3
           done
 
-          if [ "${MERGEABLE}" = "false" ]; then
-            echo "::warning::PR has merge conflicts, skipping auto-approve"
-            echo "clean=false" >> "${GITHUB_OUTPUT}"
-          else
+          if [ "${MERGEABLE}" = "true" ]; then
             echo "clean=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "::warning::PR mergeability is '${MERGEABLE}', skipping auto-approve"
+            echo "clean=false" >> "${GITHUB_OUTPUT}"
           fi
 
       - name: Approve PR

--- a/.github/workflows/auto-approve-bot-prs.yaml
+++ b/.github/workflows/auto-approve-bot-prs.yaml
@@ -72,7 +72,7 @@ jobs:
           GH_TOKEN: ${{ secrets.gh-access-token }} # zizmor: ignore[secrets-outside-env] -- PAT passed via workflow_call, not a repo secret
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          for i in 1 2 3; do
+          for _ in 1 2 3; do
             MERGEABLE=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.mergeable // "null"')
             if [ "${MERGEABLE}" != "null" ]; then break; fi
             sleep 3

--- a/.github/workflows/test-auto-approve-bot-prs.yaml
+++ b/.github/workflows/test-auto-approve-bot-prs.yaml
@@ -1,0 +1,33 @@
+name: Test auto-approve-bot-prs
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/auto-approve-bot-prs.yaml'
+
+permissions:
+  contents: read
+
+jobs:
+  auto-approve:
+    permissions:
+      contents: read
+    uses: ./.github/workflows/auto-approve-bot-prs.yaml
+    secrets:
+      gh-access-token: ${{ secrets.GITHUB_TOKEN }}
+
+  verify:
+    needs: [auto-approve]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check result
+        env:
+          RESULT: ${{ needs.auto-approve.result }}
+        run: |
+          echo "auto-approve result=$RESULT"
+          # Human-authored test PRs should succeed (steps skip on author check)
+          if [ "$RESULT" != "success" ]; then
+            echo "::error::Expected result=success (steps skip for non-bot authors), got '$RESULT'"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- Adds `auto-approve-bot-prs.yaml` reusable workflow for auto-approving PRs from trusted bots
- Adds `test-auto-approve-bot-prs.yaml` with path-filtered test
- Configurable: trusted authors, merge method, auto-merge toggle

## Why
Hundreds of Renovate/version-bump PRs per quarter require manual approval despite being fully automated. Centralizing the policy here means callers are 10-line thin wrappers, and there's one place to audit the auto-approve rules.

## How it works
1. Caller triggers on `pull_request` and calls this reusable workflow
2. Checks PR author against trusted list (exact match)
3. Checks title/branch pattern: `chore(*/fix(deps)/backport/*/renovate/*`
4. Verifies no merge conflicts (with retry for GitHub's async mergeable computation)
5. Approves with `gh-access-token` (different identity from PR author)
6. Optionally enables auto-merge (waits for required status checks)

## Callers
- `loft-sh/hosted-platform` — [PR #475](https://github.com/loft-sh/hosted-platform/pull/475)
- `loft-sh/loft-prod` — [PR #265](https://github.com/loft-sh/loft-prod/pull/265)

## Security
- Only known bot authors (configurable, default: `renovate[bot],loft-bot,github-actions[bot]`)
- Only specific title/branch patterns
- Merge conflicts block approval
- CI must pass before merge (auto-merge enforces required checks)
- No checkout step — only `gh` CLI API calls

Closes DEVOPS-714