### PR TITLE
feat: add cleanup-head-charts reusable workflow

### DIFF
--- a/.github/scripts/cleanup-head-charts/cleanup-head-charts.sh
+++ b/.github/scripts/cleanup-head-charts/cleanup-head-charts.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Cleans up old head chart versions from ChartMuseum, keeping the N most
+# recently uploaded versions. Skips the 0.0.0-latest sentinel version.
+#
+# Required environment variables:
+#   CHART_MUSEUM_URL       — ChartMuseum base URL (e.g. https://charts.loft.sh)
+#   CHART_MUSEUM_USER      — ChartMuseum username
+#   CHART_MUSEUM_PASSWORD  — ChartMuseum password
+#
+# Arguments:
+#   $1 — chart name (required, e.g. vcluster-head)
+#   $2 — max versions to keep (default: 50)
+#   $3 — dry-run mode: true/false (default: false)
+
+CHART_NAME="${1:?chart name is required}"
+MAX_VERSIONS="${2:-50}"
+DRY_RUN="${3:-false}"
+
+if ! CHART_RESPONSE=$(curl -sf -u "$CHART_MUSEUM_USER:$CHART_MUSEUM_PASSWORD" \
+  "$CHART_MUSEUM_URL/api/charts/$CHART_NAME"); then
+  echo "Error: Failed to fetch chart versions from ChartMuseum"
+  echo "This could indicate authentication failure or ChartMuseum is unreachable"
+  exit 1
+fi
+
+ALL_VERSIONS=$(echo "$CHART_RESPONSE" | \
+  jq -r '.[] | select(.version != "0.0.0-latest") | "\(.created) \(.version)"' | \
+  sort -r)
+
+VERSION_COUNT=$(echo "$ALL_VERSIONS" | grep -c '.' || true)
+echo "Found $VERSION_COUNT head chart versions (excluding '0.0.0-latest')"
+
+if [ "$VERSION_COUNT" -gt "$MAX_VERSIONS" ]; then
+  VERSIONS_TO_DELETE=$(echo "$ALL_VERSIONS" | tail -n +"$((MAX_VERSIONS + 1))" | awk '{print $2}')
+  DELETE_COUNT=$(echo "$VERSIONS_TO_DELETE" | wc -l)
+
+  if [ "$DRY_RUN" = "true" ]; then
+    echo "[dry-run] Would delete $DELETE_COUNT old versions (keeping $MAX_VERSIONS most recently uploaded):"
+    echo "$VERSIONS_TO_DELETE"
+    exit 0
+  fi
+
+  echo "Deleting $DELETE_COUNT old versions (keeping $MAX_VERSIONS most recently uploaded)..."
+
+  DELETED=0
+  for VERSION in $VERSIONS_TO_DELETE; do
+    echo "Deleting version: $VERSION"
+    if curl -sf -X DELETE \
+      -u "$CHART_MUSEUM_USER:$CHART_MUSEUM_PASSWORD" \
+      -w "\nHTTP Status: %{http_code}\n" \
+      "$CHART_MUSEUM_URL/api/charts/$CHART_NAME/$VERSION"; then
+      echo "Successfully deleted $VERSION"
+      DELETED=$((DELETED + 1))
+    else
+      echo "Failed to delete $VERSION (may not exist)"
+    fi
+  done
+
+  echo "Cleanup complete: deleted $DELETED/$DELETE_COUNT versions, kept $MAX_VERSIONS most recent"
+else
+  echo "Only $VERSION_COUNT versions found, no cleanup needed (keeping last $MAX_VERSIONS)"
+fi

--- a/.github/scripts/cleanup-head-charts/test/cleanup-head-charts.bats
+++ b/.github/scripts/cleanup-head-charts/test/cleanup-head-charts.bats
@@ -1,0 +1,191 @@
+#!/usr/bin/env bats
+# Tests for cleanup-head-charts.sh
+#
+# Uses a mock curl to simulate ChartMuseum API responses without network access.
+
+SCRIPT="$BATS_TEST_DIRNAME/../cleanup-head-charts.sh"
+
+setup() {
+  export CHART_MUSEUM_URL="https://charts.example.com"
+  export CHART_MUSEUM_USER="user"
+  export CHART_MUSEUM_PASSWORD="pass"
+
+  # Create a temp directory for the mock curl
+  MOCK_DIR=$(mktemp -d)
+  export MOCK_CURL_RESPONSE_FILE="$MOCK_DIR/curl_response"
+  export MOCK_CURL_EXIT_CODE_FILE="$MOCK_DIR/curl_exit_code"
+  export MOCK_CURL_DELETE_LOG="$MOCK_DIR/curl_delete_log"
+  export MOCK_CURL_DELETE_FAIL_VERSIONS="$MOCK_DIR/curl_delete_fail"
+
+  # Default: curl succeeds
+  echo "0" > "$MOCK_CURL_EXIT_CODE_FILE"
+  touch "$MOCK_CURL_DELETE_LOG"
+  touch "$MOCK_CURL_DELETE_FAIL_VERSIONS"
+
+  # Create the mock curl script
+  cat > "$MOCK_DIR/curl" <<'MOCK'
+#!/usr/bin/env bash
+# Mock curl for testing cleanup-head-charts.sh
+#
+# GET requests return the contents of MOCK_CURL_RESPONSE_FILE.
+# DELETE requests log the URL to MOCK_CURL_DELETE_LOG and optionally
+# fail for versions listed in MOCK_CURL_DELETE_FAIL_VERSIONS.
+
+IS_DELETE=false
+for arg in "$@"; do
+  if [ "$arg" = "DELETE" ]; then
+    IS_DELETE=true
+  fi
+done
+
+if [ "$IS_DELETE" = "true" ]; then
+  # Extract the version from the last URL argument
+  URL="${*: -1}"
+  VERSION="${URL##*/}"
+  echo "$VERSION" >> "$MOCK_CURL_DELETE_LOG"
+
+  # Check if this version should fail
+  if grep -qx "$VERSION" "$MOCK_CURL_DELETE_FAIL_VERSIONS" 2>/dev/null; then
+    exit 1
+  fi
+  echo '{"deleted":true}'
+  exit 0
+fi
+
+# GET request
+EXIT_CODE=$(cat "$MOCK_CURL_EXIT_CODE_FILE")
+if [ "$EXIT_CODE" -ne 0 ]; then
+  exit "$EXIT_CODE"
+fi
+cat "$MOCK_CURL_RESPONSE_FILE"
+MOCK
+  chmod +x "$MOCK_DIR/curl"
+
+  # Prepend mock to PATH
+  export PATH="$MOCK_DIR:$PATH"
+}
+
+teardown() {
+  rm -rf "$MOCK_DIR"
+}
+
+# Helper: generate a ChartMuseum JSON response with N versions.
+# Versions are numbered 0.0.1 through 0.0.N with ascending timestamps.
+generate_versions() {
+  local count=$1
+  local include_latest=${2:-false}
+  local json="["
+  local sep=""
+
+  if [ "$include_latest" = "true" ]; then
+    json="${json}${sep}{\"version\":\"0.0.0-latest\",\"created\":\"2000-01-01T00:00:00Z\"}"
+    sep=","
+  fi
+
+  for i in $(seq 1 "$count"); do
+    local ts
+    ts=$(printf "2025-01-%02dT00:00:00Z" "$i")
+    json="${json}${sep}{\"version\":\"0.0.$i\",\"created\":\"$ts\"}"
+    sep=","
+  done
+
+  echo "${json}]"
+}
+
+# --- Tests ---
+
+@test "fails when chart-name argument is missing" {
+  run bash "$SCRIPT"
+  [ "$status" -ne 0 ]
+}
+
+@test "no cleanup when version count is below max" {
+  generate_versions 3 > "$MOCK_CURL_RESPONSE_FILE"
+
+  run bash "$SCRIPT" "test-chart" 50
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Found 3 head chart versions"* ]]
+  [[ "$output" == *"no cleanup needed"* ]]
+}
+
+@test "no cleanup when version count equals max" {
+  generate_versions 5 > "$MOCK_CURL_RESPONSE_FILE"
+
+  run bash "$SCRIPT" "test-chart" 5
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Found 5 head chart versions"* ]]
+  [[ "$output" == *"no cleanup needed"* ]]
+}
+
+@test "deletes oldest versions when count exceeds max" {
+  generate_versions 5 > "$MOCK_CURL_RESPONSE_FILE"
+
+  run bash "$SCRIPT" "test-chart" 3
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Deleting 2 old versions"* ]]
+  [[ "$output" == *"deleted 2/2 versions"* ]]
+
+  # Versions 0.0.1 and 0.0.2 are oldest and should be deleted
+  [ "$(wc -l < "$MOCK_CURL_DELETE_LOG")" -eq 2 ]
+  grep -q "0.0.1" "$MOCK_CURL_DELETE_LOG"
+  grep -q "0.0.2" "$MOCK_CURL_DELETE_LOG"
+}
+
+@test "dry-run lists versions without deleting" {
+  generate_versions 5 > "$MOCK_CURL_RESPONSE_FILE"
+
+  run bash "$SCRIPT" "test-chart" 3 true
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"[dry-run]"* ]]
+  [[ "$output" == *"Would delete 2 old versions"* ]]
+
+  # No actual deletions
+  [ ! -s "$MOCK_CURL_DELETE_LOG" ]
+}
+
+@test "excludes 0.0.0-latest from version count and deletion" {
+  generate_versions 3 true > "$MOCK_CURL_RESPONSE_FILE"
+
+  run bash "$SCRIPT" "test-chart" 50
+  [ "$status" -eq 0 ]
+  # Should count 3, not 4 (0.0.0-latest excluded)
+  [[ "$output" == *"Found 3 head chart versions (excluding '0.0.0-latest')"* ]]
+  [[ "$output" == *"no cleanup needed"* ]]
+}
+
+@test "exits with error when API fetch fails" {
+  echo "22" > "$MOCK_CURL_EXIT_CODE_FILE"
+
+  run bash "$SCRIPT" "test-chart"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Failed to fetch chart versions"* ]]
+}
+
+@test "continues when individual version delete fails" {
+  generate_versions 5 > "$MOCK_CURL_RESPONSE_FILE"
+  # Make 0.0.1 fail to delete
+  echo "0.0.1" > "$MOCK_CURL_DELETE_FAIL_VERSIONS"
+
+  run bash "$SCRIPT" "test-chart" 3
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Failed to delete 0.0.1"* ]]
+  [[ "$output" == *"Successfully deleted 0.0.2"* ]]
+  [[ "$output" == *"deleted 1/2 versions"* ]]
+}
+
+@test "handles empty chart response" {
+  echo "[]" > "$MOCK_CURL_RESPONSE_FILE"
+
+  run bash "$SCRIPT" "test-chart" 50
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Found 0 head chart versions"* ]]
+  [[ "$output" == *"no cleanup needed"* ]]
+}
+
+@test "max-versions defaults to 50" {
+  generate_versions 3 > "$MOCK_CURL_RESPONSE_FILE"
+
+  run bash "$SCRIPT" "test-chart"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no cleanup needed (keeping last 50)"* ]]
+}

--- a/.github/workflows/cleanup-head-charts.yaml
+++ b/.github/workflows/cleanup-head-charts.yaml
@@ -1,0 +1,53 @@
+name: Cleanup ChartMuseum head charts
+
+on:
+  workflow_call:
+    inputs:
+      chart-name:
+        description: 'Chart name to clean up (e.g. vcluster-head, vcluster-platform-head)'
+        type: string
+        required: true
+      max-versions:
+        description: 'Maximum number of versions to keep'
+        type: number
+        required: false
+        default: 50
+      chart-museum-url:
+        description: 'ChartMuseum base URL (e.g. https://charts.loft.sh)'
+        type: string
+        required: true
+      dry-run:
+        description: 'List versions that would be deleted without actually deleting them'
+        type: boolean
+        required: false
+        default: false
+    secrets:
+      chart-museum-user:
+        description: 'ChartMuseum username'
+        required: true
+      chart-museum-password:
+        description: 'ChartMuseum password'
+        required: true
+
+jobs:
+  cleanup:
+    name: Cleanup old head chart versions
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: loft-sh/github-actions
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+          sparse-checkout: .github/scripts/cleanup-head-charts
+      - name: Cleanup old head chart versions
+        env:
+          CHART_MUSEUM_URL: ${{ inputs.chart-museum-url }}
+          CHART_MUSEUM_USER: ${{ secrets.chart-museum-user }} # zizmor: ignore[secrets-outside-env] -- passed via workflow_call, not a repo secret
+          CHART_MUSEUM_PASSWORD: ${{ secrets.chart-museum-password }} # zizmor: ignore[secrets-outside-env] -- passed via workflow_call, not a repo secret
+          CHART_NAME: ${{ inputs.chart-name }}
+          MAX_VERSIONS: ${{ inputs.max-versions }}
+          DRY_RUN: ${{ inputs.dry-run }}
+        run: .github/scripts/cleanup-head-charts/cleanup-head-charts.sh "$CHART_NAME" "$MAX_VERSIONS" "$DRY_RUN"

--- a/.github/workflows/dispatch-integration-tests.yaml
+++ b/.github/workflows/dispatch-integration-tests.yaml
@@ -14,6 +14,7 @@ on:
       - '.github/workflows/claude.yaml'
       - '.github/workflows/conflict-check.yaml'
       - '.github/workflows/notify-release.yaml'
+      - '.github/workflows/cleanup-head-charts.yaml'
 
 permissions:
   contents: read

--- a/.github/workflows/test-cleanup-head-charts.yaml
+++ b/.github/workflows/test-cleanup-head-charts.yaml
@@ -1,0 +1,21 @@
+name: Test cleanup-head-charts
+
+on:
+  pull_request:
+    paths:
+      - '.github/scripts/cleanup-head-charts/**'
+      - '.github/workflows/cleanup-head-charts.yaml'
+
+permissions: {}
+
+jobs:
+  bats:
+    name: Run bats tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: bats-core/bats-action@2104b40bb7b6c2d5110b23a26b0bf265ab8027db # v3.0.0
+        with:
+          tests: .github/scripts/cleanup-head-charts/test

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
-.PHONY: test test-semver-validation test-linear-pr-commenter test-release-notification test-linear-release-sync build-linear-release-sync lint help
+.PHONY: test test-semver-validation test-linear-pr-commenter test-release-notification test-linear-release-sync test-cleanup-head-charts build-linear-release-sync lint help
 
 ACTIONS_DIR := .github/actions
 
 help: ## show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-30s %s\n", $$1, $$2}'
 
-test: test-semver-validation test-linear-pr-commenter test-release-notification test-linear-release-sync ## run all action tests
+test: test-semver-validation test-linear-pr-commenter test-release-notification test-linear-release-sync test-cleanup-head-charts ## run all action tests
 
 test-semver-validation: ## run semver-validation unit tests
 	cd $(ACTIONS_DIR)/semver-validation && npm ci --silent && NODE_OPTIONS=--experimental-vm-modules npx jest --ci --coverage --watchAll=false
@@ -18,6 +18,9 @@ test-release-notification: ## run release-notification detect-branch tests
 
 test-linear-release-sync: ## run linear-release-sync unit tests
 	cd $(ACTIONS_DIR)/linear-release-sync/src && go test -v ./...
+
+test-cleanup-head-charts: ## run cleanup-head-charts bats tests
+	bats .github/scripts/cleanup-head-charts/test/cleanup-head-charts.bats
 
 build-linear-release-sync: ## build linear-release-sync binary (linux/amd64)
 	cd $(ACTIONS_DIR)/linear-release-sync/src && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-s -w" -o ../linear-release-sync-linux-amd64 .


### PR DESCRIPTION
## Summary

- Extracts duplicated ChartMuseum head chart cleanup logic from `loft-enterprise` and `vcluster` into a parameterized reusable workflow
- Business logic extracted to `.github/scripts/cleanup-head-charts/cleanup-head-charts.sh` (per CONVENTIONS.md — no inline business logic in YAML)
- 10 bats tests covering: empty response, dry-run, delete failures, `0.0.0-latest` exclusion, argument validation, default values
- Parameterized inputs: `chart-name`, `chart-museum-url`, `max-versions` (default 50), `dry-run`
- Reusable workflow pins checkout to `github.workflow_sha` so the script version always matches the resolved workflow
- Delete summary reports actual successes vs attempts (e.g. `deleted 3/5 versions`)
- Source of truth: `loft-enterprise` implementation

## Files

| File | Purpose |
|------|---------|
| `.github/scripts/cleanup-head-charts/cleanup-head-charts.sh` | Cleanup logic (testable, shellcheck clean) |
| `.github/scripts/cleanup-head-charts/test/cleanup-head-charts.bats` | 10 bats tests with mock curl |
| `.github/workflows/cleanup-head-charts.yaml` | Reusable workflow (checkout + run script) |
| `.github/workflows/test-cleanup-head-charts.yaml` | CI: runs bats on PR |
| `Makefile` | Added `test-cleanup-head-charts` target |

## Callers

| Repo | Chart | Branch |
|------|-------|--------|
| loft-enterprise | `vcluster-platform-head` | `ci/migrate-cleanup-head-charts` |
| vcluster | `vcluster-head` | `ci/migrate-cleanup-head-charts` |

## Test plan

- [x] actionlint + zizmor + shellcheck clean locally
- [x] `make test-cleanup-head-charts` — 10/10 passing
- [x] CI passes on this PR
- [ ] Tag `cleanup-head-charts/v1` after merge
- [ ] Migration PRs reference final SHA