### PR TITLE
fix(ci): persist credentials for detect-changes workflow

### DIFF
--- a/.github/workflows/detect-changes.yaml
+++ b/.github/workflows/detect-changes.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          persist-credentials: false
+          persist-credentials: true # paths-filter needs credentials to fetch the base commit on push events
 
       - name: Filter paths
         id: filter


### PR DESCRIPTION
## Summary

- Fixes `detect-changes` reusable workflow failing on push events with `fatal: could not read Username for 'https://github.com'`
- `dorny/paths-filter` needs git credentials to fetch the base commit (`github.event.before`) on push events. With `persist-credentials: false`, the credential helper is removed after checkout and the fetch fails.
- Changed to `persist-credentials: true` — the token is scoped to `contents:read` + `pull-requests:read`

## Test plan

- [ ] Re-run the failing [loft-enterprise workflow](https://github.com/loft-sh/loft-enterprise/actions/runs/24242317667/job/70779671391) after merge