### PR TITLE
ci: add generic ci-test-notify action

### DIFF
--- a/.github/actions/ci-test-notify/README.md
+++ b/.github/actions/ci-test-notify/README.md
@@ -1,0 +1,74 @@
+# CI Test Notification
+
+Generic Slack notification action for CI test results. Covers nightly E2E, conformance, and other automated test suites.
+
+Replaces the nightly-specific `ci-notify-nightly-tests` action with a generic interface: the caller provides a test name, status, and optional details markdown — the action builds the Block Kit message and sends it.
+
+## Inputs
+
+| Name | Description | Required | Default |
+|------|-------------|----------|---------|
+| `test-name` | Test suite name for the header (e.g. "E2E Ginkgo Nightly Tests"). Keep under ~130 chars (Slack header limit is 150 chars; status suffix uses ~15). | yes | |
+| `status` | Test status: `success`, `failure`, `cancelled`, or `skipped` | yes | |
+| `details` | Markdown text appended after the build URL | no | `''` |
+| `webhook-url` | Slack incoming webhook URL | yes | |
+
+## Message format
+
+```
+[emoji] [test-name] [status]
+─────────────────────────────
+Build URL: <link to workflow run>
+
+<details if provided>
+─────────────────────────────
+<repo> · Run #<number>
+```
+
+## Usage
+
+### Nightly E2E tests
+
+```yaml
+- uses: loft-sh/github-actions/.github/actions/ci-test-notify@ci-test-notify/v1
+  with:
+    test-name: E2E Ginkgo Nightly Tests
+    status: ${{ needs.e2e-tests.result }}
+    details: "E2E Tests: ${{ needs.e2e-tests.result }}"
+    webhook-url: ${{ secrets.SLACK_WEBHOOK_URL_CI_TESTS_ALERTS }}
+```
+
+### Conformance tests (with extra fields)
+
+```yaml
+- uses: loft-sh/github-actions/.github/actions/ci-test-notify@ci-test-notify/v1
+  with:
+    # Keep test-name under ~130 chars (Slack header block limit is 150)
+    test-name: "vCluster Conformance Tests (${{ inputs.sonobuoy_mode }})"
+    status: ${{ steps.status.outputs.status }}
+    details: |
+      *vCluster CLI:* `${{ steps.version.outputs.ref }}`
+      *vCluster PRO:* `${{ inputs.base_ref }}`
+
+      Sonobuoy results: ${{ steps.upload.outputs.artifact-url }}
+    webhook-url: ${{ secrets.SLACK_WEBHOOK_URL_CI_TESTS_ALERTS }}
+```
+
+### Failure-only with summary
+
+```yaml
+- uses: loft-sh/github-actions/.github/actions/ci-test-notify@ci-test-notify/v1
+  if: needs.e2e-tests.result == 'failure'
+  with:
+    test-name: E2E Ginkgo Nightly Tests
+    status: failure
+    details: |
+      E2E Tests: failure
+
+      ${{ needs.e2e-tests.outputs.failure-summary || 'Check build logs for details.' }}
+    webhook-url: ${{ secrets.SLACK_WEBHOOK_URL_DEV_VCLUSTER }}
+```
+
+## Permissions
+
+No special GitHub permissions required. The `webhook-url` must be supplied via a repository secret.

--- a/.github/actions/ci-test-notify/action.yml
+++ b/.github/actions/ci-test-notify/action.yml
@@ -1,0 +1,50 @@
+name: 'CI Test Notification'
+description: 'Send a Slack notification for CI test results (nightly E2E, conformance, etc.)'
+branding:
+  icon: "bell"
+  color: "orange"
+inputs:
+  test-name:
+    description: 'Test suite name for the header (e.g. "E2E Ginkgo Nightly Tests"). Keep under ~130 chars — Slack header blocks have a 150-char limit and the status suffix takes ~15 chars.'
+    required: true
+  status:
+    description: 'Test status: success, failure, cancelled, or skipped'
+    required: true
+  details:
+    description: 'Markdown text appended after the build URL (test results, versions, artifact links, etc.)'
+    required: false
+    default: ''
+  webhook-url:
+    description: 'Slack incoming webhook URL'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Check webhook URL
+      if: inputs.webhook-url == ''
+      shell: bash
+      run: |
+        echo "::warning::webhook-url is empty (expected on fork PRs where secrets are unavailable), skipping notification"
+
+    - name: Build Slack payload
+      if: inputs.webhook-url != ''
+      shell: bash
+      env:
+        TEST_NAME: ${{ inputs.test-name }}
+        STATUS: ${{ inputs.status }}
+        DETAILS: ${{ inputs.details }}
+        PAYLOAD_FILE: ${{ runner.temp }}/ci-test-notify-payload.json
+        RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        REPO: ${{ github.repository }}
+        RUN_NUMBER: ${{ github.run_number }}
+      run: ${{ github.action_path }}/build-payload.sh
+
+    - name: Send Slack notification
+      if: inputs.webhook-url != ''
+      uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
+      with:
+        errors: true
+        webhook-type: incoming-webhook
+        webhook: ${{ inputs.webhook-url }}
+        payload-file-path: ${{ runner.temp }}/ci-test-notify-payload.json

--- a/.github/actions/ci-test-notify/build-payload.sh
+++ b/.github/actions/ci-test-notify/build-payload.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Required env vars: TEST_NAME, STATUS, DETAILS, PAYLOAD_FILE, RUN_URL, REPO, RUN_NUMBER
+
+command -v jq >/dev/null || { echo "::error::jq is required but not found"; exit 1; }
+
+case "$STATUS" in
+  success)    EMOJI="✅"; STATUS_TEXT="Success" ;;
+  failure)    EMOJI="❌"; STATUS_TEXT="Failed" ;;
+  cancelled)  EMOJI="⚠️"; STATUS_TEXT="Cancelled" ;;
+  skipped)    EMOJI="⏭️"; STATUS_TEXT="Skipped" ;;
+  *)          EMOJI="❓"; STATUS_TEXT="Unknown ($STATUS)" ;;
+esac
+
+HEADER="${EMOJI} ${TEST_NAME} ${STATUS_TEXT}"
+
+# Slack header blocks reject >150 chars
+if [[ ${#HEADER} -gt 150 ]]; then
+  echo "::warning::Header exceeds 150-char Slack limit (${#HEADER} chars), truncating"
+  HEADER="${HEADER:0:147}..."
+fi
+
+SECTION="Build URL: ${RUN_URL}"
+if [[ "$DETAILS" =~ [^[:space:]] ]]; then
+  SECTION="$(printf '%s\n\n%s' "$SECTION" "$DETAILS")"
+fi
+
+# Slack section blocks reject >3000 chars
+if [[ ${#SECTION} -gt 3000 ]]; then
+  echo "::warning::Section exceeds 3000-char Slack limit (${#SECTION} chars), truncating"
+  SECTION="${SECTION:0:2997}..."
+fi
+
+jq -n \
+  --arg text "$HEADER" \
+  --arg section "$SECTION" \
+  --arg context "<${RUN_URL}|${REPO} · Run #${RUN_NUMBER}>" \
+  '{
+    text: $text,
+    blocks: [
+      { type: "header", text: { type: "plain_text", text: $text } },
+      { type: "section", text: { type: "mrkdwn", text: $section } },
+      { type: "context", elements: [{ type: "mrkdwn", text: $context }] }
+    ]
+  }' > "$PAYLOAD_FILE"

--- a/.github/actions/ci-test-notify/test/build-payload.bats
+++ b/.github/actions/ci-test-notify/test/build-payload.bats
@@ -1,0 +1,214 @@
+#!/usr/bin/env bats
+# Tests for build-payload.sh
+
+SCRIPT="$BATS_TEST_DIRNAME/../build-payload.sh"
+
+setup() {
+  MOCK_DIR=$(mktemp -d)
+  export PAYLOAD_FILE="$MOCK_DIR/payload.json"
+
+  # Set required env vars with defaults
+  export TEST_NAME="My Test Suite"
+  export STATUS="success"
+  export DETAILS=""
+  export RUN_URL="https://github.com/org/repo/actions/runs/12345"
+  export REPO="org/repo"
+  export RUN_NUMBER="42"
+}
+
+teardown() {
+  rm -rf "$MOCK_DIR"
+}
+
+# Helper: extract a field from the payload JSON
+payload_field() {
+  jq -r "$1" "$PAYLOAD_FILE"
+}
+
+# --- Status mapping tests ---
+
+@test "success status produces correct emoji and text" {
+  STATUS="success" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$(payload_field '.text')" == *"✅"* ]]
+  [[ "$(payload_field '.text')" == *"Success"* ]]
+}
+
+@test "failure status produces correct emoji and text" {
+  STATUS="failure" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$(payload_field '.text')" == *"❌"* ]]
+  [[ "$(payload_field '.text')" == *"Failed"* ]]
+}
+
+@test "cancelled status produces correct emoji and text" {
+  STATUS="cancelled" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$(payload_field '.text')" == *"⚠️"* ]]
+  [[ "$(payload_field '.text')" == *"Cancelled"* ]]
+}
+
+@test "skipped status produces correct emoji and text" {
+  STATUS="skipped" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$(payload_field '.text')" == *"⏭️"* ]]
+  [[ "$(payload_field '.text')" == *"Skipped"* ]]
+}
+
+@test "unknown status produces fallback emoji and includes raw value" {
+  STATUS="weird" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$(payload_field '.text')" == *"❓"* ]]
+  [[ "$(payload_field '.text')" == *"Unknown (weird)"* ]]
+}
+
+# --- Header and test name ---
+
+@test "header includes the test name" {
+  TEST_NAME="E2E Ginkgo Nightly Tests" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$(payload_field '.text')" == *"E2E Ginkgo Nightly Tests"* ]]
+}
+
+# --- Details handling ---
+
+@test "section contains build URL without details" {
+  DETAILS="" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+
+  local section
+  section=$(payload_field '.blocks[1].text.text')
+  [[ "$section" == "Build URL: https://github.com/org/repo/actions/runs/12345" ]]
+}
+
+@test "section contains build URL and details when provided" {
+  DETAILS="E2E Tests: failure" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+
+  local section
+  section=$(payload_field '.blocks[1].text.text')
+  [[ "$section" == *"Build URL:"* ]]
+  [[ "$section" == *"E2E Tests: failure"* ]]
+}
+
+@test "whitespace-only details are ignored" {
+  DETAILS="   " run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+
+  local section
+  section=$(payload_field '.blocks[1].text.text')
+  [[ "$section" == "Build URL: https://github.com/org/repo/actions/runs/12345" ]]
+}
+
+@test "multiline details are preserved" {
+  DETAILS=$'Line one\nLine two\nLine three' run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+
+  local section
+  section=$(payload_field '.blocks[1].text.text')
+  [[ "$section" == *"Line one"* ]]
+  [[ "$section" == *"Line three"* ]]
+}
+
+# --- Block Kit structure ---
+
+@test "payload has correct block structure" {
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+
+  [ "$(payload_field '.blocks | length')" -eq 3 ]
+  [ "$(payload_field '.blocks[0].type')" = "header" ]
+  [ "$(payload_field '.blocks[1].type')" = "section" ]
+  [ "$(payload_field '.blocks[2].type')" = "context" ]
+}
+
+@test "context block contains repo and run number" {
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+
+  local context
+  context=$(payload_field '.blocks[2].elements[0].text')
+  [[ "$context" == *"org/repo"* ]]
+  [[ "$context" == *"Run #42"* ]]
+}
+
+# --- Error handling ---
+
+@test "fails when jq is not available" {
+  # Build a minimal PATH that has bash but not jq
+  local fake_bin
+  fake_bin=$(mktemp -d)
+  ln -s "$(command -v bash)" "$fake_bin/bash"
+  PATH="$fake_bin" run bash "$SCRIPT"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"jq is required"* ]]
+  rm -rf "$fake_bin"
+}
+
+# --- Header truncation ---
+
+@test "header is truncated when exceeding 150 chars" {
+  TEST_NAME="$(printf 'A%.0s' {1..145})" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+
+  local header
+  header=$(payload_field '.blocks[0].text.text')
+  [ "${#header}" -le 150 ]
+  [[ "$header" == *"..."* ]]
+}
+
+@test "header is not truncated when under 150 chars" {
+  TEST_NAME="Short Name" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+
+  local header
+  header=$(payload_field '.blocks[0].text.text')
+  [[ "$header" != *"..."* ]]
+}
+
+# --- Section truncation ---
+
+@test "section is truncated when exceeding 3000 chars" {
+  DETAILS="$(printf 'X%.0s' {1..3000})" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+
+  local section
+  section=$(payload_field '.blocks[1].text.text')
+  [ "${#section}" -le 3000 ]
+  [[ "$section" == *"..."* ]]
+}
+
+@test "section is not truncated when under 3000 chars" {
+  DETAILS="Short details" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+
+  local section
+  section=$(payload_field '.blocks[1].text.text')
+  [[ "$section" != *"..."* ]]
+}
+
+# --- Missing env vars ---
+
+@test "fails when STATUS is unset" {
+  unset STATUS
+  run bash "$SCRIPT"
+  [ "$status" -ne 0 ]
+}
+
+@test "fails when PAYLOAD_FILE is unset" {
+  unset PAYLOAD_FILE
+  run bash "$SCRIPT"
+  [ "$status" -ne 0 ]
+}
+
+@test "fails when TEST_NAME is unset" {
+  unset TEST_NAME
+  run bash "$SCRIPT"
+  [ "$status" -ne 0 ]
+}
+
+@test "output is valid JSON" {
+  DETAILS="*Bold* and \`code\` with <special> & chars" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  jq empty "$PAYLOAD_FILE"
+}

--- a/.github/workflows/test-ci-test-notify.yaml
+++ b/.github/workflows/test-ci-test-notify.yaml
@@ -1,0 +1,20 @@
+name: Test ci-test-notify
+
+on:
+  pull_request:
+    paths:
+      - '.github/actions/ci-test-notify/**'
+
+permissions: {}
+
+jobs:
+  bats:
+    name: Run bats tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: bats-core/bats-action@2104b40bb7b6c2d5110b23a26b0bf265ab8027db # v3.0.0
+        with:
+          tests: .github/actions/ci-test-notify/test

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-semver-validation test-linear-pr-commenter test-release-notification test-linear-release-sync test-cleanup-head-charts test-auto-approve-bot-prs build-linear-release-sync lint help
+.PHONY: test test-semver-validation test-linear-pr-commenter test-release-notification test-linear-release-sync test-cleanup-head-charts test-ci-test-notify test-auto-approve-bot-prs build-linear-release-sync lint help
 
 ACTIONS_DIR := .github/actions
 SCRIPTS_DIR := .github/scripts
@@ -6,7 +6,7 @@ SCRIPTS_DIR := .github/scripts
 help: ## show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-30s %s\n", $$1, $$2}'
 
-test: test-semver-validation test-linear-pr-commenter test-release-notification test-linear-release-sync test-cleanup-head-charts test-auto-approve-bot-prs ## run all action tests
+test: test-semver-validation test-linear-pr-commenter test-release-notification test-linear-release-sync test-cleanup-head-charts test-auto-approve-bot-prs test-ci-test-notify ## run all action tests
 
 test-semver-validation: ## run semver-validation unit tests
 	cd $(ACTIONS_DIR)/semver-validation && npm ci --silent && NODE_OPTIONS=--experimental-vm-modules npx jest --ci --coverage --watchAll=false
@@ -25,6 +25,9 @@ test-cleanup-head-charts: ## run cleanup-head-charts bats tests
 
 test-auto-approve-bot-prs: ## run auto-approve-bot-prs bats tests
 	bats $(ACTIONS_DIR)/auto-approve-bot-prs/test/*.bats
+
+test-ci-test-notify: ## run ci-test-notify bats tests
+	bats $(ACTIONS_DIR)/ci-test-notify/test/build-payload.bats
 
 build-linear-release-sync: ## build linear-release-sync binary (linux/amd64)
 	cd $(ACTIONS_DIR)/linear-release-sync/src && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-s -w" -o ../linear-release-sync-linux-amd64 .


### PR DESCRIPTION
## Summary

- Add new `ci-test-notify` composite action for generic CI test Slack notifications
- Covers nightly E2E, conformance, and other automated test suites
- Uses `jq` for safe JSON payload construction (avoids YAML escaping issues with caller-provided markdown) and `slackapi/slack-github-action` for delivery
- The old `ci-notify-nightly-tests` action is kept during migration and will be removed once all callers are migrated

**Inputs:** `test-name`, `status`, `details` (optional markdown), `webhook-url`

The action handles:
- Status-to-emoji mapping (success, failure, cancelled, skipped)
- Block Kit envelope with header, build URL, details section, context link
- Safe JSON construction via `jq` (avoids YAML escaping issues with caller-provided markdown)
- Header truncation guard for Slack's 150-char limit
- Section truncation guard for Slack's 3000-char limit
- Whitespace-only details are ignored (no awkward blank sections)
- Delivery via `slackapi/slack-github-action@v3.0.1` with `payload-file-path`
- Notification logic in `build-payload.sh` per repo conventions (no business logic in inline YAML)

## Test plan

- [x] actionlint + zizmor pass
- [x] shellcheck clean
- [x] bats tests (20 cases): status mapping, details handling, whitespace-only details, Block Kit structure, header truncation, section truncation, error handling, special characters
- [ ] Manual test with a workflow_dispatch that calls the action with a test webhook