### PR TITLE
refactor(auto-approve): extract eligibility logic + add bats tests

### DIFF
--- a/.github/scripts/auto-approve-bot-prs/check-eligibility.sh
+++ b/.github/scripts/auto-approve-bot-prs/check-eligibility.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Decides whether a bot-authored PR qualifies for auto-approval.
+#
+# Exits 0 in all matched/unmatched branches — the eligibility decision
+# is communicated via `eligible=<true|false>` and `reason=<string>`
+# lines, written to $GITHUB_OUTPUT when set, and always echoed to stdout
+# so the script is trivial to invoke from tests and from the workflow.
+#
+# Required environment variables:
+#   TRUSTED_AUTHORS  — comma-separated list of trusted bot logins
+#   PR_AUTHOR        — PR author login (github.event.pull_request.user.login)
+#   PR_TITLE         — PR title (github.event.pull_request.title)
+#   PR_BRANCH        — PR head branch (github.event.pull_request.head.ref)
+
+: "${TRUSTED_AUTHORS:?TRUSTED_AUTHORS is required}"
+: "${PR_AUTHOR:?PR_AUTHOR is required}"
+# Allow empty title/branch so the script still returns a clean "not eligible"
+# rather than failing hard — GitHub always populates these, but tests may not.
+PR_TITLE="${PR_TITLE:-}"
+PR_BRANCH="${PR_BRANCH:-}"
+
+emit() {
+  local key="$1" value="$2"
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    printf '%s=%s\n' "$key" "$value" >> "$GITHUB_OUTPUT"
+  fi
+  printf '%s=%s\n' "$key" "$value"
+}
+
+# Exact-match author against trusted list.
+IFS=',' read -ra AUTHORS <<< "${TRUSTED_AUTHORS}"
+author_trusted=false
+for author in "${AUTHORS[@]}"; do
+  if [ "${author}" = "${PR_AUTHOR}" ]; then
+    author_trusted=true
+    break
+  fi
+done
+
+if [ "${author_trusted}" != "true" ]; then
+  echo "Author '${PR_AUTHOR}' not in trusted list, skipping" >&2
+  emit eligible false
+  emit reason ""
+  exit 0
+fi
+
+eligible=false
+reason=""
+if   [[ "${PR_TITLE}"  =~ ^chore(\(|:)           ]]; then eligible=true; reason="chore PR"
+elif [[ "${PR_TITLE}"  =~ ^fix\(deps\)           ]]; then eligible=true; reason="dependency fix PR"
+elif [[ "${PR_BRANCH}" =~ ^backport/             ]]; then eligible=true; reason="backport PR"
+elif [[ "${PR_BRANCH}" =~ ^renovate/             ]]; then eligible=true; reason="renovate PR"
+elif [[ "${PR_BRANCH}" =~ ^update-platform-version- ]]; then eligible=true; reason="platform version update PR"
+fi
+
+if [ "${eligible}" != "true" ]; then
+  echo "PR does not match auto-approve patterns (title: ${PR_TITLE}, branch: ${PR_BRANCH})" >&2
+fi
+
+emit eligible "${eligible}"
+emit reason "${reason}"

--- a/.github/scripts/auto-approve-bot-prs/test/check-eligibility.bats
+++ b/.github/scripts/auto-approve-bot-prs/test/check-eligibility.bats
@@ -1,0 +1,167 @@
+#!/usr/bin/env bats
+# Tests for check-eligibility.sh
+#
+# Covers the decision table used by the auto-approve-bot-prs reusable workflow:
+# trusted authors × title/branch eligibility patterns. Regression coverage
+# for DEVOPS-749 (dependabot[bot] must be acceptable as a trusted author).
+
+SCRIPT="$BATS_TEST_DIRNAME/../check-eligibility.sh"
+
+# Default trusted list matches what callers pass when they want the full set.
+DEFAULT_TRUSTED='renovate[bot],loft-bot,github-actions[bot],dependabot[bot]'
+
+setup() {
+  export GITHUB_OUTPUT="$(mktemp)"
+}
+
+teardown() {
+  rm -f "$GITHUB_OUTPUT"
+}
+
+# Helper: run script with overridable env inputs.
+run_check() {
+  local trusted="${1:-$DEFAULT_TRUSTED}" author="$2" title="$3" branch="$4"
+  run env \
+    TRUSTED_AUTHORS="$trusted" \
+    PR_AUTHOR="$author" \
+    PR_TITLE="$title" \
+    PR_BRANCH="$branch" \
+    GITHUB_OUTPUT="$GITHUB_OUTPUT" \
+    "$SCRIPT"
+}
+
+assert_output_kv() {
+  local key="$1" expected="$2"
+  local actual
+  actual=$(grep "^${key}=" "$GITHUB_OUTPUT" | tail -n1 | cut -d= -f2-)
+  if [ "$actual" != "$expected" ]; then
+    echo "Expected ${key}='${expected}', got '${actual}'"
+    echo "GITHUB_OUTPUT contents:"
+    cat "$GITHUB_OUTPUT"
+    return 1
+  fi
+}
+
+# --- Trusted-author matching ------------------------------------------------
+
+@test "dependabot[bot] is trusted when listed (DEVOPS-749 regression)" {
+  run_check "$DEFAULT_TRUSTED" 'dependabot[bot]' 'chore(deps): bump foo' 'dependabot/npm/foo-1.2.3'
+  [ "$status" -eq 0 ]
+  assert_output_kv eligible true
+  assert_output_kv reason "chore PR"
+}
+
+@test "dependabot[bot] is rejected when not in list (default upstream behavior)" {
+  run_check 'renovate[bot],loft-bot,github-actions[bot]' 'dependabot[bot]' 'chore(deps): bump foo' 'dependabot/npm/foo-1.2.3'
+  [ "$status" -eq 0 ]
+  assert_output_kv eligible false
+  assert_output_kv reason ""
+}
+
+@test "renovate[bot] is trusted" {
+  run_check "$DEFAULT_TRUSTED" 'renovate[bot]' 'chore(deps): bump bar' 'renovate/bar-2.0.0'
+  [ "$status" -eq 0 ]
+  assert_output_kv eligible true
+  assert_output_kv reason "chore PR"
+}
+
+@test "loft-bot is trusted" {
+  run_check "$DEFAULT_TRUSTED" 'loft-bot' 'chore: sync partials' 'update-platform-version-4.6.0'
+  [ "$status" -eq 0 ]
+  assert_output_kv eligible true
+  # update-platform-version branch wins over chore title because the title
+  # check is evaluated first — both lead to eligible=true; verify the reason
+  # matches whichever branch the logic picks so this test stays a pure
+  # behaviour lock-in.
+  assert_output_kv reason "chore PR"
+}
+
+@test "github-actions[bot] is trusted" {
+  run_check "$DEFAULT_TRUSTED" 'github-actions[bot]' 'chore: rebuild' 'gh-actions/rebuild'
+  [ "$status" -eq 0 ]
+  assert_output_kv eligible true
+}
+
+@test "unknown author is rejected even with matching title" {
+  run_check "$DEFAULT_TRUSTED" 'random-user' 'chore(deps): bump something' 'feature/foo'
+  [ "$status" -eq 0 ]
+  assert_output_kv eligible false
+  assert_output_kv reason ""
+}
+
+@test "partial-match author is rejected (exact-match only)" {
+  # 'dependabot' is a substring of 'dependabot[bot]' but must not match.
+  run_check 'dependabot,loft-bot' 'dependabot[bot]' 'chore: foo' 'foo'
+  [ "$status" -eq 0 ]
+  assert_output_kv eligible false
+}
+
+# --- Title / branch eligibility patterns ------------------------------------
+
+@test "title 'chore:' is eligible" {
+  run_check "$DEFAULT_TRUSTED" 'dependabot[bot]' 'chore: update lockfile' 'feature/foo'
+  [ "$status" -eq 0 ]
+  assert_output_kv eligible true
+  assert_output_kv reason "chore PR"
+}
+
+@test "title 'chore(deps):' is eligible" {
+  run_check "$DEFAULT_TRUSTED" 'dependabot[bot]' 'chore(deps): bump x to y' 'feature/foo'
+  [ "$status" -eq 0 ]
+  assert_output_kv eligible true
+  assert_output_kv reason "chore PR"
+}
+
+@test "title 'fix(deps):' is eligible" {
+  run_check "$DEFAULT_TRUSTED" 'dependabot[bot]' 'fix(deps): patch cve' 'feature/foo'
+  [ "$status" -eq 0 ]
+  assert_output_kv eligible true
+  assert_output_kv reason "dependency fix PR"
+}
+
+@test "branch 'backport/' is eligible" {
+  run_check "$DEFAULT_TRUSTED" 'loft-bot' 'whatever title' 'backport/v1.2-something'
+  [ "$status" -eq 0 ]
+  assert_output_kv eligible true
+  assert_output_kv reason "backport PR"
+}
+
+@test "branch 'renovate/' is eligible" {
+  run_check "$DEFAULT_TRUSTED" 'renovate[bot]' 'any title' 'renovate/foo-digest'
+  [ "$status" -eq 0 ]
+  assert_output_kv eligible true
+  assert_output_kv reason "renovate PR"
+}
+
+@test "branch 'update-platform-version-' is eligible" {
+  run_check "$DEFAULT_TRUSTED" 'loft-bot' 'bump platform' 'update-platform-version-4.6.0'
+  [ "$status" -eq 0 ]
+  assert_output_kv eligible true
+  assert_output_kv reason "platform version update PR"
+}
+
+@test "trusted author with feat-title is NOT eligible" {
+  run_check "$DEFAULT_TRUSTED" 'dependabot[bot]' 'feat: unrelated work' 'feature/foo'
+  [ "$status" -eq 0 ]
+  assert_output_kv eligible false
+  assert_output_kv reason ""
+}
+
+@test "trusted author with empty title/branch is NOT eligible" {
+  run_check "$DEFAULT_TRUSTED" 'dependabot[bot]' '' ''
+  [ "$status" -eq 0 ]
+  assert_output_kv eligible false
+  assert_output_kv reason ""
+}
+
+# --- Input validation -------------------------------------------------------
+
+@test "missing TRUSTED_AUTHORS fails" {
+  run env -u TRUSTED_AUTHORS PR_AUTHOR=x PR_TITLE=y PR_BRANCH=z "$SCRIPT"
+  [ "$status" -ne 0 ]
+}
+
+@test "missing PR_AUTHOR fails" {
+  run env -u PR_AUTHOR TRUSTED_AUTHORS="$DEFAULT_TRUSTED" PR_TITLE=y PR_BRANCH=z "$SCRIPT"
+  [ "$status" -ne 0 ]
+}

--- a/.github/workflows/auto-approve-bot-prs.yaml
+++ b/.github/workflows/auto-approve-bot-prs.yaml
@@ -28,6 +28,12 @@ jobs:
     permissions:
       contents: read
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: loft-sh/github-actions
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+          sparse-checkout: .github/scripts/auto-approve-bot-prs
       - name: Check eligibility
         id: check
         env:
@@ -35,38 +41,7 @@ jobs:
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_BRANCH: ${{ github.event.pull_request.head.ref }}
-        run: |
-          # Exact-match author against trusted list
-          IFS=',' read -ra AUTHORS <<< "${TRUSTED_AUTHORS}"
-          author_trusted=false
-          for author in "${AUTHORS[@]}"; do
-            if [ "${author}" = "${PR_AUTHOR}" ]; then
-              author_trusted=true
-              break
-            fi
-          done
-
-          if [ "${author_trusted}" != "true" ]; then
-            echo "Author '${PR_AUTHOR}' not in trusted list, skipping"
-            echo "eligible=false" >> "${GITHUB_OUTPUT}"
-            exit 0
-          fi
-
-          eligible=false
-          reason=""
-          if [[ "${PR_TITLE}" =~ ^chore(\(|:) ]]; then eligible=true; reason="chore PR"
-          elif [[ "${PR_TITLE}" =~ ^fix\(deps\) ]]; then eligible=true; reason="dependency fix PR"
-          elif [[ "${PR_BRANCH}" =~ ^backport/ ]]; then eligible=true; reason="backport PR"
-          elif [[ "${PR_BRANCH}" =~ ^renovate/ ]]; then eligible=true; reason="renovate PR"
-          elif [[ "${PR_BRANCH}" =~ ^update-platform-version- ]]; then eligible=true; reason="platform version update PR"
-          fi
-
-          echo "eligible=${eligible}" >> "${GITHUB_OUTPUT}"
-          echo "reason=${reason}" >> "${GITHUB_OUTPUT}"
-
-          if [ "${eligible}" != "true" ]; then
-            echo "PR does not match auto-approve patterns (title: ${PR_TITLE}, branch: ${PR_BRANCH})"
-          fi
+        run: .github/scripts/auto-approve-bot-prs/check-eligibility.sh
 
       - name: Check for merge conflicts
         if: steps.check.outputs.eligible == 'true'

--- a/.github/workflows/test-auto-approve-bot-prs.yaml
+++ b/.github/workflows/test-auto-approve-bot-prs.yaml
@@ -4,11 +4,23 @@ on:
   pull_request:
     paths:
       - '.github/workflows/auto-approve-bot-prs.yaml'
+      - '.github/scripts/auto-approve-bot-prs/**'
 
 permissions:
   contents: read
 
 jobs:
+  bats:
+    name: Run bats tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: bats-core/bats-action@2104b40bb7b6c2d5110b23a26b0bf265ab8027db # v3.0.0
+        with:
+          tests: .github/scripts/auto-approve-bot-prs/test
+
   auto-approve:
     permissions:
       contents: read

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
-.PHONY: test test-semver-validation test-linear-pr-commenter test-release-notification test-linear-release-sync test-cleanup-head-charts build-linear-release-sync lint help
+.PHONY: test test-semver-validation test-linear-pr-commenter test-release-notification test-linear-release-sync test-cleanup-head-charts test-auto-approve-bot-prs build-linear-release-sync lint help
 
 ACTIONS_DIR := .github/actions
+SCRIPTS_DIR := .github/scripts
 
 help: ## show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-30s %s\n", $$1, $$2}'
 
-test: test-semver-validation test-linear-pr-commenter test-release-notification test-linear-release-sync test-cleanup-head-charts ## run all action tests
+test: test-semver-validation test-linear-pr-commenter test-release-notification test-linear-release-sync test-cleanup-head-charts test-auto-approve-bot-prs ## run all action tests
 
 test-semver-validation: ## run semver-validation unit tests
 	cd $(ACTIONS_DIR)/semver-validation && npm ci --silent && NODE_OPTIONS=--experimental-vm-modules npx jest --ci --coverage --watchAll=false
@@ -20,7 +21,10 @@ test-linear-release-sync: ## run linear-release-sync unit tests
 	cd $(ACTIONS_DIR)/linear-release-sync/src && go test -v ./...
 
 test-cleanup-head-charts: ## run cleanup-head-charts bats tests
-	bats .github/scripts/cleanup-head-charts/test/cleanup-head-charts.bats
+	bats $(SCRIPTS_DIR)/cleanup-head-charts/test/cleanup-head-charts.bats
+
+test-auto-approve-bot-prs: ## run auto-approve-bot-prs eligibility tests
+	bats $(SCRIPTS_DIR)/auto-approve-bot-prs/test/check-eligibility.bats
 
 build-linear-release-sync: ## build linear-release-sync binary (linux/amd64)
 	cd $(ACTIONS_DIR)/linear-release-sync/src && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-s -w" -o ../linear-release-sync-linux-amd64 .


### PR DESCRIPTION
## Summary

- Extract the inline author-matching + eligibility logic from `auto-approve-bot-prs.yaml` into a dedicated script at `.github/scripts/auto-approve-bot-prs/check-eligibility.sh`.
- Add a bats suite covering the full decision table, including the dependabot[bot] regression case from DEVOPS-749.
- Wire the suite into `make test-auto-approve-bot-prs` and into the CI test workflow.

## Motivation

The reusable workflow embedded non-trivial shell logic (trusted-author matching, title/branch regex patterns) directly in the YAML. The existing `test-auto-approve-bot-prs.yaml` only exercised the workflow against human-authored PRs, which skip out on the author check — the decision table itself was never tested in CI.

With the vcluster-docs side of DEVOPS-749 (https://github.com/loft-sh/vcluster-docs/pull/1916) adding dependabot[bot] to the caller's `trusted-authors` list, this PR closes the testing gap so any future change to the decision table is caught by fast, deterministic unit tests.

## Changes

1. `.github/scripts/auto-approve-bot-prs/check-eligibility.sh` — eligibility logic extracted, reads env vars (TRUSTED_AUTHORS, PR_AUTHOR, PR_TITLE, PR_BRANCH), emits `eligible=…` and `reason=…` to \$GITHUB_OUTPUT and stdout.
2. `.github/scripts/auto-approve-bot-prs/test/check-eligibility.bats` — 17 test cases: dependabot trust regression, exact-match author guard, chore/fix(deps) titles, backport/renovate/update-platform-version branches, plus missing-env validation.
3. `.github/workflows/auto-approve-bot-prs.yaml` — invokes the script; adds sparse-checkout step so callers don't need to vendor scripts.
4. `.github/workflows/test-auto-approve-bot-prs.yaml` — adds a `bats` job and triggers on changes under `.github/scripts/auto-approve-bot-prs/**`.
5. `Makefile` — new `test-auto-approve-bot-prs` target, wired into `test`.

Follows the same pattern already established for cleanup-head-charts (commit 005d75d).

## Test plan

- [x] `make test-auto-approve-bot-prs` passes locally (17/17)
- [x] CI bats job passes
- [x] CI auto-approve workflow_call job still succeeds (skip-on-non-bot path)
- [x] zizmor/actionlint clean

Refs DEVOPS-749