### PR TITLE
fix(auto-approve): skip on self-approve + resolve checkout ref correctly

### DIFF
--- a/.github/workflows/auto-approve-bot-prs.yaml
+++ b/.github/workflows/auto-approve-bot-prs.yaml
@@ -28,10 +28,23 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Resolve reusable workflow ref
+        id: wref
+        env:
+          WORKFLOW_REF: ${{ github.workflow_ref }}
+        run: |
+          # `github.workflow_sha` in workflow_call resolves to the caller's
+          # triggering commit (e.g. the merge-simulation commit in a caller
+          # repo like loft-prod), not to the reusable workflow's commit, so
+          # checkout against loft-sh/github-actions with that SHA fails with
+          # `upload-pack: not our ref`. `github.workflow_ref` has the form
+          # `owner/repo/path/to.yml@ref` — the portion after `@` is the ref
+          # actions/checkout can resolve against loft-sh/github-actions.
+          echo "ref=${WORKFLOW_REF##*@}" >> "${GITHUB_OUTPUT}"
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: loft-sh/github-actions
-          ref: ${{ github.workflow_sha }}
+          ref: ${{ steps.wref.outputs.ref }}
           persist-credentials: false
           sparse-checkout: .github/scripts/auto-approve-bot-prs
       - name: Check eligibility

--- a/.github/workflows/auto-approve-bot-prs.yaml
+++ b/.github/workflows/auto-approve-bot-prs.yaml
@@ -63,8 +63,27 @@ jobs:
             echo "clean=false" >> "${GITHUB_OUTPUT}"
           fi
 
-      - name: Approve PR
+      - name: Check approver identity
         if: steps.check.outputs.eligible == 'true' && steps.conflicts.outputs.clean == 'true'
+        id: approver
+        env:
+          GH_TOKEN: ${{ secrets.gh-access-token }} # zizmor: ignore[secrets-outside-env] -- PAT passed via workflow_call, not a repo secret
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          # GitHub forbids approving your own PR. When the gh-access-token
+          # identity matches the PR author (e.g. loft-bot opening a backport
+          # PR in a repo whose GH_ACCESS_TOKEN is also loft-bot), skip the
+          # approve/merge steps rather than failing the workflow.
+          APPROVER=$(gh api user --jq '.login')
+          if [ "${APPROVER}" = "${PR_AUTHOR}" ]; then
+            echo "::notice::Approver '${APPROVER}' is the PR author; skipping approval (GitHub forbids self-review)"
+            echo "can_approve=false" >> "${GITHUB_OUTPUT}"
+          else
+            echo "can_approve=true" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Approve PR
+        if: steps.check.outputs.eligible == 'true' && steps.conflicts.outputs.clean == 'true' && steps.approver.outputs.can_approve == 'true'
         env:
           GH_TOKEN: ${{ secrets.gh-access-token }} # zizmor: ignore[secrets-outside-env] -- PAT passed via workflow_call, not a repo secret
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -76,7 +95,7 @@ jobs:
             --body "Auto-approved: ${REASON} from trusted bot with no merge conflicts. CI must pass before merge."
 
       - name: Enable auto-merge
-        if: steps.check.outputs.eligible == 'true' && steps.conflicts.outputs.clean == 'true' && inputs.auto-merge
+        if: steps.check.outputs.eligible == 'true' && steps.conflicts.outputs.clean == 'true' && steps.approver.outputs.can_approve == 'true' && inputs.auto-merge
         env:
           GH_TOKEN: ${{ secrets.gh-access-token }} # zizmor: ignore[secrets-outside-env] -- PAT passed via workflow_call, not a repo secret
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/cleanup-head-charts.yaml
+++ b/.github/workflows/cleanup-head-charts.yaml
@@ -36,10 +36,20 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Resolve reusable workflow ref
+        id: wref
+        env:
+          WORKFLOW_REF: ${{ github.workflow_ref }}
+        run: |
+          # `github.workflow_sha` resolves to the caller's commit in a
+          # workflow_call context, not the reusable workflow's commit, so
+          # checkout against loft-sh/github-actions fails with `upload-pack:
+          # not our ref`. Parse workflow_ref (owner/repo/path@ref) instead.
+          echo "ref=${WORKFLOW_REF##*@}" >> "${GITHUB_OUTPUT}"
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: loft-sh/github-actions
-          ref: ${{ github.workflow_sha }}
+          ref: ${{ steps.wref.outputs.ref }}
           persist-credentials: false
           sparse-checkout: .github/scripts/cleanup-head-charts
       - name: Cleanup old head chart versions


### PR DESCRIPTION
## Summary

Two production auto-approve failures + one latent identical bug in cleanup-head-charts.

### Bug 1: checkout fails with `upload-pack: not our ref`

[loft-prod PR #272 run](https://github.com/loft-sh/loft-prod/actions/runs/24331942689/job/71039633466) failed at the sparse-checkout step. Root cause: `ref: ${{ github.workflow_sha }}` in a `workflow_call` context resolves to the **caller's** triggering commit (the merge-simulation commit produced by the pull_request event in loft-prod), not the reusable workflow's SHA. That commit doesn't exist in loft-sh/github-actions, so `actions/checkout` aborts.

**Fix**: parse `github.workflow_ref` (format: `owner/repo/path@ref`) and use the substring after the `@` as the checkout ref. Works whether the caller pinned by branch, tag, or SHA.

### Bug 2: workflow fails instead of skipping on self-approve

[vcluster-docs PR #1917 run](https://github.com/loft-sh/vcluster-docs/actions/runs/24331800421/job/71039183296) failed with `GraphQL: Review Can not approve your own pull request` because the PR is authored by `loft-bot` and `GH_ACCESS_TOKEN` in vcluster-docs is also `loft-bot`. The goal of this workflow is 'approve or skip, never fail' — a failed check on a backport PR is noise.

**Fix**: add a `Check approver identity` step that compares `gh api user` against the PR author and gates the approve + auto-merge steps on a `can_approve` output. On match, emit `::notice::` and job stays green.

### Proactive: same workflow_sha fix applied to cleanup-head-charts

`cleanup-head-charts.yaml` has the identical `ref: ${{ github.workflow_sha }}` pattern. It hasn't manifested because callers haven't yet triggered it via pull_request, but the bug is the same. Applied the same fix.

## Changes

- `.github/workflows/auto-approve-bot-prs.yaml` — resolve-ref step + approver identity check
- `.github/workflows/cleanup-head-charts.yaml` — resolve-ref step (proactive)

## Test plan

- [ ] CI bats + actionlint + zizmor pass
- [ ] After merge, re-run loft-prod PR #272 and vcluster-docs PR #1917 auto-approve jobs — both should either approve or green-skip

Refs DEVOPS-749