### PR TITLE
refactor(auto-approve): composite action + bash scripts + bats coverage

### DIFF
--- a/.github/actions/auto-approve-bot-prs/action.yml
+++ b/.github/actions/auto-approve-bot-prs/action.yml
@@ -1,0 +1,81 @@
+name: Auto-approve bot PRs
+description: |
+  Approves PRs from trusted bot authors whose title/branch matches a known
+  safe pattern, after all other CI checks pass. Never hard-fails the job —
+  every failure mode degrades to a notice-level skip.
+inputs:
+  trusted-authors:
+    description: 'Comma-separated list of trusted bot logins'
+    required: false
+    default: 'renovate[bot],loft-bot,github-actions[bot]'
+  merge-method:
+    description: 'Merge method for auto-merge (squash|merge|rebase)'
+    required: false
+    default: 'squash'
+  auto-merge:
+    description: 'Enable GitHub auto-merge after approval'
+    required: false
+    default: 'false'
+  github-token:
+    description: 'PAT used to read PR state, approve, and enable auto-merge. Must NOT match the PR author.'
+    required: true
+  wait-max-attempts:
+    description: 'Max polling attempts waiting for other CI checks'
+    required: false
+    default: '90'
+  wait-sleep-seconds:
+    description: 'Seconds between polling attempts'
+    required: false
+    default: '10'
+
+runs:
+  using: composite
+  steps:
+    - name: Check eligibility
+      id: check
+      shell: bash
+      env:
+        TRUSTED_AUTHORS: ${{ inputs.trusted-authors }}
+        PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        PR_TITLE: ${{ github.event.pull_request.title }}
+        PR_BRANCH: ${{ github.event.pull_request.head.ref }}
+      run: ${{ github.action_path }}/src/check-eligibility.sh
+
+    - name: Check PR ready (mergeable + approver identity)
+      if: steps.check.outputs.eligible == 'true'
+      id: ready
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+      run: ${{ github.action_path }}/src/check-pr-ready.sh
+
+    - name: Wait for other CI to pass
+      if: steps.ready.outputs.proceed == 'true'
+      id: ci
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        SELF_RUN_ID: ${{ github.run_id }}
+        WAIT_MAX_ATTEMPTS: ${{ inputs.wait-max-attempts }}
+        WAIT_SLEEP_SECONDS: ${{ inputs.wait-sleep-seconds }}
+      run: ${{ github.action_path }}/src/wait-for-ci.sh
+
+    - name: Approve PR
+      if: steps.ci.outputs.ci_green == 'true'
+      continue-on-error: true
+      uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363 # v4.0.0
+      with:
+        github-token: ${{ inputs.github-token }}
+        review-message: 'Auto-approved: trusted bot, CI green, no merge conflicts.'
+
+    - name: Enable auto-merge
+      if: steps.ci.outputs.ci_green == 'true' && inputs.auto-merge == 'true'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        MERGE_METHOD: ${{ inputs.merge-method }}
+      run: ${{ github.action_path }}/src/enable-auto-merge.sh

--- a/.github/actions/auto-approve-bot-prs/src/check-eligibility.sh
+++ b/.github/actions/auto-approve-bot-prs/src/check-eligibility.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Decides whether a bot-authored PR qualifies for auto-approval.
+#
+# Required env: TRUSTED_AUTHORS, PR_AUTHOR, PR_TITLE, PR_BRANCH
+# Writes: eligible=true|false and reason=<string> to $GITHUB_OUTPUT (and stdout).
+# Always exits 0 — decisions flow through the output, never through exit code.
+set -euo pipefail
+
+: "${TRUSTED_AUTHORS:?TRUSTED_AUTHORS required}"
+: "${PR_AUTHOR:?PR_AUTHOR required}"
+PR_TITLE="${PR_TITLE:-}"
+PR_BRANCH="${PR_BRANCH:-}"
+
+emit() {
+  local k="$1" v="$2"
+  [ -n "${GITHUB_OUTPUT:-}" ] && printf '%s=%s\n' "$k" "$v" >> "$GITHUB_OUTPUT"
+  printf '%s=%s\n' "$k" "$v"
+}
+
+IFS=',' read -ra AUTHORS <<< "${TRUSTED_AUTHORS}"
+author_trusted=false
+for a in "${AUTHORS[@]}"; do
+  if [ "$a" = "$PR_AUTHOR" ]; then
+    author_trusted=true
+    break
+  fi
+done
+
+if [ "$author_trusted" != "true" ]; then
+  echo "::notice::Author '$PR_AUTHOR' not in trusted list"
+  emit eligible false
+  emit reason ""
+  exit 0
+fi
+
+eligible=false
+reason=""
+if   [[ "$PR_TITLE"  =~ ^chore(\(|:)              ]]; then eligible=true; reason="chore PR"
+elif [[ "$PR_TITLE"  =~ ^fix\(deps\)              ]]; then eligible=true; reason="dependency fix PR"
+elif [[ "$PR_BRANCH" =~ ^backport/                ]]; then eligible=true; reason="backport PR"
+elif [[ "$PR_BRANCH" =~ ^renovate/                ]]; then eligible=true; reason="renovate PR"
+elif [[ "$PR_BRANCH" =~ ^update-platform-version- ]]; then eligible=true; reason="platform version update PR"
+fi
+
+if [ "$eligible" != "true" ]; then
+  echo "::notice::PR not in auto-approve patterns (title='$PR_TITLE' branch='$PR_BRANCH')"
+fi
+
+emit eligible "$eligible"
+emit reason   "$reason"

--- a/.github/actions/auto-approve-bot-prs/src/check-pr-ready.sh
+++ b/.github/actions/auto-approve-bot-prs/src/check-pr-ready.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Combines two gates: merge-conflict check and approver-identity check.
+# Only writes proceed=true if BOTH pass.
+#
+# Required env: GH_TOKEN, GITHUB_REPOSITORY, PR_NUMBER, PR_AUTHOR
+# Writes: proceed=true|false to $GITHUB_OUTPUT (and stdout).
+# Always exits 0.
+set -euo pipefail
+
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY required}"
+: "${PR_NUMBER:?PR_NUMBER required}"
+: "${PR_AUTHOR:?PR_AUTHOR required}"
+
+emit() {
+  local k="$1" v="$2"
+  [ -n "${GITHUB_OUTPUT:-}" ] && printf '%s=%s\n' "$k" "$v" >> "$GITHUB_OUTPUT"
+  printf '%s=%s\n' "$k" "$v"
+}
+
+# mergeable can be null briefly while GitHub computes metadata.
+mergeable="null"
+for _ in 1 2 3; do
+  mergeable=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.mergeable // "null"' 2>/dev/null || echo "null")
+  [ "$mergeable" != "null" ] && break
+  sleep 3
+done
+
+if [ "$mergeable" != "true" ]; then
+  echo "::notice::PR mergeability is '$mergeable', skipping"
+  emit proceed false
+  exit 0
+fi
+
+# GitHub forbids self-approval. Pre-empt hmarr's 422 setFailed path.
+approver=$(gh api user --jq '.login' 2>/dev/null || echo "")
+if [ -z "$approver" ] || [ "$approver" = "$PR_AUTHOR" ]; then
+  echo "::notice::Skipping approval (approver='$approver' author='$PR_AUTHOR')"
+  emit proceed false
+  exit 0
+fi
+
+emit proceed true

--- a/.github/actions/auto-approve-bot-prs/src/enable-auto-merge.sh
+++ b/.github/actions/auto-approve-bot-prs/src/enable-auto-merge.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Enables GitHub's auto-merge on the PR. Never exits non-zero.
+#
+# Required env: GH_TOKEN, GITHUB_REPOSITORY, PR_NUMBER, MERGE_METHOD
+set -euo pipefail
+
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY required}"
+: "${PR_NUMBER:?PR_NUMBER required}"
+: "${MERGE_METHOD:?MERGE_METHOD required}"
+
+case "$MERGE_METHOD" in
+  squash|merge|rebase) ;;
+  *)
+    echo "::notice::Invalid merge method '$MERGE_METHOD'; skipping"
+    exit 0
+    ;;
+esac
+
+gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --auto --"$MERGE_METHOD" 2>&1 \
+  || echo "::notice::gh pr merge failed; auto-merge not enabled"

--- a/.github/actions/auto-approve-bot-prs/src/wait-for-ci.sh
+++ b/.github/actions/auto-approve-bot-prs/src/wait-for-ci.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Polls non-self check-runs on the PR head until they complete.
+# Outputs ci_green=true only if every non-self check ends success/skipped/neutral.
+#
+# Required env: GH_TOKEN, GITHUB_REPOSITORY, PR_HEAD_SHA, SELF_RUN_ID
+# Optional env: WAIT_MAX_ATTEMPTS (default 90), WAIT_SLEEP_SECONDS (default 10)
+# Writes: ci_green=true|false to $GITHUB_OUTPUT (and stdout).
+# Always exits 0.
+set -euo pipefail
+
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY required}"
+: "${PR_HEAD_SHA:?PR_HEAD_SHA required}"
+: "${SELF_RUN_ID:?SELF_RUN_ID required}"
+
+max_attempts="${WAIT_MAX_ATTEMPTS:-90}"
+sleep_seconds="${WAIT_SLEEP_SECONDS:-10}"
+
+emit() {
+  local k="$1" v="$2"
+  [ -n "${GITHUB_OUTPUT:-}" ] && printf '%s=%s\n' "$k" "$v" >> "$GITHUB_OUTPUT"
+  printf '%s=%s\n' "$k" "$v"
+}
+
+# Self-identification: exclude check-runs whose details_url contains our run id,
+# `.../runs/<SELF_RUN_ID>/...`. Works for both check-runs and statuses from
+# github-actions.
+EXCLUDE_PATTERN="/runs/${SELF_RUN_ID}/"
+
+for attempt in $(seq 1 "$max_attempts"); do
+  runs=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${PR_HEAD_SHA}/check-runs" --paginate --jq '.check_runs // []' 2>/dev/null || echo '[]')
+  other=$(echo "$runs" | jq --arg p "$EXCLUDE_PATTERN" '[.[] | select((.details_url // "") | contains($p) | not)]')
+  pending=$(echo "$other" | jq '[.[] | select(.status != "completed")] | length')
+  failed=$(echo  "$other" | jq '[.[] | select(.conclusion != null and ([.conclusion] | inside(["success","skipped","neutral"]) | not))] | length')
+  echo "attempt ${attempt}/${max_attempts}: pending=${pending} failed=${failed}"
+
+  if [ "${failed:-0}" -gt 0 ]; then
+    echo "::notice::Other CI checks failed; skipping approval"
+    emit ci_green false
+    exit 0
+  fi
+  if [ "${pending:-0}" -eq 0 ]; then
+    emit ci_green true
+    exit 0
+  fi
+  sleep "$sleep_seconds"
+done
+
+echo "::notice::Timed out waiting for other CI checks"
+emit ci_green false

--- a/.github/actions/auto-approve-bot-prs/test/check-eligibility.bats
+++ b/.github/actions/auto-approve-bot-prs/test/check-eligibility.bats
@@ -1,0 +1,72 @@
+#!/usr/bin/env bats
+# Decision-table coverage for check-eligibility.sh.
+
+SCRIPT="$BATS_TEST_DIRNAME/../src/check-eligibility.sh"
+DEFAULT='renovate[bot],loft-bot,github-actions[bot],dependabot[bot]'
+
+setup() { export GITHUB_OUTPUT; GITHUB_OUTPUT="$(mktemp)"; }
+teardown() { rm -f "$GITHUB_OUTPUT"; }
+
+run_script() {
+  run env \
+    TRUSTED_AUTHORS="$1" PR_AUTHOR="$2" PR_TITLE="$3" PR_BRANCH="$4" \
+    GITHUB_OUTPUT="$GITHUB_OUTPUT" "$SCRIPT"
+}
+
+assert_kv() {
+  local want="$1=$2" actual
+  actual=$(grep "^$1=" "$GITHUB_OUTPUT" | tail -n1)
+  [ "$actual" = "$want" ] || { echo "want: $want"; echo "got:  $actual"; cat "$GITHUB_OUTPUT"; return 1; }
+}
+
+@test "dependabot[bot] trusted + chore(deps) title → eligible" {
+  run_script "$DEFAULT" 'dependabot[bot]' 'chore(deps): bump foo' 'dependabot/npm/foo'
+  [ "$status" -eq 0 ]; assert_kv eligible true
+}
+
+@test "dependabot[bot] not in list → eligible=false" {
+  run_script 'renovate[bot],loft-bot' 'dependabot[bot]' 'chore(deps): bump' 'x'
+  [ "$status" -eq 0 ]; assert_kv eligible false
+}
+
+@test "chore: title → eligible" {
+  run_script "$DEFAULT" 'loft-bot' 'chore: update' 'x'; assert_kv eligible true
+}
+
+@test "fix(deps): title → eligible" {
+  run_script "$DEFAULT" 'loft-bot' 'fix(deps): cve' 'x'; assert_kv eligible true
+}
+
+@test "backport/ branch → eligible" {
+  run_script "$DEFAULT" 'loft-bot' 'anything' 'backport/v1.2'; assert_kv eligible true
+}
+
+@test "renovate/ branch → eligible" {
+  run_script "$DEFAULT" 'renovate[bot]' 'anything' 'renovate/pkg'; assert_kv eligible true
+}
+
+@test "update-platform-version- branch → eligible" {
+  run_script "$DEFAULT" 'loft-bot' 'anything' 'update-platform-version-4.6.0'; assert_kv eligible true
+}
+
+@test "feat: title on trusted author → not eligible" {
+  run_script "$DEFAULT" 'dependabot[bot]' 'feat: new' 'feature/foo'; assert_kv eligible false
+}
+
+@test "untrusted author + chore title → not eligible" {
+  run_script "$DEFAULT" 'random-user' 'chore: x' 'x'; assert_kv eligible false
+}
+
+@test "exact-match author only (no substring)" {
+  run_script 'dependabot,loft-bot' 'dependabot[bot]' 'chore: x' 'x'; assert_kv eligible false
+}
+
+@test "missing TRUSTED_AUTHORS fails" {
+  run env -u TRUSTED_AUTHORS PR_AUTHOR=x PR_TITLE=y PR_BRANCH=z "$SCRIPT"
+  [ "$status" -ne 0 ]
+}
+
+@test "missing PR_AUTHOR fails" {
+  run env -u PR_AUTHOR TRUSTED_AUTHORS="$DEFAULT" PR_TITLE=y PR_BRANCH=z "$SCRIPT"
+  [ "$status" -ne 0 ]
+}

--- a/.github/actions/auto-approve-bot-prs/test/check-pr-ready.bats
+++ b/.github/actions/auto-approve-bot-prs/test/check-pr-ready.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+
+SCRIPT="$BATS_TEST_DIRNAME/../src/check-pr-ready.sh"
+load gh_mock
+
+setup() {
+  setup_gh_mock
+  export GITHUB_OUTPUT; GITHUB_OUTPUT="$(mktemp)"
+  export GITHUB_REPOSITORY="owner/repo"
+  export PR_NUMBER=42
+  export PR_AUTHOR="dependabot[bot]"
+}
+teardown() { rm -f "$GITHUB_OUTPUT"; teardown_gh_mock; }
+
+kv() { grep "^$1=" "$GITHUB_OUTPUT" | tail -n1; }
+
+@test "mergeable=true + different approver → proceed=true" {
+  GH_MOCK_MERGEABLE=true GH_MOCK_APPROVER="loft-bot" run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv proceed)" = "proceed=true" ]
+}
+
+@test "mergeable=false → proceed=false" {
+  GH_MOCK_MERGEABLE=false GH_MOCK_APPROVER="loft-bot" run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv proceed)" = "proceed=false" ]
+}
+
+@test "mergeable=null → proceed=false (never treat unknown as clean)" {
+  GH_MOCK_MERGEABLE=null GH_MOCK_APPROVER="loft-bot" run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv proceed)" = "proceed=false" ]
+}
+
+@test "approver == author → proceed=false (self-review guard)" {
+  GH_MOCK_MERGEABLE=true GH_MOCK_APPROVER="dependabot[bot]" run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv proceed)" = "proceed=false" ]
+}
+
+@test "empty approver → proceed=false" {
+  GH_MOCK_MERGEABLE=true GH_MOCK_APPROVER="" run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv proceed)" = "proceed=false" ]
+}
+
+@test "missing PR_NUMBER fails" {
+  run env -u PR_NUMBER GITHUB_OUTPUT="$GITHUB_OUTPUT" GITHUB_REPOSITORY=o/r PR_AUTHOR=x "$SCRIPT"
+  [ "$status" -ne 0 ]
+}

--- a/.github/actions/auto-approve-bot-prs/test/gh_mock.bash
+++ b/.github/actions/auto-approve-bot-prs/test/gh_mock.bash
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Shared helper: install a stub `gh` on PATH that dispatches by first argument.
+# Call setup_gh_mock first; set GH_MOCK_* env vars to control responses.
+
+setup_gh_mock() {
+  MOCK_DIR="$(mktemp -d)"
+  export MOCK_DIR
+  PATH="$MOCK_DIR:$PATH"
+  export PATH
+
+  cat > "$MOCK_DIR/gh" <<'EOF'
+#!/usr/bin/env bash
+# Mock `gh`. Only covers the subset used by auto-approve scripts.
+#
+# GH_MOCK_MERGEABLE          → response for `gh api ...pulls/N`
+# GH_MOCK_APPROVER           → response for `gh api user`
+# GH_MOCK_CHECK_RUNS_JSON    → response for `gh api .../check-runs` (full object)
+# GH_MOCK_PR_MERGE_EXIT      → exit code for `gh pr merge`
+# GH_MOCK_PR_MERGE_OUT       → stdout for `gh pr merge`
+# GH_MOCK_CALLS              → path; each invocation appends one line of args
+
+[ -n "${GH_MOCK_CALLS:-}" ] && printf '%s\n' "$*" >> "$GH_MOCK_CALLS"
+
+# Emit the raw response that matches the api path, then apply --jq/--paginate
+# like real gh does, so callers see exactly what they'd see in production.
+emit_api_response() {
+  local path="$1" default_runs='{"check_runs":[]}'
+  case "$path" in
+    user)
+      printf '{"login":"%s"}\n' "${GH_MOCK_APPROVER:-}"
+      ;;
+    *"/pulls/"*)
+      local m="${GH_MOCK_MERGEABLE:-null}"
+      case "$m" in true|false) ;; *) m=null ;; esac
+      printf '{"mergeable":%s}\n' "$m"
+      ;;
+    *"/check-runs"*)
+      printf '%s\n' "${GH_MOCK_CHECK_RUNS_JSON:-$default_runs}"
+      ;;
+    *) printf '{}\n' ;;
+  esac
+}
+
+apply_filter() {
+  local filter="$1"
+  if [ -n "$filter" ]; then jq -r "$filter"; else cat; fi
+}
+
+case "${1:-}" in
+  api)
+    shift
+    path="${1:-}"; shift || true
+    jq_filter=""
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --jq) jq_filter="$2"; shift 2 ;;
+        --paginate|--method|--header|-H|-X) shift 2>/dev/null || true ;;
+        *) shift ;;
+      esac
+    done
+    emit_api_response "$path" | apply_filter "$jq_filter"
+    ;;
+  pr)
+    shift
+    case "${1:-}" in
+      merge)
+        echo "${GH_MOCK_PR_MERGE_OUT:-enabled}"
+        exit "${GH_MOCK_PR_MERGE_EXIT:-0}"
+        ;;
+      *) echo "unsupported gh pr subcommand: $*" >&2; exit 99 ;;
+    esac
+    ;;
+  *) echo "unsupported gh invocation: $*" >&2; exit 99 ;;
+esac
+EOF
+  chmod +x "$MOCK_DIR/gh"
+
+  export GH_MOCK_CALLS="$MOCK_DIR/calls.log"
+  : > "$GH_MOCK_CALLS"
+}
+
+teardown_gh_mock() {
+  rm -rf "$MOCK_DIR"
+}

--- a/.github/actions/auto-approve-bot-prs/test/wait-for-ci.bats
+++ b/.github/actions/auto-approve-bot-prs/test/wait-for-ci.bats
@@ -1,0 +1,71 @@
+#!/usr/bin/env bats
+
+SCRIPT="$BATS_TEST_DIRNAME/../src/wait-for-ci.sh"
+load gh_mock
+
+setup() {
+  setup_gh_mock
+  export GITHUB_OUTPUT; GITHUB_OUTPUT="$(mktemp)"
+  export GITHUB_REPOSITORY="owner/repo"
+  export PR_HEAD_SHA="deadbeef"
+  export SELF_RUN_ID="111111"
+  export WAIT_MAX_ATTEMPTS=2
+  export WAIT_SLEEP_SECONDS=1
+}
+teardown() { rm -f "$GITHUB_OUTPUT"; teardown_gh_mock; }
+
+kv() { grep "^$1=" "$GITHUB_OUTPUT" | tail -n1; }
+
+@test "no check-runs → ci_green=true" {
+  GH_MOCK_CHECK_RUNS_JSON='{"check_runs":[]}' run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv ci_green)" = "ci_green=true" ]
+}
+
+@test "only self check-run → ci_green=true" {
+  GH_MOCK_CHECK_RUNS_JSON='{"check_runs":[{"status":"in_progress","conclusion":null,"details_url":"https://github.com/o/r/actions/runs/111111/job/1"}]}' \
+    run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv ci_green)" = "ci_green=true" ]
+}
+
+@test "all other checks success → ci_green=true" {
+  GH_MOCK_CHECK_RUNS_JSON='{"check_runs":[
+    {"status":"completed","conclusion":"success","details_url":"https://github.com/o/r/actions/runs/222/job/1"},
+    {"status":"completed","conclusion":"skipped","details_url":"https://github.com/o/r/actions/runs/333/job/1"},
+    {"status":"completed","conclusion":"neutral","details_url":"https://github.com/o/r/actions/runs/444/job/1"}
+  ]}' run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv ci_green)" = "ci_green=true" ]
+}
+
+@test "any other check failed → ci_green=false" {
+  GH_MOCK_CHECK_RUNS_JSON='{"check_runs":[
+    {"status":"completed","conclusion":"success","details_url":"https://github.com/o/r/actions/runs/222/job/1"},
+    {"status":"completed","conclusion":"failure","details_url":"https://github.com/o/r/actions/runs/333/job/1"}
+  ]}' run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv ci_green)" = "ci_green=false" ]
+}
+
+@test "other check still pending exceeds attempts → ci_green=false (timeout)" {
+  GH_MOCK_CHECK_RUNS_JSON='{"check_runs":[
+    {"status":"in_progress","conclusion":null,"details_url":"https://github.com/o/r/actions/runs/222/job/1"}
+  ]}' run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv ci_green)" = "ci_green=false" ]
+}
+
+@test "self check pending but other check passed → ci_green=true" {
+  GH_MOCK_CHECK_RUNS_JSON='{"check_runs":[
+    {"status":"in_progress","conclusion":null,"details_url":"https://github.com/o/r/actions/runs/111111/job/1"},
+    {"status":"completed","conclusion":"success","details_url":"https://github.com/o/r/actions/runs/222/job/1"}
+  ]}' run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv ci_green)" = "ci_green=true" ]
+}
+
+@test "missing PR_HEAD_SHA fails" {
+  run env -u PR_HEAD_SHA GITHUB_OUTPUT="$GITHUB_OUTPUT" GITHUB_REPOSITORY=o/r SELF_RUN_ID=1 "$SCRIPT"
+  [ "$status" -ne 0 ]
+}

--- a/.github/workflows/auto-approve-bot-prs.yaml
+++ b/.github/workflows/auto-approve-bot-prs.yaml
@@ -20,96 +20,28 @@ on:
         description: 'GitHub PAT for approving PRs (must be different identity from PR author)'
         required: true
 
-# Policy: this reusable workflow must never block caller CI. Every step
-# catches its own errors and exits 0; `continue-on-error: true` on the job
-# is a final safety net so the check reports soft-fail (orange) at worst,
-# never red.
 jobs:
   auto-approve:
     runs-on: ubuntu-latest
+    # Skip fork PRs — secrets are not available.
     if: github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       pull-requests: write
       contents: read
+    # Safety net — internal steps already guard every failure mode, but if
+    # anything unforeseen slips through this still prevents the job from
+    # reporting a hard red check on caller CI.
     continue-on-error: true
     steps:
-      - name: Check eligibility
-        id: check
-        env:
-          TRUSTED_AUTHORS: ${{ inputs.trusted-authors }}
-          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          PR_BRANCH: ${{ github.event.pull_request.head.ref }}
-        run: |
-          IFS=',' read -ra AUTHORS <<< "${TRUSTED_AUTHORS}"
-          for author in "${AUTHORS[@]}"; do
-            [ "${author}" = "${PR_AUTHOR}" ] && trusted=true && break
-          done
-          if [ -z "${trusted:-}" ]; then
-            echo "::notice::Author '${PR_AUTHOR}' not in trusted list"
-            echo "eligible=false" >> "${GITHUB_OUTPUT}"
-            exit 0
-          fi
-
-          if   [[ "${PR_TITLE}"  =~ ^chore(\(|:)              ]]; then eligible=true
-          elif [[ "${PR_TITLE}"  =~ ^fix\(deps\)              ]]; then eligible=true
-          elif [[ "${PR_BRANCH}" =~ ^backport/                ]]; then eligible=true
-          elif [[ "${PR_BRANCH}" =~ ^renovate/                ]]; then eligible=true
-          elif [[ "${PR_BRANCH}" =~ ^update-platform-version- ]]; then eligible=true
-          else eligible=false
-          fi
-          echo "eligible=${eligible}" >> "${GITHUB_OUTPUT}"
-          [ "${eligible}" = "true" ] || echo "::notice::PR not in auto-approve patterns (title: ${PR_TITLE}, branch: ${PR_BRANCH})"
-
-      - name: Check merge conflicts and approver identity
-        if: steps.check.outputs.eligible == 'true'
-        id: gate
-        env:
-          GH_TOKEN: ${{ secrets.gh-access-token }} # zizmor: ignore[secrets-outside-env] -- PAT passed via workflow_call, not a repo secret
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-        run: |
-          # mergeable can be null briefly while GitHub computes metadata.
-          MERGEABLE="null"
-          for _ in 1 2 3; do
-            MERGEABLE=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.mergeable // "null"' 2>/dev/null || echo "null")
-            [ "${MERGEABLE}" != "null" ] && break
-            sleep 3
-          done
-          if [ "${MERGEABLE}" != "true" ]; then
-            echo "::notice::PR mergeability is '${MERGEABLE}', skipping"
-            echo "proceed=false" >> "${GITHUB_OUTPUT}"
-            exit 0
-          fi
-
-          # Pre-empt hmarr/auto-approve-action's 422 "approve your own PR"
-          # failure — it calls core.setFailed on that error.
-          APPROVER=$(gh api user --jq '.login' 2>/dev/null || echo "")
-          if [ -z "${APPROVER}" ] || [ "${APPROVER}" = "${PR_AUTHOR}" ]; then
-            echo "::notice::Skipping approval (approver='${APPROVER}', author='${PR_AUTHOR}')"
-            echo "proceed=false" >> "${GITHUB_OUTPUT}"
-            exit 0
-          fi
-          echo "proceed=true" >> "${GITHUB_OUTPUT}"
-
-      - name: Approve PR
-        if: steps.gate.outputs.proceed == 'true'
-        continue-on-error: true
-        uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363 # v4.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          github-token: ${{ secrets.gh-access-token }} # zizmor: ignore[secrets-outside-env] -- PAT passed via workflow_call, not a repo secret
-          review-message: 'Auto-approved: trusted bot, no merge conflicts. CI must pass before merge.'
-
-      - name: Enable auto-merge
-        if: steps.gate.outputs.proceed == 'true' && inputs.auto-merge
-        env:
-          GH_TOKEN: ${{ secrets.gh-access-token }} # zizmor: ignore[secrets-outside-env] -- PAT passed via workflow_call, not a repo secret
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          MERGE_METHOD: ${{ inputs.merge-method }}
-        run: |
-          case "${MERGE_METHOD}" in
-            squash|merge|rebase) ;;
-            *) echo "::notice::Invalid merge method '${MERGE_METHOD}'"; exit 0 ;;
-          esac
-          gh pr merge "${PR_NUMBER}" --repo "${GITHUB_REPOSITORY}" --auto --"${MERGE_METHOD}" 2>&1 || \
-            echo "::notice::gh pr merge failed; auto-merge not enabled"
+          repository: loft-sh/github-actions
+          ref: main
+          persist-credentials: false
+          sparse-checkout: .github/actions/auto-approve-bot-prs
+      - uses: ./.github/actions/auto-approve-bot-prs
+        with:
+          trusted-authors: ${{ inputs.trusted-authors }}
+          merge-method: ${{ inputs.merge-method }}
+          auto-merge: ${{ inputs.auto-merge }}
+          github-token: ${{ secrets.gh-access-token }}

--- a/.github/workflows/auto-approve-bot-prs.yaml
+++ b/.github/workflows/auto-approve-bot-prs.yaml
@@ -44,4 +44,4 @@ jobs:
           trusted-authors: ${{ inputs.trusted-authors }}
           merge-method: ${{ inputs.merge-method }}
           auto-merge: ${{ inputs.auto-merge }}
-          github-token: ${{ secrets.gh-access-token }}
+          github-token: ${{ secrets.gh-access-token }} # zizmor: ignore[secrets-outside-env] -- PAT passed via workflow_call, not a repo secret

--- a/.github/workflows/test-auto-approve-bot-prs.yaml
+++ b/.github/workflows/test-auto-approve-bot-prs.yaml
@@ -21,24 +21,19 @@ jobs:
         with:
           tests: .github/actions/auto-approve-bot-prs/test
 
-  auto-approve:
+  # Smoke test the composite action on the PR branch (the reusable workflow
+  # pins ref: main, which wouldn't yet contain the composite during this
+  # PR's CI). Human-authored PRs skip on the trusted-author check, so the
+  # job always reports success.
+  composite-smoke:
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
-    uses: ./.github/workflows/auto-approve-bot-prs.yaml
-    secrets:
-      gh-access-token: ${{ secrets.GITHUB_TOKEN }}
-
-  verify:
-    needs: [auto-approve]
-    if: always()
-    runs-on: ubuntu-latest
     steps:
-      - name: Check result
-        env:
-          RESULT: ${{ needs.auto-approve.result }}
-        run: |
-          if [ "$RESULT" != "success" ]; then
-            echo "::error::Expected result=success, got '$RESULT'"
-            exit 1
-          fi
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/auto-approve-bot-prs
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-auto-approve-bot-prs.yaml
+++ b/.github/workflows/test-auto-approve-bot-prs.yaml
@@ -4,11 +4,23 @@ on:
   pull_request:
     paths:
       - '.github/workflows/auto-approve-bot-prs.yaml'
+      - '.github/actions/auto-approve-bot-prs/**'
 
 permissions:
   contents: read
 
 jobs:
+  bats:
+    name: Run bats tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: bats-core/bats-action@2104b40bb7b6c2d5110b23a26b0bf265ab8027db # v3.0.0
+        with:
+          tests: .github/actions/auto-approve-bot-prs/test
+
   auto-approve:
     permissions:
       contents: read

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,38 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Keep actions focused on a single responsibility
 - Use input validation and provide helpful error messages
 
+## Testing Reusable Workflows
+
+A unit-testable script + bats suite can't cover a `workflow_call` reusable workflow
+end-to-end: both `github.workflow_sha` and `github.workflow_ref` resolve to the
+caller's context in `workflow_call`, so sparse-checkout of the reusable workflow's
+own repo doesn't work. Keep non-trivial reusable-workflow logic inline in the YAML
+and cover scenarios via a dedicated e2e repo instead.
+
+Pattern (see `auto-approve-bot-prs.yaml` + `vClusterLabs-Experiments/auto-approve-e2e`):
+
+1. **Keep the in-repo smoke test** (`test-<workflow>.yaml`) — calls the workflow
+   with GITHUB_TOKEN, asserts the skip-path stays green. Fast signal on every PR.
+2. **Add a scenario matrix in a dedicated e2e repo** under
+   `vClusterLabs-Experiments/`. One caller workflow uses `@main`. An orchestrator
+   (`workflow_dispatch` + weekly cron) creates real PRs covering every decision
+   branch, waits for the caller to finish, and asserts:
+   - `conclusion ∈ {success, skipped, neutral}` — the **never-hard-fail invariant**
+     (advisory workflows must not block caller CI)
+   - decision-table outputs (`eligible=true|false`) match expectations
+3. **Gotcha: GITHUB_TOKEN-created PRs don't trigger `pull_request` events for
+   other workflows.** The orchestrator needs a PAT (`GH_ACCESS_TOKEN`) to open
+   PRs that actually fire the caller workflow.
+
+Never-hard-fail enforcement for advisory workflows (approval, notifications):
+
+- `continue-on-error: true` on the job (final safety net)
+- every shell step catches its own errors and exits 0 (`::notice::` / `::warning::`
+  instead of `::error::`)
+- pre-empt known failure modes in external actions before calling them (e.g.
+  check PR author vs approver identity before calling hmarr's auto-approve,
+  which otherwise `setFailed`s on the 422 self-review error)
+
 ## Release Process
 
 Actions use per-action tags (e.g. `semver-validation/v1`, `linear-release-sync/v1`).

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-semver-validation test-linear-pr-commenter test-release-notification test-linear-release-sync test-cleanup-head-charts build-linear-release-sync lint help
+.PHONY: test test-semver-validation test-linear-pr-commenter test-release-notification test-linear-release-sync test-cleanup-head-charts test-auto-approve-bot-prs build-linear-release-sync lint help
 
 ACTIONS_DIR := .github/actions
 SCRIPTS_DIR := .github/scripts
@@ -6,7 +6,7 @@ SCRIPTS_DIR := .github/scripts
 help: ## show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-30s %s\n", $$1, $$2}'
 
-test: test-semver-validation test-linear-pr-commenter test-release-notification test-linear-release-sync test-cleanup-head-charts ## run all action tests
+test: test-semver-validation test-linear-pr-commenter test-release-notification test-linear-release-sync test-cleanup-head-charts test-auto-approve-bot-prs ## run all action tests
 
 test-semver-validation: ## run semver-validation unit tests
 	cd $(ACTIONS_DIR)/semver-validation && npm ci --silent && NODE_OPTIONS=--experimental-vm-modules npx jest --ci --coverage --watchAll=false
@@ -22,6 +22,9 @@ test-linear-release-sync: ## run linear-release-sync unit tests
 
 test-cleanup-head-charts: ## run cleanup-head-charts bats tests
 	bats $(SCRIPTS_DIR)/cleanup-head-charts/test/cleanup-head-charts.bats
+
+test-auto-approve-bot-prs: ## run auto-approve-bot-prs bats tests
+	bats $(ACTIONS_DIR)/auto-approve-bot-prs/test/*.bats
 
 build-linear-release-sync: ## build linear-release-sync binary (linux/amd64)
 	cd $(ACTIONS_DIR)/linear-release-sync/src && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-s -w" -o ../linear-release-sync-linux-amd64 .

--- a/README.md
+++ b/README.md
@@ -81,6 +81,49 @@ jobs:
 
 Detected config files: `renovate.json`, `renovate.json5`, `.renovaterc`, `.renovaterc.json`, `.github/renovate.json`, `.github/renovate.json5`.
 
+### Auto-approve bot PRs
+
+Approves (and optionally enables auto-merge on) PRs from trusted bot accounts
+whose title or branch matches a known safe pattern (`chore:` / `fix(deps):` /
+`backport/` / `renovate/` / `update-platform-version-`). Hardened to **never
+block caller CI**: `continue-on-error: true` on the job, every shell step
+catches its own errors and exits 0, self-approval is pre-empted before calling
+the external approve action.
+
+**Location:** `.github/workflows/auto-approve-bot-prs.yaml`
+
+**Usage:**
+
+```yaml
+name: Auto-approve bot PRs
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  auto-approve:
+    permissions:
+      pull-requests: write
+      contents: read
+    uses: loft-sh/github-actions/.github/workflows/auto-approve-bot-prs.yaml@main
+    with:
+      trusted-authors: 'renovate[bot],loft-bot,github-actions[bot],dependabot[bot]'
+      auto-merge: false
+    secrets:
+      gh-access-token: ${{ secrets.GH_ACCESS_TOKEN }}
+```
+
+`gh-access-token` must be a PAT whose identity differs from PR authors you want
+to auto-approve (GitHub forbids self-review). When identity matches, the job
+skips gracefully instead of failing.
+
+**End-to-end coverage:** scenario-level e2e lives in
+[vClusterLabs-Experiments/auto-approve-e2e](https://github.com/vClusterLabs-Experiments/auto-approve-e2e).
+Runs weekly and on demand. Creates real PRs exercising every decision-table
+branch (chore/fix(deps) titles, backport/renovate/update-platform-version
+branches, ineligible titles) and asserts the never-hard-fail invariant.
+
 ### Actionlint
 
 Lints GitHub Actions workflow files using actionlint with reviewdog integration.


### PR DESCRIPTION
Supersedes #91 (fresh branch from main). Replaces inline YAML shell with a proper composite action and unit-tested bash scripts — and adds the \"wait for other CI to be green\" gate.

## Changes

- New `.github/actions/auto-approve-bot-prs/` composite action
  - `src/check-eligibility.sh` — decision table
  - `src/check-pr-ready.sh` — mergeable + approver-identity gate
  - `src/wait-for-ci.sh` — polls non-self check-runs on PR head until all green
  - `src/enable-auto-merge.sh` — `gh pr merge --auto`
  - 25 bats tests with a shared `gh` mock
- Reusable workflow becomes a thin wrapper: sparse-checkout the composite from `@main` + hand off via `uses:`
- Makefile target `test-auto-approve-bot-prs`, CI bats job, path-filtered on the composite dir

## Why this shape

- No logic in YAML. Bash scripts are testable; YAML \`run: |\` blocks are not.
- Composite action sidesteps the workflow_sha/workflow_ref gotcha. Both resolve to the caller's context under workflow_call; we hardcode \`ref: main\` on the sparse-checkout.
- Wait-for-other-CI gate: approval waits until every non-self check-run finishes green/skipped/neutral. Self-identification via \`details_url\` containing \`/runs/<run_id>/\`.
- Never-block preserved: \`continue-on-error: true\` on the job, every script exits 0 on every path, self-approve 422 pre-empted before calling hmarr.

## Test plan
- [x] `make test-auto-approve-bot-prs` → 25/25 local
- [ ] CI bats + actionlint + zizmor pass
- [ ] smoke auto-approve workflow call still reports success

Refs DEVOPS-749