### PR TITLE
feat(release-notification): add status input (v2)

### DIFF
--- a/.github/actions/release-notification/action.yml
+++ b/.github/actions/release-notification/action.yml
@@ -33,6 +33,10 @@ inputs:
     description: 'Source branch from which the release was cut (auto-detected from git history when omitted)'
     required: false
     default: ''
+  status:
+    description: 'Release status: success, failure, cancelled, or skipped'
+    required: false
+    default: 'success'
   webhook_url:
     description: 'Slack Webhook URL'
     required: true
@@ -40,9 +44,18 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Validate status input
+      shell: bash
+      env:
+        STATUS: ${{ inputs.status }}
+      run: |
+        case "$STATUS" in
+          success|failure|cancelled|skipped) ;;
+          *) echo "::error::Invalid status '$STATUS'. Must be one of: success, failure, cancelled, skipped."; exit 1 ;;
+        esac
     - name: Detect base branch
       id: detect_branch
-      if: inputs.base_branch == ''
+      if: inputs.status == 'success' && inputs.base_branch == ''
       shell: bash
       env:
         RELEASE_VERSION: ${{ inputs.version }}
@@ -50,6 +63,7 @@ runs:
         BRANCH=$("${{ github.action_path }}/detect-branch.sh")
         echo "base_branch=$BRANCH" >> "$GITHUB_OUTPUT"
     - name: Post release notification
+      if: inputs.status == 'success'
       uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95  # v3.0.1
       with:
         errors: true
@@ -85,3 +99,42 @@ runs:
               elements:
                 - type: mrkdwn
                   text: "<https://github.com/${{ inputs.target_repo }}/releases/tag/${{ inputs.version }}|View Release>"
+    - name: Resolve status text
+      id: status_text
+      if: inputs.status != 'success'
+      shell: bash
+      env:
+        STATUS: ${{ inputs.status }}
+      run: |
+        case "$STATUS" in
+          failure)   echo "emoji=:rotating_light:" >> "$GITHUB_OUTPUT"; echo "label=Failed" >> "$GITHUB_OUTPUT" ;;
+          cancelled) echo "emoji=:warning:" >> "$GITHUB_OUTPUT"; echo "label=Cancelled" >> "$GITHUB_OUTPUT" ;;
+          skipped)   echo "emoji=:fast_forward:" >> "$GITHUB_OUTPUT"; echo "label=Skipped" >> "$GITHUB_OUTPUT" ;;
+        esac
+    - name: Post release failure notification
+      if: inputs.status != 'success'
+      uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95  # v3.0.1
+      with:
+        errors: true
+        webhook-type: incoming-webhook
+        webhook: ${{ inputs.webhook_url }}
+        payload: |
+          text: "${{ steps.status_text.outputs.emoji }} ${{ inputs.product }} release pipeline ${{ steps.status_text.outputs.label }} for ${{ inputs.version }}"
+          blocks:
+            - type: header
+              text:
+                type: plain_text
+                text: "${{ steps.status_text.outputs.emoji }} Release Pipeline ${{ steps.status_text.outputs.label }}"
+                emoji: false
+            - type: section
+              fields:
+                - type: mrkdwn
+                  text: "*Product:*\n${{ inputs.product }}"
+                - type: mrkdwn
+                  text: "*Version:*\n${{ inputs.version }}"
+            - type: section
+              fields:
+                - type: mrkdwn
+                  text: "*Triggered by:*\n${{ github.actor }}"
+                - type: mrkdwn
+                  text: "*Run:*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View details>"

--- a/.github/workflows/notify-release.yaml
+++ b/.github/workflows/notify-release.yaml
@@ -8,9 +8,10 @@ on:
         required: true
         type: string
       previous_tag:
-        description: 'The previous tag for changelog comparison'
-        required: true
+        description: 'The previous tag for changelog comparison (required when status=success)'
+        required: false
         type: string
+        default: ''
       target_repo:
         description: 'Target repository (e.g. loft-sh/vcluster)'
         required: true
@@ -19,6 +20,11 @@ on:
         description: 'Product name (e.g. vCluster, vCluster Platform)'
         required: true
         type: string
+      status:
+        description: 'Release status: success, failure, cancelled, or skipped (default: success)'
+        required: false
+        type: string
+        default: 'success'
       ref:
         description: 'The git ref to checkout (defaults to github.ref)'
         required: false
@@ -48,13 +54,19 @@ jobs:
           PREVIOUS_TAG: ${{ inputs.previous_tag }}
           TARGET_REPO: ${{ inputs.target_repo }}
           PRODUCT: ${{ inputs.product }}
+          STATUS: ${{ inputs.status }}
         run: |
           echo "dry-run: validating notify-release inputs"
           echo "  release_version=$RELEASE_VERSION"
           echo "  previous_tag=$PREVIOUS_TAG"
           echo "  target_repo=$TARGET_REPO"
           echo "  product=$PRODUCT"
-          for var in RELEASE_VERSION PREVIOUS_TAG TARGET_REPO PRODUCT; do
+          echo "  status=$STATUS"
+          REQUIRED_VARS="RELEASE_VERSION TARGET_REPO PRODUCT"
+          if [ "$STATUS" = "success" ]; then
+            REQUIRED_VARS="$REQUIRED_VARS PREVIOUS_TAG"
+          fi
+          for var in $REQUIRED_VARS; do
             if [ -z "${!var}" ]; then
               echo "::error::Required input $var is empty"
               exit 1
@@ -62,7 +74,7 @@ jobs:
           done
           echo "All required inputs are valid"
       - name: Checkout repository
-        if: ${{ !inputs.dry-run }}
+        if: ${{ !inputs.dry-run && inputs.status == 'success' }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ inputs.target_repo }}
@@ -79,4 +91,5 @@ jobs:
           changes: "See changelog link below"
           target_repo: ${{ inputs.target_repo }}
           product: ${{ inputs.product }}
+          status: ${{ inputs.status }}
           webhook_url: ${{ secrets.SLACK_WEBHOOK_URL_PRODUCT_RELEASES }} # zizmor: ignore[secrets-outside-env] -- webhook URL passed via workflow_call


### PR DESCRIPTION
## Summary

- Add `status` input to `release-notification` action and `notify-release` workflow (success, failure, cancelled, skipped)
- Non-success statuses render a failure-style payload with product, version, actor, and run link
- Checkout is skipped for non-success statuses (no branch detection needed)
- Dry-run validation only requires `previous_tag` when status=success

**BREAKING CHANGE:** `previous_tag` is no longer required at the workflow level (still required when status=success). Existing callers that already pass `previous_tag` are unaffected.

Tag as `release-notification/v2` after merge.

## Test plan

- [ ] Existing callers (vcluster-pro, loft-enterprise) continue to work unchanged (status defaults to success)
- [ ] New failure callers render correct emoji/label in Slack
- [ ] Dry-run validates correctly for both success and non-success statuses
- [ ] actionlint passes