### PR TITLE
fix(auto-approve): block prerelease platform versions from auto-approve

### DIFF
--- a/.github/actions/auto-approve-bot-prs/src/check-eligibility.sh
+++ b/.github/actions/auto-approve-bot-prs/src/check-eligibility.sh
@@ -33,6 +33,16 @@ if [ "$author_trusted" != "true" ]; then
   exit 0
 fi
 
+# Prerelease platform versions must never be auto-approved — the title
+# (chore: update platform version to vX.Y.Z-alpha.N) would otherwise
+# match the chore pattern below, bypassing the branch-level check.
+if [[ "$PR_BRANCH" =~ ^update-platform-version-.*-(alpha|beta|rc)\. ]]; then
+  echo "::warning::Platform version update contains prerelease tag, skipping (branch: $PR_BRANCH)"
+  emit eligible false
+  emit reason ""
+  exit 0
+fi
+
 eligible=false
 reason=""
 if   [[ "$PR_TITLE"  =~ ^chore(\(|:)              ]]; then eligible=true; reason="chore PR"

--- a/.github/actions/auto-approve-bot-prs/test/check-eligibility.bats
+++ b/.github/actions/auto-approve-bot-prs/test/check-eligibility.bats
@@ -45,8 +45,23 @@ assert_kv() {
   run_script "$DEFAULT" 'renovate[bot]' 'anything' 'renovate/pkg'; assert_kv eligible true
 }
 
-@test "update-platform-version- branch → eligible" {
+@test "update-platform-version- branch (stable) → eligible" {
   run_script "$DEFAULT" 'loft-bot' 'anything' 'update-platform-version-4.6.0'; assert_kv eligible true
+}
+
+@test "update-platform-version- branch (alpha) → not eligible" {
+  run_script "$DEFAULT" 'loft-bot' 'chore: update platform version to v4.9.0-alpha.2' 'update-platform-version-v4.9.0-alpha.2'
+  [ "$status" -eq 0 ]; assert_kv eligible false
+}
+
+@test "update-platform-version- branch (beta) → not eligible" {
+  run_script "$DEFAULT" 'loft-bot' 'chore: update platform version to v4.9.0-beta.1' 'update-platform-version-v4.9.0-beta.1'
+  [ "$status" -eq 0 ]; assert_kv eligible false
+}
+
+@test "update-platform-version- branch (rc) → not eligible" {
+  run_script "$DEFAULT" 'loft-bot' 'chore: update platform version to v4.9.0-rc.1' 'update-platform-version-v4.9.0-rc.1'
+  [ "$status" -eq 0 ]; assert_kv eligible false
 }
 
 @test "feat: title on trusted author → not eligible" {


### PR DESCRIPTION
## Summary

- Add early-exit guard in `check-eligibility.sh` that rejects platform version update PRs containing prerelease tags (alpha, beta, rc)
- Without this, the PR title `chore: update platform version to vX.Y.Z-alpha.N` matches the `^chore` pattern and bypasses the branch-level check
- Three bats test cases cover alpha, beta, and rc branch names

## Context

PR loft-sh/loft-prod#276 auto-merged `v4.9.0-alpha.2` to production, breaking Terraform because the alpha chart doesn't exist in the Helm repo.

Root cause fix (inline approval removal): loft-sh/loft-prod#278
This PR is defense-in-depth for the reusable workflow.

## Test plan

- [x] All 15 bats tests pass locally (`bats .github/actions/auto-approve-bot-prs/test/check-eligibility.bats`)
- [ ] CI green

Closes DEVOPS-714