### PR TITLE
fix(release-notification): remove top-level permissions to allow callers with permissions: {}

### DIFF
--- a/.github/workflows/notify-release.yaml
+++ b/.github/workflows/notify-release.yaml
@@ -40,9 +40,6 @@ on:
         description: 'Slack incoming webhook URL for #product-releases'
         required: true
 
-permissions:
-  contents: read
-
 jobs:
   notify_release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Remove `permissions: contents: read` from the `notify-release.yaml` reusable workflow
- The checkout step is already conditional on `inputs.status == 'success'`, so failure callers never need contents access
- Fixes release workflow validation failures in loft-enterprise, vcluster-pro, and vcluster where `notify_failure` jobs use `permissions: {}` but the reusable workflow required `contents: read`

## Context

Error from loft-enterprise release workflow:
```
.github/workflows/release.yaml (Line: 186, Col: 3): Error calling workflow
'loft-sh/github-actions/.github/workflows/notify-release.yaml@55d5b75...'.
The workflow is requesting 'contents: read', but is only allowed 'contents: none'.
```

GitHub statically validates that callers grant at least the permissions declared by a reusable workflow. Since failure notification jobs correctly use `permissions: {}` (they only need a Slack webhook, no GITHUB_TOKEN scopes), the fix is to remove the top-level declaration and let callers control their own token scope.

## Test plan

- [ ] Verify loft-enterprise release workflow passes validation
- [ ] Verify vcluster-pro release workflow passes validation
- [ ] Verify vcluster release workflow passes validation