### PR TITLE
feat(run-ginkgo): add composite action for Ginkgo test execution

### DIFF
--- a/.github/actions/run-ginkgo/README.md
+++ b/.github/actions/run-ginkgo/README.md
@@ -1,0 +1,48 @@
+# Run Ginkgo Tests
+
+Execute Ginkgo tests with directory or label-based filtering and JSON failure
+reporting. Handles Ginkgo CLI installation, argument construction, and
+markdown summary generation.
+
+## Inputs
+
+<!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
+
+|          INPUT          |  TYPE  | REQUIRED |   DEFAULT    |                                      DESCRIPTION                                       |
+|-------------------------|--------|----------|--------------|----------------------------------------------------------------------------------------|
+|     additional-args     | string |  false   |              |               Extra arguments passed to the test <br>binary (after --)                 |
+| additional-ginkgo-flags | string |  false   |              |     Extra ginkgo CLI flags (e.g. -v, --skip-package=linters, --show-node-events)       |
+|      ginkgo-label       | string |  false   |              | Ginkgo label filter expression. When set, <br>adds --label-filter and -r (recursive).  |
+|          procs          | string |  false   |    `"8"`     |                          Number of parallel Ginkgo processes                           |
+|        test-dir         | string |  false   | `"e2e-next"` |                            Directory containing test suites                            |
+|         timeout         | string |  false   |   `"60m"`    |                                  Ginkgo test timeout                                   |
+
+<!-- AUTO-DOC-INPUT:END -->
+
+## Outputs
+
+<!-- AUTO-DOC-OUTPUT:START - Do not remove or modify this section -->
+
+|     OUTPUT      |  TYPE  |               DESCRIPTION               |
+|-----------------|--------|-----------------------------------------|
+| failure-summary | string | Markdown-formatted test results summary |
+
+<!-- AUTO-DOC-OUTPUT:END -->
+
+## Usage
+
+```yaml
+- uses: loft-sh/github-actions/.github/actions/run-ginkgo@run-ginkgo/v1
+  with:
+    test-dir: e2e-next
+    ginkgo-label: "networking"
+    additional-args: "--vcluster-image=ghcr.io/loft-sh/vcluster:latest --teardown=false"
+```
+
+## Testing
+
+```bash
+make test-run-ginkgo
+```
+
+Runs the bats suites in `test/` against the shell scripts in `src/`.

--- a/.github/actions/run-ginkgo/action.yml
+++ b/.github/actions/run-ginkgo/action.yml
@@ -1,0 +1,61 @@
+name: "Run Ginkgo Tests"
+description: "Execute Ginkgo tests with directory or label-based filtering and JSON failure reporting"
+
+inputs:
+  timeout:
+    description: "Ginkgo test timeout"
+    required: false
+    default: "60m"
+  procs:
+    description: "Number of parallel Ginkgo processes"
+    required: false
+    default: "8"
+  ginkgo-label:
+    description: "Ginkgo label filter expression. When set, adds --label-filter and -r (recursive)."
+    required: false
+    default: ""
+  test-dir:
+    description: "Directory containing test suites"
+    required: false
+    default: "e2e-next"
+  additional-args:
+    description: "Extra arguments passed to the test binary (after --)"
+    required: false
+    default: ""
+  additional-ginkgo-flags:
+    description: "Extra ginkgo CLI flags (e.g. -v, --skip-package=linters, --show-node-events)"
+    required: false
+    default: ""
+
+outputs:
+  failure-summary:
+    description: "Markdown-formatted test results summary"
+    value: ${{ steps.generate-summary.outputs.failure-summary }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install Ginkgo CLI
+      shell: bash
+      run: |
+        cd "$TEST_DIR"
+        go install github.com/onsi/ginkgo/v2/ginkgo
+      env:
+        TEST_DIR: ${{ inputs.test-dir }}
+
+    - name: Execute Ginkgo tests
+      shell: bash
+      env:
+        GINKGO_LABEL: ${{ inputs.ginkgo-label }}
+        TEST_DIR: ${{ inputs.test-dir }}
+        TIMEOUT: ${{ inputs.timeout }}
+        PROCS: ${{ inputs.procs }}
+        ADDITIONAL_ARGS: ${{ inputs.additional-args }}
+        ADDITIONAL_GINKGO_FLAGS: ${{ inputs.additional-ginkgo-flags }}
+      run: ${{ github.action_path }}/src/execute-tests.sh
+
+    - name: Generate failure summary
+      id: generate-summary
+      if: always()
+      shell: bash
+      run: ${{ github.action_path }}/src/generate-summary.sh

--- a/.github/actions/run-ginkgo/src/execute-tests.sh
+++ b/.github/actions/run-ginkgo/src/execute-tests.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Required env vars: TEST_DIR, TIMEOUT, PROCS
+# Optional env vars: GINKGO_LABEL, ADDITIONAL_ARGS, ADDITIONAL_GINKGO_FLAGS
+
+WORKSPACE_ROOT="$(pwd)"
+REPORTS_DIR="${WORKSPACE_ROOT}/test-reports"
+mkdir -p "$REPORTS_DIR"
+
+# Build ginkgo command
+GINKGO_ARGS=(
+  "run"
+  "--timeout=${TIMEOUT}"
+  "--procs=${PROCS}"
+  "--poll-progress-after=20s"
+  "--poll-progress-interval=10s"
+  "--github-output"
+  "--json-report=${REPORTS_DIR}/report.json"
+)
+
+# Append caller-supplied ginkgo flags
+if [[ -n "${ADDITIONAL_GINKGO_FLAGS:-}" ]]; then
+  read -ra EXTRA_FLAGS <<< "$ADDITIONAL_GINKGO_FLAGS"
+  GINKGO_ARGS+=("${EXTRA_FLAGS[@]}")
+fi
+
+# Add label filter and recursive search when ginkgo-label is set
+if [[ -n "${GINKGO_LABEL:-}" ]]; then
+  LABEL_FILTER=$(echo "${GINKGO_LABEL}" | awk '{$1=$1; print}')
+  GINKGO_ARGS+=("--label-filter=${LABEL_FILTER}")
+  GINKGO_ARGS+=("-r")
+fi
+
+echo "Working directory: ${TEST_DIR}"
+echo "Command: ginkgo ${GINKGO_ARGS[*]} .${ADDITIONAL_ARGS:+ -- ${ADDITIONAL_ARGS}}"
+
+cd "$TEST_DIR"
+# shellcheck disable=SC2086
+ginkgo "${GINKGO_ARGS[@]}" . ${ADDITIONAL_ARGS:+-- ${ADDITIONAL_ARGS}}

--- a/.github/actions/run-ginkgo/src/generate-summary.sh
+++ b/.github/actions/run-ginkgo/src/generate-summary.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Required env vars: GITHUB_OUTPUT
+# Optional env vars: REPORT_FILE (defaults to test-reports/report.json)
+
+REPORT_FILE="${REPORT_FILE:-test-reports/report.json}"
+
+if [[ ! -f "$REPORT_FILE" ]]; then
+  echo "::warning::JSON report not found at ${REPORT_FILE}"
+  if [[ -d "$(dirname "$REPORT_FILE")" ]]; then
+    echo "Directory contents:"
+    ls -lah "$(dirname "$REPORT_FILE")" || true
+  else
+    echo "Report directory does not exist"
+  fi
+  echo "failure-summary=No detailed failure summary available" >> "$GITHUB_OUTPUT"
+  exit 0
+fi
+
+echo "Generating failure summary from JSON report..."
+
+command -v jq >/dev/null || { echo "::error::jq is required but not found"; exit 1; }
+
+# Count as failed: anything not passed, skipped, or pending
+STATS=$(jq -r '
+  {
+    failed: ([.[].SpecReports[] | select(.State | IN("passed", "skipped", "pending") | not)] | length),
+    passed: ([.[].SpecReports[] | select(.State == "passed")] | length),
+    skipped: ([.[].SpecReports[] | select(.State == "skipped")] | length),
+    pending: ([.[].SpecReports[] | select(.State == "pending")] | length),
+    total_specs: (.[0].PreRunStats.TotalSpecs // 0),
+    specs_to_run: (.[0].PreRunStats.SpecsThatWillRun // 0),
+    runtime: ((.[0].RunTime // 0) / 1000000000 | floor)
+  }
+' "$REPORT_FILE")
+
+FAILED_COUNT=$(echo "$STATS" | jq -r '.failed')
+PASSED_COUNT=$(echo "$STATS" | jq -r '.passed')
+SKIPPED_COUNT=$(echo "$STATS" | jq -r '.skipped')
+PENDING_COUNT=$(echo "$STATS" | jq -r '.pending')
+TOTAL_SPECS=$(echo "$STATS" | jq -r '.total_specs')
+SPECS_TO_RUN=$(echo "$STATS" | jq -r '.specs_to_run')
+RUNTIME=$(echo "$STATS" | jq -r '.runtime')
+
+{
+  echo "failure-summary<<EOF"
+
+  echo "*Test Results Summary:*"
+  echo "Executed: ${SPECS_TO_RUN}/${TOTAL_SPECS} tests"
+
+  if [[ "$FAILED_COUNT" -gt 0 ]]; then
+    echo "Failed: ${FAILED_COUNT}"
+    echo "Passed: ${PASSED_COUNT}"
+  else
+    echo "All tests passed! (${PASSED_COUNT}/${SPECS_TO_RUN})"
+  fi
+
+  if [[ "$SKIPPED_COUNT" -gt 0 ]]; then
+    echo "Skipped: ${SKIPPED_COUNT}"
+  fi
+  if [[ "$PENDING_COUNT" -gt 0 ]]; then
+    echo "Pending: ${PENDING_COUNT}"
+  fi
+  echo "Duration: ${RUNTIME}s"
+
+  if [[ "$FAILED_COUNT" -gt 0 ]]; then
+    echo ""
+    echo "*Failed Tests:*"
+    jq -r '[.[].SpecReports[] | select(.State | IN("passed", "skipped", "pending") | not)] |
+      .[] |
+      "[" + (.State | ascii_upcase) + "] [" + .LeafNodeType + "]" +
+      (if .ContainerHierarchyTexts then " " + (.ContainerHierarchyTexts | join(" ")) else "" end) +
+      (if .LeafNodeText != "" then " " + .LeafNodeText else "" end) +
+      "\n  " + .LeafNodeLocation.FileName + ":" + (.LeafNodeLocation.LineNumber | tostring)' \
+      "$REPORT_FILE"
+  fi
+
+  echo "EOF"
+} >> "$GITHUB_OUTPUT"
+
+echo "Summary generated (Failed: ${FAILED_COUNT}, Passed: ${PASSED_COUNT})"

--- a/.github/actions/run-ginkgo/test/execute-tests.bats
+++ b/.github/actions/run-ginkgo/test/execute-tests.bats
@@ -1,0 +1,185 @@
+#!/usr/bin/env bats
+# Tests for execute-tests.sh argument construction.
+# Mocks `ginkgo` to capture the arguments it would receive.
+
+SCRIPT="$BATS_TEST_DIRNAME/../src/execute-tests.sh"
+
+setup() {
+  MOCK_DIR=$(mktemp -d)
+  export MOCK_ARGS_FILE="$MOCK_DIR/ginkgo-args"
+
+  # Create a mock ginkgo that records arguments
+  MOCK_BIN="$MOCK_DIR/bin"
+  mkdir -p "$MOCK_BIN"
+  cat > "$MOCK_BIN/ginkgo" <<'MOCK'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "$MOCK_ARGS_FILE"
+MOCK
+  chmod +x "$MOCK_BIN/ginkgo"
+
+  # Create a fake test directory structure
+  export WORK_DIR="$MOCK_DIR/workspace"
+  mkdir -p "$WORK_DIR/e2e-next/suites/basic"
+
+  # Required env vars
+  export TEST_DIR="e2e-next"
+  export TIMEOUT="60m"
+  export PROCS="8"
+  export PATH="$MOCK_BIN:$PATH"
+}
+
+teardown() {
+  rm -rf "$MOCK_DIR"
+}
+
+has_arg() {
+  grep -qF -- "$1" "$MOCK_ARGS_FILE"
+}
+
+# --- Label-based tests ---
+
+@test "label-based: passes --label-filter as-is" {
+  cd "$WORK_DIR"
+  export GINKGO_LABEL="my-suite"
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  has_arg "--label-filter=my-suite"
+}
+
+@test "label-based: passes label with || pr when caller includes it" {
+  cd "$WORK_DIR"
+  export GINKGO_LABEL="my-suite || pr"
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  has_arg "--label-filter=my-suite || pr"
+}
+
+@test "label-based: adds -r for recursive search" {
+  cd "$WORK_DIR"
+  export GINKGO_LABEL="my-suite"
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  has_arg "-r"
+}
+
+@test "label-based: trims whitespace from label" {
+  cd "$WORK_DIR"
+  export GINKGO_LABEL="  my-suite  "
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  has_arg "--label-filter=my-suite"
+}
+
+# --- Directory-based tests ---
+
+@test "directory-based: does not add --label-filter or -r when ginkgo-label is empty" {
+  cd "$WORK_DIR"
+  export GINKGO_LABEL=""
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  ! grep -q "\-\-label-filter" "$MOCK_ARGS_FILE"
+  ! grep -q "^-r$" "$MOCK_ARGS_FILE"
+}
+
+@test "directory-based: uses test-dir directly" {
+  cd "$WORK_DIR"
+  export TEST_DIR="e2e-next/suites/basic"
+  export GINKGO_LABEL=""
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  has_arg "."
+}
+
+# --- Common flags ---
+
+@test "passes --timeout from env" {
+  cd "$WORK_DIR"
+  export GINKGO_LABEL="suite"
+  export TIMEOUT="120m"
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  has_arg "--timeout=120m"
+}
+
+@test "passes --procs from env" {
+  cd "$WORK_DIR"
+  export GINKGO_LABEL="suite"
+  export PROCS="4"
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  has_arg "--procs=4"
+}
+
+@test "always includes --github-output" {
+  cd "$WORK_DIR"
+  export GINKGO_LABEL="suite"
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  has_arg "--github-output"
+}
+
+@test "always includes --json-report" {
+  cd "$WORK_DIR"
+  export GINKGO_LABEL="suite"
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  grep -q "\-\-json-report=" "$MOCK_ARGS_FILE"
+}
+
+@test "always includes --poll-progress-after" {
+  cd "$WORK_DIR"
+  export GINKGO_LABEL="suite"
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  has_arg "--poll-progress-after=20s"
+}
+
+# --- Additional flags ---
+
+@test "additional-ginkgo-flags are appended" {
+  cd "$WORK_DIR"
+  export GINKGO_LABEL="suite"
+  export ADDITIONAL_GINKGO_FLAGS="-v --skip-package=linters"
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  has_arg "-v"
+  has_arg "--skip-package=linters"
+}
+
+@test "additional-args are passed after --" {
+  cd "$WORK_DIR"
+  export GINKGO_LABEL="suite"
+  export ADDITIONAL_ARGS="--vcluster-image=ghcr.io/loft-sh/vcluster:test --teardown=false"
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  grep -qx -- '--' "$MOCK_ARGS_FILE"
+  has_arg "--vcluster-image=ghcr.io/loft-sh/vcluster:test"
+  has_arg "--teardown=false"
+}
+
+@test "no -- separator when additional-args is empty" {
+  cd "$WORK_DIR"
+  export GINKGO_LABEL="suite"
+  export ADDITIONAL_ARGS=""
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  ! grep -qx -- '--' "$MOCK_ARGS_FILE"
+}
+
+# --- Report directory ---
+
+@test "creates test-reports directory" {
+  cd "$WORK_DIR"
+  export GINKGO_LABEL="suite"
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ -d "$WORK_DIR/test-reports" ]
+}
+
+@test "json-report uses absolute path" {
+  cd "$WORK_DIR"
+  export GINKGO_LABEL="suite"
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  grep -q "\-\-json-report=$WORK_DIR/test-reports/report.json" "$MOCK_ARGS_FILE"
+}

--- a/.github/actions/run-ginkgo/test/fixtures/all-passed.json
+++ b/.github/actions/run-ginkgo/test/fixtures/all-passed.json
@@ -1,0 +1,13 @@
+[
+  {
+    "PreRunStats": { "TotalSpecs": 5, "SpecsThatWillRun": 5 },
+    "RunTime": 120000000000,
+    "SpecReports": [
+      { "State": "passed", "LeafNodeType": "It", "LeafNodeText": "creates a vcluster", "ContainerHierarchyTexts": ["VCluster", "Lifecycle"], "LeafNodeLocation": { "FileName": "lifecycle_test.go", "LineNumber": 10 } },
+      { "State": "passed", "LeafNodeType": "It", "LeafNodeText": "syncs pods", "ContainerHierarchyTexts": ["VCluster", "Sync"], "LeafNodeLocation": { "FileName": "sync_test.go", "LineNumber": 20 } },
+      { "State": "passed", "LeafNodeType": "It", "LeafNodeText": "connects to vcluster", "ContainerHierarchyTexts": ["VCluster", "Lifecycle"], "LeafNodeLocation": { "FileName": "lifecycle_test.go", "LineNumber": 30 } },
+      { "State": "passed", "LeafNodeType": "It", "LeafNodeText": "deletes a vcluster", "ContainerHierarchyTexts": ["VCluster", "Lifecycle"], "LeafNodeLocation": { "FileName": "lifecycle_test.go", "LineNumber": 40 } },
+      { "State": "passed", "LeafNodeType": "It", "LeafNodeText": "handles network policies", "ContainerHierarchyTexts": ["VCluster", "Networking"], "LeafNodeLocation": { "FileName": "network_test.go", "LineNumber": 50 } }
+    ]
+  }
+]

--- a/.github/actions/run-ginkgo/test/fixtures/with-failures.json
+++ b/.github/actions/run-ginkgo/test/fixtures/with-failures.json
@@ -1,0 +1,13 @@
+[
+  {
+    "PreRunStats": { "TotalSpecs": 5, "SpecsThatWillRun": 5 },
+    "RunTime": 180000000000,
+    "SpecReports": [
+      { "State": "passed", "LeafNodeType": "It", "LeafNodeText": "creates a vcluster", "ContainerHierarchyTexts": ["VCluster", "Lifecycle"], "LeafNodeLocation": { "FileName": "lifecycle_test.go", "LineNumber": 10 } },
+      { "State": "failed", "LeafNodeType": "It", "LeafNodeText": "syncs pods", "ContainerHierarchyTexts": ["VCluster", "Sync"], "LeafNodeLocation": { "FileName": "sync_test.go", "LineNumber": 20 } },
+      { "State": "passed", "LeafNodeType": "It", "LeafNodeText": "connects to vcluster", "ContainerHierarchyTexts": ["VCluster", "Lifecycle"], "LeafNodeLocation": { "FileName": "lifecycle_test.go", "LineNumber": 30 } },
+      { "State": "skipped", "LeafNodeType": "It", "LeafNodeText": "deletes a vcluster", "ContainerHierarchyTexts": ["VCluster", "Lifecycle"], "LeafNodeLocation": { "FileName": "lifecycle_test.go", "LineNumber": 40 } },
+      { "State": "panicked", "LeafNodeType": "It", "LeafNodeText": "handles network policies", "ContainerHierarchyTexts": ["VCluster", "Networking"], "LeafNodeLocation": { "FileName": "network_test.go", "LineNumber": 50 } }
+    ]
+  }
+]

--- a/.github/actions/run-ginkgo/test/fixtures/with-pending.json
+++ b/.github/actions/run-ginkgo/test/fixtures/with-pending.json
@@ -1,0 +1,12 @@
+[
+  {
+    "PreRunStats": { "TotalSpecs": 4, "SpecsThatWillRun": 3 },
+    "RunTime": 60000000000,
+    "SpecReports": [
+      { "State": "passed", "LeafNodeType": "It", "LeafNodeText": "creates a vcluster", "ContainerHierarchyTexts": ["VCluster"], "LeafNodeLocation": { "FileName": "lifecycle_test.go", "LineNumber": 10 } },
+      { "State": "passed", "LeafNodeType": "It", "LeafNodeText": "syncs pods", "ContainerHierarchyTexts": ["VCluster"], "LeafNodeLocation": { "FileName": "sync_test.go", "LineNumber": 20 } },
+      { "State": "pending", "LeafNodeType": "It", "LeafNodeText": "future feature", "ContainerHierarchyTexts": ["VCluster"], "LeafNodeLocation": { "FileName": "future_test.go", "LineNumber": 30 } },
+      { "State": "skipped", "LeafNodeType": "It", "LeafNodeText": "optional test", "ContainerHierarchyTexts": ["VCluster"], "LeafNodeLocation": { "FileName": "optional_test.go", "LineNumber": 40 } }
+    ]
+  }
+]

--- a/.github/actions/run-ginkgo/test/generate-summary.bats
+++ b/.github/actions/run-ginkgo/test/generate-summary.bats
@@ -1,0 +1,205 @@
+#!/usr/bin/env bats
+# Tests for generate-summary.sh
+
+SCRIPT="$BATS_TEST_DIRNAME/../src/generate-summary.sh"
+FIXTURES="$BATS_TEST_DIRNAME/fixtures"
+
+setup() {
+  MOCK_DIR=$(mktemp -d)
+  export GITHUB_OUTPUT="$MOCK_DIR/output"
+  touch "$GITHUB_OUTPUT"
+}
+
+teardown() {
+  rm -rf "$MOCK_DIR"
+}
+
+# Helper: extract the failure-summary multiline value from GITHUB_OUTPUT
+get_summary() {
+  # Parse heredoc-style output: failure-summary<<EOF ... EOF
+  sed -n '/^failure-summary<<EOF$/,/^EOF$/{ /^failure-summary<<EOF$/d; /^EOF$/d; p; }' "$GITHUB_OUTPUT"
+}
+
+# Helper: get single-line failure-summary value
+get_summary_line() {
+  grep '^failure-summary=' "$GITHUB_OUTPUT" | cut -d= -f2-
+}
+
+# --- All tests passed ---
+
+@test "all-passed report shows success message" {
+  REPORT_FILE="$FIXTURES/all-passed.json" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+
+  local summary
+  summary="$(get_summary)"
+  [[ "$summary" == *"All tests passed!"* ]]
+  [[ "$summary" == *"5/5"* ]]
+}
+
+@test "all-passed report does not show Failed Tests section" {
+  REPORT_FILE="$FIXTURES/all-passed.json" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+
+  local summary
+  summary="$(get_summary)"
+  [[ "$summary" != *"Failed Tests"* ]]
+}
+
+@test "all-passed report shows correct duration" {
+  REPORT_FILE="$FIXTURES/all-passed.json" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+
+  local summary
+  summary="$(get_summary)"
+  [[ "$summary" == *"Duration: 120s"* ]]
+}
+
+@test "all-passed report does not show skipped or pending lines" {
+  REPORT_FILE="$FIXTURES/all-passed.json" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+
+  local summary
+  summary="$(get_summary)"
+  [[ "$summary" != *"Skipped:"* ]]
+  [[ "$summary" != *"Pending:"* ]]
+}
+
+# --- With failures ---
+
+@test "failure report shows failed count" {
+  REPORT_FILE="$FIXTURES/with-failures.json" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+
+  local summary
+  summary="$(get_summary)"
+  [[ "$summary" == *"Failed: 2"* ]]
+  [[ "$summary" == *"Passed: 2"* ]]
+}
+
+@test "failure report lists failed tests with details" {
+  REPORT_FILE="$FIXTURES/with-failures.json" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+
+  local summary
+  summary="$(get_summary)"
+  [[ "$summary" == *"[FAILED]"* ]]
+  [[ "$summary" == *"syncs pods"* ]]
+  [[ "$summary" == *"sync_test.go:20"* ]]
+}
+
+@test "panicked tests are counted as failures" {
+  REPORT_FILE="$FIXTURES/with-failures.json" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+
+  local summary
+  summary="$(get_summary)"
+  [[ "$summary" == *"[PANICKED]"* ]]
+  [[ "$summary" == *"handles network policies"* ]]
+  [[ "$summary" == *"network_test.go:50"* ]]
+}
+
+@test "failure report shows skipped count" {
+  REPORT_FILE="$FIXTURES/with-failures.json" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+
+  local summary
+  summary="$(get_summary)"
+  [[ "$summary" == *"Skipped: 1"* ]]
+}
+
+@test "failure report shows correct duration" {
+  REPORT_FILE="$FIXTURES/with-failures.json" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+
+  local summary
+  summary="$(get_summary)"
+  [[ "$summary" == *"Duration: 180s"* ]]
+}
+
+@test "failure report shows Failed Tests section" {
+  REPORT_FILE="$FIXTURES/with-failures.json" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+
+  local summary
+  summary="$(get_summary)"
+  [[ "$summary" == *"*Failed Tests:*"* ]]
+}
+
+# --- With pending ---
+
+@test "pending report shows pending count" {
+  REPORT_FILE="$FIXTURES/with-pending.json" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+
+  local summary
+  summary="$(get_summary)"
+  [[ "$summary" == *"Pending: 1"* ]]
+}
+
+@test "pending report shows skipped count" {
+  REPORT_FILE="$FIXTURES/with-pending.json" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+
+  local summary
+  summary="$(get_summary)"
+  [[ "$summary" == *"Skipped: 1"* ]]
+}
+
+@test "pending report shows all passed when no failures" {
+  REPORT_FILE="$FIXTURES/with-pending.json" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+
+  local summary
+  summary="$(get_summary)"
+  [[ "$summary" == *"All tests passed!"* ]]
+}
+
+# --- Missing report file ---
+
+@test "missing report file produces fallback message" {
+  REPORT_FILE="$MOCK_DIR/nonexistent.json" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+
+  local line
+  line="$(get_summary_line)"
+  [[ "$line" == "No detailed failure summary available" ]]
+}
+
+@test "missing report file emits warning" {
+  REPORT_FILE="$MOCK_DIR/nonexistent.json" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"JSON report not found"* ]]
+}
+
+# --- Error handling ---
+
+@test "fails when jq is not available" {
+  local fake_bin
+  fake_bin=$(mktemp -d)
+  ln -s "$(command -v bash)" "$fake_bin/bash"
+  ln -s "$(command -v ls)" "$fake_bin/ls"
+  ln -s "$(command -v cat)" "$fake_bin/cat"
+  ln -s "$(command -v echo)" "$fake_bin/echo"
+  ln -s "$(command -v grep)" "$fake_bin/grep"
+  ln -s "$(command -v sed)" "$fake_bin/sed"
+  ln -s "$(command -v dirname)" "$fake_bin/dirname"
+  ln -s "$(command -v test)" "$fake_bin/test"
+  ln -s "$(command -v [)" "$fake_bin/["
+  REPORT_FILE="$FIXTURES/all-passed.json" PATH="$fake_bin" run bash "$SCRIPT"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"jq is required"* ]]
+  rm -rf "$fake_bin"
+}
+
+# --- Container hierarchy ---
+
+@test "failure output includes container hierarchy" {
+  REPORT_FILE="$FIXTURES/with-failures.json" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+
+  local summary
+  summary="$(get_summary)"
+  [[ "$summary" == *"VCluster Sync"* ]]
+  [[ "$summary" == *"VCluster Networking"* ]]
+}

--- a/.github/workflows/test-run-ginkgo.yaml
+++ b/.github/workflows/test-run-ginkgo.yaml
@@ -1,0 +1,20 @@
+name: Test run-ginkgo
+
+on:
+  pull_request:
+    paths:
+      - '.github/actions/run-ginkgo/**'
+
+permissions: {}
+
+jobs:
+  bats:
+    name: Run bats tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
+        with:
+          tests: .github/actions/run-ginkgo/test

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-semver-validation test-linear-pr-commenter test-release-notification test-linear-release-sync test-cleanup-head-charts test-ci-test-notify test-auto-approve-bot-prs test-publish-helm-chart test-govulncheck test-go-licenses build-linear-release-sync lint install-auto-doc generate-docs check-docs help
+.PHONY: test test-semver-validation test-linear-pr-commenter test-release-notification test-linear-release-sync test-cleanup-head-charts test-ci-test-notify test-auto-approve-bot-prs test-publish-helm-chart test-govulncheck test-go-licenses test-run-ginkgo build-linear-release-sync lint install-auto-doc generate-docs check-docs help
 
 ACTIONS_DIR := .github/actions
 WORKFLOWS_DIR := .github/workflows
@@ -91,7 +91,7 @@ check-docs: generate-docs ## verify docs are up to date (fails if drift detected
 help: ## show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-30s %s\n", $$1, $$2}'
 
-test: test-semver-validation test-linear-pr-commenter test-release-notification test-linear-release-sync test-cleanup-head-charts test-auto-approve-bot-prs test-ci-test-notify test-go-licenses test-publish-helm-chart test-govulncheck ## run all action tests
+test: test-semver-validation test-linear-pr-commenter test-release-notification test-linear-release-sync test-cleanup-head-charts test-auto-approve-bot-prs test-ci-test-notify test-go-licenses test-publish-helm-chart test-govulncheck test-run-ginkgo ## run all action tests
 
 test-semver-validation: ## run semver-validation unit tests
 	cd $(ACTIONS_DIR)/semver-validation && npm ci --silent && NODE_OPTIONS=--experimental-vm-modules npx jest --ci --coverage --watchAll=false
@@ -122,6 +122,9 @@ test-govulncheck: ## run govulncheck bats tests
 
 test-go-licenses: ## run go-licenses bats tests
 	bats $(ACTIONS_DIR)/go-licenses/test/run.bats
+
+test-run-ginkgo: ## run run-ginkgo bats tests
+	bats $(ACTIONS_DIR)/run-ginkgo/test/*.bats
 
 build-linear-release-sync: ## build linear-release-sync binary (linux/amd64)
 	cd $(ACTIONS_DIR)/linear-release-sync/src && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-s -w" -o ../linear-release-sync-linux-amd64 .

--- a/README.md
+++ b/README.md
@@ -58,6 +58,56 @@ Syncs Linear issues to the "Released" state when a GitHub release is published. 
 
 See [linear-release-sync README](./.github/actions/linear-release-sync/README.md) for detailed documentation.
 
+### Run Ginkgo Tests
+
+Runs Ginkgo tests with directory or label-based filtering and generates a
+JSON failure summary. Runtime-agnostic — callers handle their own cluster and
+image setup (vind, Kind, bare Docker).
+
+**Location:** `.github/actions/run-ginkgo`
+
+**Usage:**
+
+```yaml
+- name: Run E2E tests
+  id: e2e
+  uses: loft-sh/github-actions/.github/actions/run-ginkgo@run-ginkgo/v1
+  with:
+    ginkgo-label: "my-suite && !non-default"
+    test-image: ghcr.io/loft-sh/vcluster:dev
+    # test-image-flag: "--platform-image"  # default: --vcluster-image
+    # additional-ginkgo-flags: "-v --skip-package=linters"
+    # additional-args: "--use-license-server=false"
+
+- name: Notify on failure
+  if: failure()
+  uses: loft-sh/github-actions/.github/actions/ci-test-notify@ci-test-notify/v1
+  with:
+    test-name: "E2E Tests"
+    status: failure
+    details: ${{ steps.e2e.outputs.failure-summary }}
+    webhook-url: ${{ secrets.SLACK_WEBHOOK }}
+```
+
+**Inputs:**
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `test-image` | yes | | Image passed to the test binary |
+| `test-image-flag` | no | `--vcluster-image` | CLI flag name for the image |
+| `timeout` | no | `60m` | Ginkgo test timeout |
+| `procs` | no | `8` | Parallel Ginkgo processes |
+| `test-dir` | no | | Directory-based test selection (mutually exclusive with `ginkgo-label`) |
+| `ginkgo-label` | no | | Label-based test selection (mutually exclusive with `test-dir`) |
+| `append-pr-label` | no | `true` | Append `\|\| pr` to the label filter |
+| `e2e-dir` | no | `e2e-next` | Root test directory |
+| `additional-args` | no | | Extra args for the test binary (after `--`) |
+| `additional-ginkgo-flags` | no | | Extra ginkgo CLI flags |
+
+**Outputs:**
+
+- `failure-summary`: Markdown-formatted test results summary
+
 ## Available Reusable Workflows
 
 ### Validate Renovate Config


### PR DESCRIPTION
## Summary

- Adds `run-ginkgo` composite action that centralizes the duplicated Ginkgo
  test execution logic from all three production repos
- Container-runtime agnostic — callers handle their own cluster and image
  setup (vind, Kind, etc.)
- Test-binary flags (image, teardown, etc.) are the caller's responsibility
  via `additional-args` — the action only handles Ginkgo-level concerns
- Structure follows repo conventions: YAML glue only in action.yml, business
  logic in `src/` scripts, bats tests in `test/`

### Action structure

```
.github/actions/run-ginkgo/
  action.yml              # thin glue, delegates to scripts
  src/execute-tests.sh    # builds ginkgo args, handles directory/label strategy
  src/generate-summary.sh # parses JSON report into markdown failure summary
  test/
    execute-tests.bats    # 16 tests: arg construction, label filtering, flags
    generate-summary.bats # 17 tests: all states, missing report, jq errors
    fixtures/             # sample Ginkgo JSON reports
```

### Replaces

| Repo | Current approach |
|------|------------------|
| vcluster | `.github/actions/run-ginkgo-e2e/` (local composite action) |
| loft-enterprise | `.github/actions/run-ginkgo-e2e/` (local composite action) |
| vcluster-pro | Inline Ginkgo steps in `e2e-next.yaml` + `e2e-next-nightly.yaml` |

### Key inputs

| Input | Default | Description |
|-------|---------|-------------|
| `test-dir` | `e2e-next` | Directory containing test suites |
| `ginkgo-label` | | Label filter expression; adds `--label-filter` + `-r` when set |
| `timeout` | `60m` | Ginkgo test timeout |
| `procs` | `8` | Parallel Ginkgo processes |
| `additional-args` | | Test binary args after `--` (e.g. `--vcluster-image=... --teardown=false`) |
| `additional-ginkgo-flags` | | Extra ginkgo flags (e.g. `-v`, `--skip-package=linters`) |

## Test plan

- [x] shellcheck clean on both scripts
- [x] zizmor clean (0 findings) on action + test workflow
- [x] actionlint clean (`make lint`)
- [x] 33/33 bats tests pass locally (`make test-run-ginkgo`)
- [ ] CI green on this PR
- [ ] Migration PRs in vcluster, loft-enterprise, vcluster-pro (separate PRs after tag)