### PR TITLE
feat(go-licenses): add composite action with check + report modes

### DIFF
--- a/.github/actions/go-licenses/README.md
+++ b/.github/actions/go-licenses/README.md
@@ -1,0 +1,111 @@
+# go-licenses
+
+Runs [go-licenses](https://github.com/google/go-licenses) against a Go module in one of two modes:
+
+- **`check`** — scan the module, fail the job (or warn, per `fail-on-error`) if any dependency has an incompatible license.
+- **`report`** — render a license report via a Go template and open a PR with the updated file.
+
+Both modes share the same setup (setup-go, install go-licenses, optional private-repo git auth) and differ only in the trailing steps.
+
+## Inputs
+
+| Name | Description | Required | Default |
+|------|-------------|----------|---------|
+| `mode` | `check` or `report` | yes | — |
+| `go-licenses-version` | go-licenses version to install. `v1.0.0` lacks `--ignore`; use `package-mode: go-work` with it | no | `v1.6.0` |
+| `go-version-file` | Passed to `actions/setup-go` | no | `go.mod` |
+| `ignored-packages` | Comma-separated package path prefixes to skip. In `all` mode → `--ignore` flags; in `go-work` mode → substring-matched against `go.work` DiskPaths | no | `github.com/loft-sh` |
+| `package-mode` | `all` (pass `./...` + `--ignore`) or `go-work` (enumerate workspace modules — required for go-licenses < v1.6.0) | no | `all` |
+| `fail-on-error` | [check] When `"false"`, non-zero go-licenses exit is surfaced as a warning; the step still succeeds | no | `"true"` |
+| `template-path` | [report] Path to the go-licenses .tmpl template | no | `.github/licenses.tmpl` |
+| `output-path` | [report] File path to write the rendered report to | required for `report` | `""` |
+| `pr-branch` | [report] Branch name for the generated PR | required for `report` | `""` |
+| `pr-title` | [report] PR title | required for `report` | `""` |
+| `pr-commit-message` | [report] Commit message; defaults to `pr-title` | no | `""` |
+| `gh-access-token` | GitHub PAT — fetches private loft-sh modules (both modes) and opens the PR (report mode) | required for `report`, optional for private-module `check` | `""` |
+
+## Usage
+
+### Check (single-module repo, public)
+
+```yaml
+name: go-licenses check
+
+on:
+  pull_request:
+    paths:
+      - 'go.mod'
+      - 'go.sum'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'loft-sh'
+    permissions:
+      contents: read
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: loft-sh/github-actions/.github/actions/go-licenses@go-licenses/v1
+        with:
+          mode: check
+```
+
+### Check (go.work monorepo with private modules, older go-licenses)
+
+```yaml
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'loft-sh'
+    permissions:
+      contents: read
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: loft-sh/github-actions/.github/actions/go-licenses@go-licenses/v1
+        with:
+          mode: check
+          go-licenses-version: v1.0.0
+          go-version-file: go.work
+          package-mode: go-work
+          ignored-packages: github.com/loft-sh
+          gh-access-token: ${{ secrets.GH_ACCESS_TOKEN }}
+```
+
+### Report (render file + open PR)
+
+```yaml
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'loft-sh'
+    permissions:
+      contents: write
+      pull-requests: write
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: loft-sh/github-actions/.github/actions/go-licenses@go-licenses/v1
+        with:
+          mode: report
+          template-path: .github/licenses.tmpl
+          output-path: docs/pages/licenses/vcluster.mdx
+          pr-branch: licenses/vcluster
+          pr-title: "Update vcluster licenses"
+          gh-access-token: ${{ secrets.GH_ACCESS_TOKEN }}
+```
+
+## Testing
+
+```bash
+make test-go-licenses
+```
+
+Runs the bats suite in `test/run.bats` against `run.sh` with stubbed `go-licenses` and `go work` binaries.

--- a/.github/actions/go-licenses/action.yml
+++ b/.github/actions/go-licenses/action.yml
@@ -1,0 +1,143 @@
+name: 'go-licenses'
+description: "Run `go-licenses check` or `go-licenses report` against a Go module, with private-module auth and optional PR creation for report mode."
+branding:
+  icon: "file-text"
+  color: "blue"
+
+inputs:
+  mode:
+    description: "`check` — run `go-licenses check` against the module. `report` — render a license report with a template and open a PR with the output."
+    required: true
+  go-licenses-version:
+    description: "Version of go-licenses to install (e.g. v1.6.0, v1.0.0). v1.0.0 does not support `--ignore` — set `package-mode: go-work` when using it."
+    required: false
+    # renovate: datasource=go depName=github.com/google/go-licenses
+    default: v1.6.0
+  go-version-file:
+    description: "Path to go.mod or go.work for setup-go."
+    required: false
+    default: go.mod
+  ignored-packages:
+    description: "Comma-separated package path prefixes to skip. In `all` mode these become `--ignore` flags; in `go-work` mode they are substring-matched against go.work DiskPaths."
+    required: false
+    default: github.com/loft-sh
+  package-mode:
+    description: "Package selection strategy: `all` (pass `./...` with `--ignore` flags) or `go-work` (enumerate modules via `go work edit` and filter at the package list — required for go-licenses < v1.6.0)."
+    required: false
+    default: all
+  fail-on-error:
+    description: "[check mode] When `false`, non-zero exit codes from go-licenses are surfaced as a workflow warning instead of a failure. Use only as a temporary escape hatch when upstream go-licenses is broken."
+    required: false
+    default: "true"
+  template-path:
+    description: "[report mode] Path to the go-licenses .tmpl template used to render the report."
+    required: false
+    default: .github/licenses.tmpl
+  output-path:
+    description: "[report mode, required] File path in the caller repo to write the rendered report to, e.g. `docs/pages/licenses/vcluster.mdx`."
+    required: false
+    default: ""
+  pr-branch:
+    description: "[report mode, required] Branch name to push the rendered report onto."
+    required: false
+    default: ""
+  pr-title:
+    description: "[report mode, required] PR title for the generated pull request."
+    required: false
+    default: ""
+  pr-commit-message:
+    description: "[report mode] Commit message for the generated pull request. Defaults to `pr-title`."
+    required: false
+    default: ""
+  gh-access-token:
+    description: "GitHub PAT used to fetch private loft-sh modules (both modes) and to open the generated pull request (report mode, required)."
+    required: false
+    default: ""
+
+runs:
+  using: "composite"
+  steps:
+    - name: Validate inputs
+      shell: bash
+      env:
+        MODE: ${{ inputs.mode }}
+        OUTPUT_PATH: ${{ inputs.output-path }}
+        PR_BRANCH: ${{ inputs.pr-branch }}
+        PR_TITLE: ${{ inputs.pr-title }}
+        GH_ACCESS_TOKEN: ${{ inputs.gh-access-token }}
+      run: |
+        case "${MODE}" in
+          check|report) ;;
+          *) echo "::error::mode must be 'check' or 'report' (got '${MODE}')"; exit 1 ;;
+        esac
+        if [ "${MODE}" = "report" ]; then
+          missing=()
+          [ -z "${OUTPUT_PATH}" ] && missing+=("output-path")
+          [ -z "${PR_BRANCH}" ] && missing+=("pr-branch")
+          [ -z "${PR_TITLE}" ] && missing+=("pr-title")
+          [ -z "${GH_ACCESS_TOKEN}" ] && missing+=("gh-access-token")
+          if [ "${#missing[@]}" -gt 0 ]; then
+            echo "::error::mode=report requires: ${missing[*]}"
+            exit 1
+          fi
+        fi
+
+    - name: Configure git for private repos
+      if: inputs.gh-access-token != ''
+      shell: bash
+      env:
+        GH_ACCESS_TOKEN: ${{ inputs.gh-access-token }}
+      run: git config --global "url.https://${GH_ACCESS_TOKEN}@github.com/.insteadOf" https://github.com/
+
+    - name: Set up Go
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      with:
+        go-version-file: ${{ inputs.go-version-file }}
+
+    - name: Install go-licenses
+      shell: bash
+      env:
+        GO_LICENSES_VERSION: ${{ inputs.go-licenses-version }}
+      run: go install "github.com/google/go-licenses@${GO_LICENSES_VERSION}"
+
+    - name: Run go-licenses
+      shell: bash
+      env:
+        MODE: ${{ inputs.mode }}
+        GOPRIVATE: github.com/loft-sh/*
+        PACKAGE_MODE: ${{ inputs.package-mode }}
+        IGNORED_PACKAGES: ${{ inputs.ignored-packages }}
+        FAIL_ON_ERROR: ${{ inputs.fail-on-error }}
+        TEMPLATE_PATH: ${{ inputs.template-path }}
+        OUTPUT_PATH: ${{ inputs.output-path }}
+      run: ${{ github.action_path }}/run.sh "${MODE}"
+
+    - name: Resolve PR commit message
+      if: inputs.mode == 'report'
+      id: commit
+      shell: bash
+      env:
+        COMMIT_MESSAGE: ${{ inputs.pr-commit-message }}
+        PR_TITLE: ${{ inputs.pr-title }}
+      run: |
+        if [ -z "${COMMIT_MESSAGE}" ]; then
+          COMMIT_MESSAGE="${PR_TITLE}"
+        fi
+        {
+          echo "message<<EOF"
+          echo "${COMMIT_MESSAGE}"
+          echo "EOF"
+        } >> "${GITHUB_OUTPUT}"
+
+    - name: Create pull request
+      if: inputs.mode == 'report'
+      uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+      with:
+        token: ${{ inputs.gh-access-token }}
+        committer: Loft Bot <loft-bot@users.noreply.github.com>
+        branch: ${{ inputs.pr-branch }}
+        commit-message: ${{ steps.commit.outputs.message }}
+        title: ${{ inputs.pr-title }}
+        body: Triggered by ${{ github.repository }}@${{ github.sha }}
+        signoff: true
+        delete-branch: true

--- a/.github/actions/go-licenses/run.sh
+++ b/.github/actions/go-licenses/run.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Runs `go-licenses check` or `go-licenses report` with consistent handling of
+# package selection and ignored packages across `go.mod` and `go.work`
+# projects. Called from the go-licenses-check / go-licenses-report reusable
+# workflows so the branching logic lives in a shellcheck-clean script instead
+# of inline YAML.
+#
+# Usage:
+#   run.sh check
+#   run.sh report
+#
+# Required environment variables:
+#   PACKAGE_MODE     "all" — pass ./... and --ignore flags to go-licenses.
+#                    "go-work" — enumerate workspace modules from go.work and
+#                    filter out ignored prefixes at the package list level.
+#                    Use this for go-licenses versions < v1.6.0 (no --ignore
+#                    flag) and for monorepos whose root does not compile.
+#   IGNORED_PACKAGES Comma-separated list of package path prefixes to skip.
+#                    In "all" mode they become --ignore flags (matching the
+#                    import path prefix). In "go-work" mode they are matched
+#                    as substrings against go.work DiskPaths.
+#
+# Check-mode variables:
+#   FAIL_ON_ERROR    "true" (default) or "false". When "false", non-zero exit
+#                    codes from go-licenses are logged as a workflow warning
+#                    and the step still succeeds — used only as a temporary
+#                    escape hatch when upstream go-licenses is broken.
+#
+# Report-mode variables:
+#   TEMPLATE_PATH    Path to the go-licenses .tmpl template (required).
+#   OUTPUT_PATH      File to write the rendered report to (required). Any
+#                    missing parent directories are created.
+
+SUBCOMMAND="${1:?subcommand is required: check or report}"
+PACKAGE_MODE="${PACKAGE_MODE:-all}"
+IGNORED_PACKAGES="${IGNORED_PACKAGES:-}"
+
+# Parse IGNORED_PACKAGES into an array of trimmed, non-empty prefixes.
+IGNORE=()
+if [ -n "${IGNORED_PACKAGES}" ]; then
+  IFS=',' read -ra raw_ignore <<< "${IGNORED_PACKAGES}"
+  for prefix in "${raw_ignore[@]}"; do
+    trimmed="${prefix// /}"
+    if [ -n "${trimmed}" ]; then
+      IGNORE+=("${trimmed}")
+    fi
+  done
+fi
+
+# Build the go-licenses argument vector based on PACKAGE_MODE.
+ARGS=()
+case "${PACKAGE_MODE}" in
+  all)
+    ARGS+=("./...")
+    for prefix in ${IGNORE[@]+"${IGNORE[@]}"}; do
+      ARGS+=("--ignore" "${prefix}")
+    done
+    ;;
+  go-work)
+    mapfile -t PKGS < <(go work edit -json | jq -r '.Use[].DiskPath + "/..."')
+    for prefix in ${IGNORE[@]+"${IGNORE[@]}"}; do
+      FILTERED=()
+      for pkg in ${PKGS[@]+"${PKGS[@]}"}; do
+        case "${pkg}" in
+          *"${prefix}"*) ;;
+          *) FILTERED+=("${pkg}") ;;
+        esac
+      done
+      PKGS=(${FILTERED[@]+"${FILTERED[@]}"})
+    done
+    if [ "${#PKGS[@]}" -eq 0 ]; then
+      echo "::error::no packages to check after filtering IGNORED_PACKAGES" >&2
+      exit 1
+    fi
+    ARGS+=(${PKGS[@]+"${PKGS[@]}"})
+    ;;
+  *)
+    echo "::error::invalid PACKAGE_MODE '${PACKAGE_MODE}' (expected: all, go-work)" >&2
+    exit 1
+    ;;
+esac
+
+case "${SUBCOMMAND}" in
+  check)
+    FAIL_ON_ERROR="${FAIL_ON_ERROR:-true}"
+    if [ "${FAIL_ON_ERROR}" = "true" ]; then
+      go-licenses check "${ARGS[@]}"
+    else
+      if ! go-licenses check "${ARGS[@]}"; then
+        echo "::warning::go-licenses check reported errors (ignored because fail-on-error=false)"
+      fi
+    fi
+    ;;
+  report)
+    : "${TEMPLATE_PATH:?TEMPLATE_PATH env var is required for report}"
+    : "${OUTPUT_PATH:?OUTPUT_PATH env var is required for report}"
+    mkdir -p "$(dirname "${OUTPUT_PATH}")"
+    go-licenses report --template "${TEMPLATE_PATH}" "${ARGS[@]}" > "${OUTPUT_PATH}"
+    ;;
+  *)
+    echo "::error::invalid subcommand '${SUBCOMMAND}' (expected: check, report)" >&2
+    exit 1
+    ;;
+esac

--- a/.github/actions/go-licenses/test/run.bats
+++ b/.github/actions/go-licenses/test/run.bats
@@ -1,0 +1,219 @@
+#!/usr/bin/env bats
+# Tests for run.sh
+#
+# Stubs `go-licenses` and `go` so we can assert on the argument vector the
+# script builds without needing a real Go toolchain or real Go sources.
+
+SCRIPT="$BATS_TEST_DIRNAME/../run.sh"
+
+setup() {
+  MOCK_DIR=$(mktemp -d)
+  export MOCK_DIR
+  export GO_LICENSES_ARGS_FILE="$MOCK_DIR/go_licenses_args"
+  export GO_LICENSES_EXIT_CODE_FILE="$MOCK_DIR/go_licenses_exit_code"
+  export GO_LICENSES_STDOUT_FILE="$MOCK_DIR/go_licenses_stdout"
+  export GO_WORK_JSON_FILE="$MOCK_DIR/go_work_json"
+
+  echo "0" > "$GO_LICENSES_EXIT_CODE_FILE"
+  : > "$GO_LICENSES_STDOUT_FILE"
+
+  # Stub go-licenses: record its arguments, optionally emit stdout, exit with
+  # the configured exit code.
+  cat > "$MOCK_DIR/go-licenses" <<'MOCK'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "$GO_LICENSES_ARGS_FILE"
+if [ -s "$GO_LICENSES_STDOUT_FILE" ]; then
+  cat "$GO_LICENSES_STDOUT_FILE"
+fi
+exit "$(cat "$GO_LICENSES_EXIT_CODE_FILE")"
+MOCK
+  chmod +x "$MOCK_DIR/go-licenses"
+
+  # Stub `go` so `go work edit -json` returns a fixture. Any other `go`
+  # invocation fails loudly — the script should not call `go` outside the
+  # go-work mode path.
+  cat > "$MOCK_DIR/go" <<'MOCK'
+#!/usr/bin/env bash
+if [ "$1" = "work" ] && [ "$2" = "edit" ] && [ "$3" = "-json" ]; then
+  cat "$GO_WORK_JSON_FILE"
+  exit 0
+fi
+echo "unexpected go invocation: $*" >&2
+exit 99
+MOCK
+  chmod +x "$MOCK_DIR/go"
+
+  export PATH="$MOCK_DIR:$PATH"
+}
+
+teardown() {
+  rm -rf "$MOCK_DIR"
+}
+
+# --- Subcommand / PACKAGE_MODE validation ---
+
+@test "fails when subcommand is missing" {
+  run bash "$SCRIPT"
+  [ "$status" -ne 0 ]
+}
+
+@test "fails on invalid subcommand" {
+  run bash "$SCRIPT" invalid
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"invalid subcommand"* ]]
+}
+
+@test "fails on invalid PACKAGE_MODE" {
+  PACKAGE_MODE=bogus run bash "$SCRIPT" check
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"invalid PACKAGE_MODE"* ]]
+}
+
+# --- Mode: all (./... + --ignore) ---
+
+@test "all mode with no ignores passes ./..." {
+  run bash "$SCRIPT" check
+  [ "$status" -eq 0 ]
+  [ "$(cat "$GO_LICENSES_ARGS_FILE")" = "check
+./..." ]
+}
+
+@test "all mode appends --ignore for each comma-separated prefix" {
+  IGNORED_PACKAGES="github.com/loft-sh,modernc.org/mathutil" \
+    run bash "$SCRIPT" check
+  [ "$status" -eq 0 ]
+  [ "$(cat "$GO_LICENSES_ARGS_FILE")" = "check
+./...
+--ignore
+github.com/loft-sh
+--ignore
+modernc.org/mathutil" ]
+}
+
+@test "all mode trims whitespace and drops empty entries" {
+  IGNORED_PACKAGES=" github.com/loft-sh , , modernc.org/mathutil " \
+    run bash "$SCRIPT" check
+  [ "$status" -eq 0 ]
+  [ "$(cat "$GO_LICENSES_ARGS_FILE")" = "check
+./...
+--ignore
+github.com/loft-sh
+--ignore
+modernc.org/mathutil" ]
+}
+
+# --- Mode: go-work (enumerate + filter) ---
+
+@test "go-work mode enumerates DiskPaths from go.work" {
+  cat > "$GO_WORK_JSON_FILE" <<'JSON'
+{"Use":[{"DiskPath":"."},{"DiskPath":"staging/src/github.com/loft-sh/api"}]}
+JSON
+  PACKAGE_MODE=go-work run bash "$SCRIPT" check
+  [ "$status" -eq 0 ]
+  [ "$(cat "$GO_LICENSES_ARGS_FILE")" = "check
+./...
+staging/src/github.com/loft-sh/api/..." ]
+}
+
+@test "go-work mode filters out DiskPaths matching ignored prefixes" {
+  cat > "$GO_WORK_JSON_FILE" <<'JSON'
+{"Use":[{"DiskPath":"."},{"DiskPath":"staging/src/github.com/loft-sh/api"},{"DiskPath":"staging/src/github.com/loft-sh/agentapi"}]}
+JSON
+  PACKAGE_MODE=go-work \
+    IGNORED_PACKAGES="github.com/loft-sh" \
+    run bash "$SCRIPT" check
+  [ "$status" -eq 0 ]
+  [ "$(cat "$GO_LICENSES_ARGS_FILE")" = "check
+./..." ]
+}
+
+@test "go-work mode fails when all packages are filtered out" {
+  cat > "$GO_WORK_JSON_FILE" <<'JSON'
+{"Use":[{"DiskPath":"staging/src/github.com/loft-sh/api"}]}
+JSON
+  PACKAGE_MODE=go-work \
+    IGNORED_PACKAGES="github.com/loft-sh" \
+    run bash "$SCRIPT" check
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"no packages to check"* ]]
+}
+
+# --- Check subcommand: fail-on-error ---
+
+@test "check fails when go-licenses exits non-zero and fail-on-error=true" {
+  echo "1" > "$GO_LICENSES_EXIT_CODE_FILE"
+  run bash "$SCRIPT" check
+  [ "$status" -ne 0 ]
+}
+
+@test "check succeeds with warning when fail-on-error=false" {
+  echo "1" > "$GO_LICENSES_EXIT_CODE_FILE"
+  FAIL_ON_ERROR=false run bash "$SCRIPT" check
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"::warning::"* ]]
+  [[ "$output" == *"fail-on-error=false"* ]]
+}
+
+@test "check succeeds silently when go-licenses exits zero" {
+  run bash "$SCRIPT" check
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"::warning::"* ]]
+}
+
+# --- Report subcommand ---
+
+@test "report requires TEMPLATE_PATH" {
+  OUTPUT_PATH="$MOCK_DIR/out.mdx" run bash "$SCRIPT" report
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"TEMPLATE_PATH"* ]]
+}
+
+@test "report requires OUTPUT_PATH" {
+  TEMPLATE_PATH="$MOCK_DIR/tpl.tmpl" run bash "$SCRIPT" report
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"OUTPUT_PATH"* ]]
+}
+
+@test "report writes go-licenses stdout to OUTPUT_PATH" {
+  echo "rendered licenses" > "$GO_LICENSES_STDOUT_FILE"
+  touch "$MOCK_DIR/tpl.tmpl"
+  TEMPLATE_PATH="$MOCK_DIR/tpl.tmpl" \
+    OUTPUT_PATH="$MOCK_DIR/nested/dir/out.mdx" \
+    run bash "$SCRIPT" report
+  [ "$status" -eq 0 ]
+  [ "$(cat "$MOCK_DIR/nested/dir/out.mdx")" = "rendered licenses" ]
+}
+
+@test "report passes report subcommand and template path to go-licenses" {
+  touch "$MOCK_DIR/tpl.tmpl"
+  TEMPLATE_PATH="$MOCK_DIR/tpl.tmpl" \
+    OUTPUT_PATH="$MOCK_DIR/out.mdx" \
+    IGNORED_PACKAGES="github.com/loft-sh" \
+    run bash "$SCRIPT" report
+  [ "$status" -eq 0 ]
+  [ "$(cat "$GO_LICENSES_ARGS_FILE")" = "report
+--template
+$MOCK_DIR/tpl.tmpl
+./...
+--ignore
+github.com/loft-sh" ]
+}
+
+@test "report works in go-work mode" {
+  cat > "$GO_WORK_JSON_FILE" <<'JSON'
+{"Use":[{"DiskPath":"."},{"DiskPath":"staging/src/github.com/loft-sh/api"}]}
+JSON
+  echo "rendered" > "$GO_LICENSES_STDOUT_FILE"
+  touch "$MOCK_DIR/tpl.tmpl"
+  PACKAGE_MODE=go-work \
+    IGNORED_PACKAGES="github.com/loft-sh" \
+    TEMPLATE_PATH="$MOCK_DIR/tpl.tmpl" \
+    OUTPUT_PATH="$MOCK_DIR/out.mdx" \
+    run bash "$SCRIPT" report
+  [ "$status" -eq 0 ]
+  [ "$(cat "$MOCK_DIR/out.mdx")" = "rendered" ]
+  [ "$(cat "$GO_LICENSES_ARGS_FILE")" = "report
+--template
+$MOCK_DIR/tpl.tmpl
+./..." ]
+}

--- a/.github/workflows/test-go-licenses.yaml
+++ b/.github/workflows/test-go-licenses.yaml
@@ -1,0 +1,21 @@
+name: Test go-licenses
+
+on:
+  pull_request:
+    paths:
+      - '.github/actions/go-licenses/**'
+      - '.github/workflows/test-go-licenses.yaml'
+
+permissions: {}
+
+jobs:
+  bats:
+    name: Run bats tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
+        with:
+          tests: .github/actions/go-licenses/test

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-semver-validation test-linear-pr-commenter test-release-notification test-linear-release-sync test-cleanup-head-charts test-ci-test-notify test-auto-approve-bot-prs test-publish-helm-chart test-govulncheck build-linear-release-sync lint help
+.PHONY: test test-semver-validation test-linear-pr-commenter test-release-notification test-linear-release-sync test-cleanup-head-charts test-ci-test-notify test-auto-approve-bot-prs test-publish-helm-chart test-govulncheck test-go-licenses build-linear-release-sync lint help
 
 ACTIONS_DIR := .github/actions
 SCRIPTS_DIR := .github/scripts
@@ -6,7 +6,7 @@ SCRIPTS_DIR := .github/scripts
 help: ## show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-30s %s\n", $$1, $$2}'
 
-test: test-semver-validation test-linear-pr-commenter test-release-notification test-linear-release-sync test-cleanup-head-charts test-auto-approve-bot-prs test-ci-test-notify test-publish-helm-chart test-govulncheck ## run all action tests
+test: test-semver-validation test-linear-pr-commenter test-release-notification test-linear-release-sync test-cleanup-head-charts test-auto-approve-bot-prs test-ci-test-notify test-go-licenses test-publish-helm-chart test-govulncheck ## run all action tests
 
 test-semver-validation: ## run semver-validation unit tests
 	cd $(ACTIONS_DIR)/semver-validation && npm ci --silent && NODE_OPTIONS=--experimental-vm-modules npx jest --ci --coverage --watchAll=false
@@ -34,6 +34,9 @@ test-publish-helm-chart: ## run publish-helm-chart bats tests (requires mikefara
 
 test-govulncheck: ## run govulncheck bats tests
 	bats $(ACTIONS_DIR)/govulncheck/test/run.bats
+
+test-go-licenses: ## run go-licenses bats tests
+	bats $(ACTIONS_DIR)/go-licenses/test/run.bats
 
 build-linear-release-sync: ## build linear-release-sync binary (linux/amd64)
 	cd $(ACTIONS_DIR)/linear-release-sync/src && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-s -w" -o ../linear-release-sync-linux-amd64 .


### PR DESCRIPTION
## Why

Reusable workflows can't resolve their own ref at call time — both `github.workflow_ref` and `github.workflow_sha` leak the **caller's** context under `workflow_call`, so any sparse-checkout of `loft-sh/github-actions` for scripts fails on PR-triggered callers with:

```
fatal: couldn't find remote ref refs/pull/N/merge
```

This was just observed in the sibling govulncheck work ([loft-enterprise#6676](https://github.com/loft-sh/loft-enterprise/pull/6676)) and fixed by converting to a composite action in [#109](https://github.com/loft-sh/github-actions/pull/109). `github.job_workflow_sha` is documented but only exposed as an OIDC claim ([actions/runner#2417](https://github.com/actions/runner/issues/2417)).

Ship go-licenses as a composite action from the start to avoid the same bug class — the pattern already used by `ci-test-notify`, `release-notification`, `linear-release-sync`, `semver-validation`, and `govulncheck`.

## What

**One composite action** at `.github/actions/go-licenses/` with a `mode: check|report` input, rather than two separate actions. Both modes share ~90% of the setup (setup-go, install go-licenses, private-repo git auth); only the trailing steps differ (`go-licenses check` vs `go-licenses report` + peter-evans/create-pull-request). The existing `run.sh` with `check`/`report` subcommands ports unchanged.

## Caller contract

Each caller provides their own `actions/checkout`, `runs-on`, `timeout-minutes`, and fork guard at the job level.

Check mode:

```yaml
jobs:
  check:
    runs-on: ubuntu-latest
    if: github.repository_owner == 'loft-sh'
    permissions:
      contents: read
    timeout-minutes: 15
    steps:
      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
        with:
          persist-credentials: false
      - uses: loft-sh/github-actions/.github/actions/go-licenses@go-licenses/v1
        with:
          mode: check
          gh-access-token: ${{ secrets.GH_ACCESS_TOKEN }}
```

Report mode:

```yaml
jobs:
  report:
    runs-on: ubuntu-latest
    if: github.repository_owner == 'loft-sh'
    permissions:
      contents: write
      pull-requests: write
    timeout-minutes: 15
    steps:
      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
        with:
          persist-credentials: false
      - uses: loft-sh/github-actions/.github/actions/go-licenses@go-licenses/v1
        with:
          mode: report
          template-path: .github/licenses.tmpl
          output-path: docs/pages/licenses/vcluster.mdx
          pr-branch: licenses/vcluster
          pr-title: "Update vcluster licenses"
          gh-access-token: ${{ secrets.GH_ACCESS_TOKEN }}
```

## Files

- `.github/actions/go-licenses/action.yml` — composite action
- `.github/actions/go-licenses/run.sh` — unchanged, moved from `.github/scripts/`
- `.github/actions/go-licenses/test/run.bats` — unchanged, 17 tests
- `.github/actions/go-licenses/README.md` — inputs + usage
- `.github/workflows/test-go-licenses.yaml` — path filter retargeted
- `Makefile` — `test-go-licenses` now points at `ACTIONS_DIR`

## Test plan

- [x] `make test-go-licenses` — 17/17 bats tests pass
- [x] `make lint` — actionlint + zizmor clean
- [x] `shellcheck .github/actions/go-licenses/run.sh` — clean
- [x] Script executable (`mode 100755`)
- [x] CI green on this PR
- [ ] After merge: push `go-licenses/v1` tag; migrate callers (vcluster, vcluster-pro, loft-enterprise)

Refs DEVOPS-772