### PR TITLE
chore(auto-approve): make review body self-explanatory

### DIFF
--- a/.github/actions/auto-approve-bot-prs/action.yml
+++ b/.github/actions/auto-approve-bot-prs/action.yml
@@ -69,7 +69,10 @@ runs:
       uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363 # v4.0.0
       with:
         github-token: ${{ inputs.github-token }}
-        review-message: 'Auto-approved: trusted bot, CI green, no merge conflicts.'
+        review-message: |
+          Approved by the shared auto-approve workflow because this PR matched the approval criteria.
+
+          For more information, see https://github.com/loft-sh/github-actions?tab=readme-ov-file#auto-approve-bot-prs.
 
     - name: Enable auto-merge
       if: steps.ci.outputs.ci_green == 'true' && inputs.auto-merge == 'true'


### PR DESCRIPTION
## Summary

Replace the review body that `auto-approve-bot-prs` leaves on approved PRs with something actually useful to someone auditing an approval.

**Before:**
> Auto-approved: trusted bot, CI green, no merge conflicts.

**After:**
> Approved by the shared auto-approve workflow because this PR matched the approval criteria.
>
> For more information, see https://github.com/loft-sh/github-actions?tab=readme-ov-file#auto-approve-bot-prs.

## Why

The old message just restated the approval status (already shown by GitHub's UI) and gave no pointer to the source of the rules. Because this action runs against PRs in every repo that wires up the reusable workflow (`vcluster-docs`, `vcluster`, `vcluster-pro`, `loft-enterprise`, `hosted-platform`, `loft-prod`, ...), the body needs to stand on its own and point somewhere that anyone can audit without repo-specific knowledge. Linking directly to the README section gives exactly that.

The value is a YAML block scalar with a paragraph break so GitHub's markdown renders the URL on its own line rather than collapsing the whole message into a single run-on sentence.

## References

DEVOPS-714 (review-body cleanup surfaced during the auto-approve rollout)

## Test plan

- [ ] Verified YAML parses to the expected two-paragraph string (manual `yaml.safe_load`).
- [ ] No other changes to the composite action, so existing bats suites and PR smoke-tests are unaffected.
- [ ] After merge, pick any trusted-author PR and confirm the new body renders with a proper paragraph break and a clickable link to the README anchor.