### PR TITLE
feat(govulncheck): add reusable workflow for Go vulnerability scanning

### DIFF
--- a/.github/scripts/govulncheck/run.sh
+++ b/.github/scripts/govulncheck/run.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# Runs govulncheck against the caller's module and emits two GitHub Actions
+# step outputs:
+#
+#   has_vulnerabilities  govulncheck's exit code (0 = clean, non-zero = found)
+#   report               Slack-ready report text (only set on non-zero), built
+#                        from the tail of govulncheck's output and truncated
+#                        to fit Slack's 3000-char block limit.
+#
+# We capture the exit code ourselves rather than letting `set -e` abort
+# because govulncheck returning non-zero is the *expected* outcome on a
+# vulnerable module; the workflow then routes it to Slack.
+#
+# Required environment:
+#   GITHUB_OUTPUT         Standard GitHub Actions step output file path.
+#
+# Optional environment:
+#   SCAN_PATHS            Space-separated Go package patterns. Default: ./...
+#   TEST_FLAG             "true" to pass -test to govulncheck (include test
+#                         files in the scan). Default: "true".
+#   GOVULNCHECK_BIN       Override the govulncheck binary (for testing).
+#                         Default: govulncheck.
+#   REPORT_LIMIT          Max chars of report text. Default: 2800. Slack
+#                         block text is capped at 3000; we reserve room for
+#                         the "truncated" footer.
+
+SCAN_PATHS="${SCAN_PATHS:-./...}"
+TEST_FLAG="${TEST_FLAG:-true}"
+GOVULNCHECK_BIN="${GOVULNCHECK_BIN:-govulncheck}"
+REPORT_LIMIT="${REPORT_LIMIT:-2800}"
+
+: "${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
+
+ARGS=()
+if [ "${TEST_FLAG}" = "true" ]; then
+  ARGS+=(-test)
+fi
+
+# shellcheck disable=SC2206  # intentional word-splitting of SCAN_PATHS
+PATHS_ARR=(${SCAN_PATHS})
+
+echo "Running: ${GOVULNCHECK_BIN} ${ARGS[*]} ${PATHS_ARR[*]}"
+
+# Capture stdout+stderr so Slack gets the full picture. `+e` around the
+# invocation only; we need the exit code to decide what to output.
+set +e
+OUTPUT=$("${GOVULNCHECK_BIN}" "${ARGS[@]}" "${PATHS_ARR[@]}" 2>&1)
+EXIT_CODE=$?
+set -e
+
+echo "${OUTPUT}"
+echo "has_vulnerabilities=${EXIT_CODE}" >> "${GITHUB_OUTPUT}"
+
+if [ "${EXIT_CODE}" -eq 0 ]; then
+  echo "No vulnerabilities found"
+  exit 0
+fi
+
+# Build the report body. When the output exceeds REPORT_LIMIT we keep the
+# *tail* rather than the head: govulncheck lists the vulnerability summary
+# at the end, so truncating the head is less informative than truncating
+# the start of the trace.
+if [ "${#OUTPUT}" -gt "${REPORT_LIMIT}" ]; then
+  # tail -c takes bytes, which matches ${#OUTPUT}'s char count for ASCII
+  # govulncheck output.
+  TRUNCATED=$(printf '%s' "${OUTPUT}" | tail -c "${REPORT_LIMIT}")
+  REPORT="_...output truncated, see full report in workflow logs_"$'\n\n'"${TRUNCATED}"
+else
+  REPORT="${OUTPUT}"
+fi
+
+{
+  echo 'report<<GOVULNCHECK_REPORT_EOF'
+  echo "${REPORT}"
+  echo 'GOVULNCHECK_REPORT_EOF'
+} >> "${GITHUB_OUTPUT}"
+
+# Exit non-zero so the caller's job is marked failed when vulnerabilities
+# are found. The Slack step runs via `if: always()` branch logic in the
+# workflow, not here.
+exit "${EXIT_CODE}"

--- a/.github/scripts/govulncheck/test/run.bats
+++ b/.github/scripts/govulncheck/test/run.bats
@@ -1,0 +1,173 @@
+#!/usr/bin/env bats
+# Tests for govulncheck/run.sh
+#
+# Stubs `govulncheck` so we can assert on the argument vector and simulate
+# different output/exit-code combinations without downloading the real tool.
+
+SCRIPT="$BATS_TEST_DIRNAME/../run.sh"
+
+setup() {
+  TEST_DIR=$(mktemp -d)
+  export TEST_DIR
+
+  MOCK_DIR="$TEST_DIR/mock"
+  mkdir -p "$MOCK_DIR"
+
+  export GITHUB_OUTPUT="$TEST_DIR/github_output"
+  : > "$GITHUB_OUTPUT"
+
+  export GOVULNCHECK_CALLS="$TEST_DIR/govulncheck_calls"
+  export GOVULNCHECK_OUTPUT="$TEST_DIR/govulncheck_output"
+  export GOVULNCHECK_EXIT="$TEST_DIR/govulncheck_exit"
+
+  : > "$GOVULNCHECK_CALLS"
+  : > "$GOVULNCHECK_OUTPUT"
+  echo "0" > "$GOVULNCHECK_EXIT"
+
+  # Stub govulncheck:
+  #   - record every invocation's args as a tab-separated line in
+  #     GOVULNCHECK_CALLS
+  #   - echo GOVULNCHECK_OUTPUT (file contents) to stdout
+  #   - exit with GOVULNCHECK_EXIT
+  cat > "$MOCK_DIR/govulncheck" <<'MOCK'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$GOVULNCHECK_CALLS"
+cat "$GOVULNCHECK_OUTPUT"
+exit "$(cat "$GOVULNCHECK_EXIT")"
+MOCK
+  chmod +x "$MOCK_DIR/govulncheck"
+
+  export PATH="$MOCK_DIR:$PATH"
+}
+
+teardown() {
+  rm -rf "$TEST_DIR"
+}
+
+# Helper: read the `has_vulnerabilities` value back from GITHUB_OUTPUT.
+get_has_vuln() {
+  grep -E '^has_vulnerabilities=' "$GITHUB_OUTPUT" | tail -n1 | cut -d= -f2
+}
+
+# Helper: read the `report` multiline value back from GITHUB_OUTPUT. Uses
+# awk so we don't assume a particular heredoc delimiter escape.
+get_report() {
+  awk '
+    /^report<<GOVULNCHECK_REPORT_EOF$/ { in_report = 1; next }
+    /^GOVULNCHECK_REPORT_EOF$/ { in_report = 0; next }
+    in_report { print }
+  ' "$GITHUB_OUTPUT"
+}
+
+# --- Required env validation ------------------------------------------------
+
+@test "fails when GITHUB_OUTPUT is unset" {
+  unset GITHUB_OUTPUT
+  run bash "$SCRIPT"
+  [ "$status" -ne 0 ]
+}
+
+# --- Arg construction -------------------------------------------------------
+
+@test "defaults to -test ./... when nothing is set" {
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  grep -F -- "-test ./..." "$GOVULNCHECK_CALLS"
+}
+
+@test "omits -test when TEST_FLAG=false" {
+  TEST_FLAG=false run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  ! grep -F -- "-test" "$GOVULNCHECK_CALLS"
+}
+
+@test "passes SCAN_PATHS verbatim (multiple paths)" {
+  SCAN_PATHS="./cmd/... ./pkg/..." run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  grep -F -- "-test ./cmd/... ./pkg/..." "$GOVULNCHECK_CALLS"
+}
+
+# --- Exit code + has_vulnerabilities output ---------------------------------
+
+@test "writes has_vulnerabilities=0 on clean scan" {
+  echo "No vulnerabilities found" > "$GOVULNCHECK_OUTPUT"
+  echo "0" > "$GOVULNCHECK_EXIT"
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(get_has_vuln)" = "0" ]
+}
+
+@test "writes has_vulnerabilities=3 and exits 3 when govulncheck exits 3" {
+  echo "Vulnerability #1: GO-2024-1234" > "$GOVULNCHECK_OUTPUT"
+  echo "3" > "$GOVULNCHECK_EXIT"
+  run bash "$SCRIPT"
+  [ "$status" -eq 3 ]
+  [ "$(get_has_vuln)" = "3" ]
+}
+
+# --- Report output ----------------------------------------------------------
+
+@test "does NOT write report when scan is clean" {
+  echo "No vulnerabilities found" > "$GOVULNCHECK_OUTPUT"
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  ! grep -q '^report<<' "$GITHUB_OUTPUT"
+}
+
+@test "writes full report when output fits under limit" {
+  printf 'Vulnerability #1: GO-2024-1234\ntrace...\n' > "$GOVULNCHECK_OUTPUT"
+  echo "3" > "$GOVULNCHECK_EXIT"
+  run bash "$SCRIPT"
+  [ "$status" -eq 3 ]
+  report=$(get_report)
+  [[ "$report" == *"GO-2024-1234"* ]]
+  [[ "$report" != *"truncated"* ]]
+}
+
+@test "truncates report to REPORT_LIMIT, keeping the tail and prepending marker" {
+  # Build ~3100 chars: 3000 chars of 'A' + unique marker at the end so we
+  # can assert the tail is kept.
+  head_block=$(printf 'A%.0s' $(seq 1 3000))
+  tail_block="Vulnerability #1: GO-2024-DEADBEEF"
+  printf '%s\n%s\n' "$head_block" "$tail_block" > "$GOVULNCHECK_OUTPUT"
+  echo "3" > "$GOVULNCHECK_EXIT"
+
+  REPORT_LIMIT=2800 run bash "$SCRIPT"
+  [ "$status" -eq 3 ]
+  report=$(get_report)
+  [[ "$report" == *"truncated"* ]]
+  [[ "$report" == *"GO-2024-DEADBEEF"* ]]
+}
+
+@test "custom REPORT_LIMIT is honored" {
+  # Output is 100 chars. With REPORT_LIMIT=50 it should be truncated.
+  body=$(printf 'B%.0s' $(seq 1 100))
+  echo "${body}" > "$GOVULNCHECK_OUTPUT"
+  echo "3" > "$GOVULNCHECK_EXIT"
+  REPORT_LIMIT=50 run bash "$SCRIPT"
+  [ "$status" -eq 3 ]
+  report=$(get_report)
+  [[ "$report" == *"truncated"* ]]
+}
+
+# --- GOVULNCHECK_BIN override -----------------------------------------------
+
+@test "respects GOVULNCHECK_BIN override" {
+  # Create a second stub binary with a different name
+  cat > "$TEST_DIR/mock/my-vuln" <<'MOCK'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$GOVULNCHECK_CALLS"
+exit 0
+MOCK
+  chmod +x "$TEST_DIR/mock/my-vuln"
+
+  GOVULNCHECK_BIN=my-vuln run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  # govulncheck stub should NOT have been called
+  [ ! -s "$GOVULNCHECK_CALLS" ] || {
+    # Only my-vuln's invocation should be there, not the default binary.
+    # Our stubs both write to the same log, so we assert on presence of -test
+    # which the script always passes.
+    grep -F -- "-test" "$GOVULNCHECK_CALLS"
+  }
+}

--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -1,0 +1,139 @@
+name: govulncheck (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      scan-paths:
+        description: "Space-separated Go package patterns to scan. Example: `./... ./cmd/...`."
+        type: string
+        required: false
+        default: "./..."
+      test-flag:
+        description: "Pass `-test` to govulncheck (include test files in the scan)."
+        type: boolean
+        required: false
+        default: true
+      go-version-file:
+        description: "Path to go.mod (or go.work) passed to actions/setup-go."
+        type: string
+        required: false
+        default: go.mod
+      runs-on:
+        description: "Runner label. Use `ubuntu-latest` for most repos; larger self-hosted labels (e.g. `large-8_32`) for big modules."
+        type: string
+        required: false
+        default: ubuntu-latest
+      private-repo:
+        description: "When true, configures `git` url rewriting with `gh-access-token` and sets `GOPRIVATE=github.com/loft-sh/*` so the scan can resolve private modules."
+        type: boolean
+        required: false
+        default: false
+      goprivate:
+        description: "Value of the GOPRIVATE env var when `private-repo` is true."
+        type: string
+        required: false
+        default: "github.com/loft-sh/*"
+      govulncheck-version:
+        description: "Version of golang.org/x/vuln/cmd/govulncheck to install."
+        type: string
+        required: false
+        # renovate: datasource=go depName=golang.org/x/vuln
+        default: latest
+      timeout-minutes:
+        description: "Timeout for the scan step."
+        type: number
+        required: false
+        default: 10
+      test-name:
+        description: "Slack notification header (passed to ci-test-notify)."
+        type: string
+        required: false
+        default: govulncheck
+      notify:
+        description: "Send a Slack notification on vulnerabilities. Only fires on `schedule` events — PR/manual runs never notify."
+        type: boolean
+        required: false
+        default: true
+    secrets:
+      gh-access-token:
+        description: "PAT with access to private loft-sh repos. Required when `private-repo: true`."
+        required: false
+      slack-webhook-url:
+        description: "Slack incoming webhook URL for the ci-test-notify action. Required when `notify: true` and the workflow runs on `schedule`."
+        required: false
+
+jobs:
+  scan:
+    runs-on: ${{ inputs.runs-on }}
+    if: github.repository_owner == 'loft-sh' # do not run on forks
+    permissions:
+      contents: read
+    steps:
+      - name: Resolve reusable workflow ref
+        id: wref
+        env:
+          WORKFLOW_REF: ${{ github.workflow_ref }}
+        run: |
+          # Caller context leaks into github.workflow_sha under workflow_call,
+          # so we parse owner/repo/path@ref to get the reusable workflow's ref.
+          echo "ref=${WORKFLOW_REF##*@}" >> "${GITHUB_OUTPUT}"
+
+      - name: Check out caller repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Check out reusable workflow scripts
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: loft-sh/github-actions
+          ref: ${{ steps.wref.outputs.ref }}
+          persist-credentials: false
+          sparse-checkout: .github/scripts/govulncheck
+          path: .github-actions-scripts
+
+      - name: Configure git for private modules
+        if: inputs.private-repo
+        env:
+          GH_ACCESS_TOKEN: ${{ secrets.gh-access-token }} # zizmor: ignore[secrets-outside-env] -- passed via workflow_call, not a repo secret
+        run: |
+          if [ -z "${GH_ACCESS_TOKEN}" ]; then
+            echo "::error::private-repo=true requires gh-access-token secret"
+            exit 1
+          fi
+          git config --global url."https://${GH_ACCESS_TOKEN}@github.com/".insteadOf "https://github.com/"
+
+      - name: Set up Go
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
+        with:
+          go-version-file: ${{ inputs.go-version-file }}
+
+      - name: Install govulncheck
+        env:
+          GOVULNCHECK_VERSION: ${{ inputs.govulncheck-version }}
+        run: go install "golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION}"
+
+      - name: Scan source code for known vulnerabilities
+        id: govulncheck
+        timeout-minutes: ${{ fromJSON(inputs.timeout-minutes) }}
+        env:
+          SCAN_PATHS: ${{ inputs.scan-paths }}
+          TEST_FLAG: ${{ inputs.test-flag }}
+          GOPRIVATE: ${{ inputs.private-repo && inputs.goprivate || '' }}
+        run: .github-actions-scripts/.github/scripts/govulncheck/run.sh
+
+      - name: Send Slack notification on vulnerabilities found
+        if: >-
+          always() &&
+          steps.govulncheck.conclusion == 'failure' &&
+          inputs.notify &&
+          github.event_name == 'schedule'
+        uses: loft-sh/github-actions/.github/actions/ci-test-notify@85d7023c5749421d369f59430c7849f2d00ad694 # ci-test-notify/v1
+        with:
+          test-name: ${{ inputs.test-name }}
+          status: failure
+          details: |
+            ```
+            ${{ steps.govulncheck.outputs.report }}
+            ```
+          webhook-url: ${{ secrets.slack-webhook-url }} # zizmor: ignore[secrets-outside-env] -- passed via workflow_call, not a repo secret

--- a/.github/workflows/test-govulncheck.yaml
+++ b/.github/workflows/test-govulncheck.yaml
@@ -1,0 +1,21 @@
+name: Test govulncheck
+
+on:
+  pull_request:
+    paths:
+      - '.github/scripts/govulncheck/**'
+      - '.github/workflows/govulncheck.yaml'
+
+permissions: {}
+
+jobs:
+  bats:
+    name: Run bats tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
+        with:
+          tests: .github/scripts/govulncheck/test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Test linear-pr-commenter: `make test-linear-pr-commenter`
 - Test linear-release-sync: `make test-linear-release-sync`
 - Test publish-helm-chart: `make test-publish-helm-chart` (requires mikefarah/yq on PATH)
+- Test govulncheck: `make test-govulncheck`
 - Build linear-release-sync binary: `make build-linear-release-sync`
 - Lint workflows: `make lint` (requires actionlint and zizmor)
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-semver-validation test-linear-pr-commenter test-release-notification test-linear-release-sync test-cleanup-head-charts test-ci-test-notify test-auto-approve-bot-prs test-publish-helm-chart build-linear-release-sync lint help
+.PHONY: test test-semver-validation test-linear-pr-commenter test-release-notification test-linear-release-sync test-cleanup-head-charts test-ci-test-notify test-auto-approve-bot-prs test-publish-helm-chart test-govulncheck build-linear-release-sync lint help
 
 ACTIONS_DIR := .github/actions
 SCRIPTS_DIR := .github/scripts
@@ -6,7 +6,7 @@ SCRIPTS_DIR := .github/scripts
 help: ## show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-30s %s\n", $$1, $$2}'
 
-test: test-semver-validation test-linear-pr-commenter test-release-notification test-linear-release-sync test-cleanup-head-charts test-auto-approve-bot-prs test-ci-test-notify test-publish-helm-chart ## run all action tests
+test: test-semver-validation test-linear-pr-commenter test-release-notification test-linear-release-sync test-cleanup-head-charts test-auto-approve-bot-prs test-ci-test-notify test-publish-helm-chart test-govulncheck ## run all action tests
 
 test-semver-validation: ## run semver-validation unit tests
 	cd $(ACTIONS_DIR)/semver-validation && npm ci --silent && NODE_OPTIONS=--experimental-vm-modules npx jest --ci --coverage --watchAll=false
@@ -31,6 +31,9 @@ test-ci-test-notify: ## run ci-test-notify bats tests
 
 test-publish-helm-chart: ## run publish-helm-chart bats tests (requires mikefarah/yq on PATH)
 	bats $(SCRIPTS_DIR)/publish-helm-chart/test/run.bats
+
+test-govulncheck: ## run govulncheck bats tests
+	bats $(SCRIPTS_DIR)/govulncheck/test/run.bats
 
 build-linear-release-sync: ## build linear-release-sync binary (linux/amd64)
 	cd $(ACTIONS_DIR)/linear-release-sync/src && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-s -w" -o ../linear-release-sync-linux-amd64 .

--- a/README.md
+++ b/README.md
@@ -208,6 +208,73 @@ jobs:
 
 **Secrets:** `chart-museum-user`, `chart-museum-password`.
 
+### Govulncheck
+
+Runs [govulncheck](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck)
+against a Go module and, on scheduled runs, posts a Slack notification
+(via `ci-test-notify`) when vulnerabilities are found. The scan always
+marks the job failed on vulnerabilities — notification is the side
+channel, not the gate.
+
+**Location:** `.github/workflows/govulncheck.yaml`
+
+**Usage (public repo, weekly schedule):**
+
+```yaml
+name: govulncheck
+
+on:
+  schedule:
+    - cron: "0 12 * * 1" # Mon 12:00 UTC
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/govulncheck.yaml"
+
+jobs:
+  scan:
+    permissions:
+      contents: read
+    uses: loft-sh/github-actions/.github/workflows/govulncheck.yaml@govulncheck/v1
+    secrets:
+      slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL_CI_TESTS_ALERTS }}
+```
+
+**Usage (private repo that depends on `github.com/loft-sh/*`):**
+
+```yaml
+jobs:
+  scan:
+    permissions:
+      contents: read
+    uses: loft-sh/github-actions/.github/workflows/govulncheck.yaml@govulncheck/v1
+    with:
+      scan-paths: "./... ./cmd/..."
+      runs-on: large-8_32
+      private-repo: true
+    secrets:
+      gh-access-token: ${{ secrets.GH_ACCESS_TOKEN }}
+      slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL_CI_TESTS_ALERTS }}
+```
+
+**Inputs:**
+
+- `scan-paths` (optional, default: `./...`): space-separated Go package patterns
+- `test-flag` (optional, default: `true`): pass `-test` to govulncheck
+- `go-version-file` (optional, default: `go.mod`): passed to `actions/setup-go`
+- `runs-on` (optional, default: `ubuntu-latest`)
+- `private-repo` (optional, default: `false`): enable git url rewrite + `GOPRIVATE`
+- `goprivate` (optional, default: `github.com/loft-sh/*`)
+- `govulncheck-version` (optional, default: `latest`)
+- `timeout-minutes` (optional, default: `10`)
+- `test-name` (optional, default: `govulncheck`): Slack header
+- `notify` (optional, default: `true`): send Slack on vulnerabilities; fires on `schedule` events only
+
+**Secrets:**
+
+- `gh-access-token` (required when `private-repo: true`)
+- `slack-webhook-url` (required when `notify: true` and the run is on `schedule`)
+
 ## Testing
 
 Run all action tests locally:


### PR DESCRIPTION
## Summary

- New reusable workflow `.github/workflows/govulncheck.yaml` that runs [govulncheck](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck) against a caller's Go module and optionally notifies Slack on scheduled runs.
- Output truncation + report formatting lives in a shellcheck-clean script (`.github/scripts/govulncheck/run.sh`) with 11 bats tests (stubbed `govulncheck` binary — no network, no real Go scans).
- Keeps the **tail** of govulncheck's output on truncation (govulncheck lists findings at the end; truncating the head is less informative).

## Contract

| Input | Default | Purpose |
|-------|---------|---------|
| `scan-paths` | `./...` | space-separated Go package patterns |
| `test-flag` | `true` | pass `-test` to govulncheck |
| `go-version-file` | `go.mod` | passed to `actions/setup-go` |
| `runs-on` | `ubuntu-latest` | runner label (override for large self-hosted) |
| `private-repo` | `false` | enables git url rewrite + `GOPRIVATE` |
| `goprivate` | `github.com/loft-sh/*` | value for `GOPRIVATE` |
| `govulncheck-version` | `latest` | go-install version pin |
| `timeout-minutes` | `10` | scan step timeout |
| `test-name` | `govulncheck` | Slack notification header |
| `notify` | `true` | send Slack on vulnerabilities; fires on `schedule` events only |

Secrets: `gh-access-token` (private-repo only), `slack-webhook-url` (notify only).

## Security posture

- SHA-pinned: `actions/checkout`, `actions/setup-go`, `ci-test-notify`
- `persist-credentials: false` on both checkouts
- `permissions: contents: read`
- Skips on forks via `if: github.repository_owner == 'loft-sh'`
- `secrets-outside-env` suppressed with justification (secrets come via `workflow_call`, not repo scope)

## Test plan

- [x] `make test-govulncheck` passes 11 bats tests locally
- [x] `actionlint` clean on the new workflow files
- [x] `zizmor` clean (2 suppressions with justifications)
- [x] `shellcheck` clean on `run.sh`
- [x] CI green on this PR
- [x] Post-merge: tag `govulncheck/v1` for downstream pinning
- [ ] Migration PR: loft-enterprise (replaces existing `govulncheck.yaml`)
- [ ] New coverage PR: vcluster
- [ ] New coverage PR: vcluster-pro

Related to DEVOPS-772