### PR TITLE
fix(auto-approve): drop github app token path from reusable workflow

### DIFF
--- a/.github/workflows/auto-approve-bot-prs.yaml
+++ b/.github/workflows/auto-approve-bot-prs.yaml
@@ -15,17 +15,10 @@ on:
         description: 'Enable auto-merge after approval'
         type: boolean
         default: true
-      app-id:
-        description: 'GitHub App ID for minting installation tokens (preferred over PAT)'
-        type: string
-        default: ''
     secrets:
       gh-access-token:
-        description: 'GitHub PAT for approving PRs (legacy — use app-id + app-private-key instead)'
-        required: false
-      app-private-key:
-        description: 'GitHub App private key (PEM) for minting installation tokens'
-        required: false
+        description: 'GitHub PAT for approving PRs (must be different identity from PR author)'
+        required: true
 
 jobs:
   auto-approve:
@@ -40,13 +33,6 @@ jobs:
     # reporting a hard red check on caller CI.
     continue-on-error: true
     steps:
-      - name: Mint GitHub App token
-        id: app-token
-        if: inputs.app-id != ''
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
-        with:
-          app-id: ${{ inputs.app-id }}
-          private-key: ${{ secrets.app-private-key }} # zizmor: ignore[secrets-outside-env] -- PEM key passed via workflow_call, not a repo secret
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: loft-sh/github-actions
@@ -58,4 +44,4 @@ jobs:
           trusted-authors: ${{ inputs.trusted-authors }}
           merge-method: ${{ inputs.merge-method }}
           auto-merge: ${{ inputs.auto-merge }}
-          github-token: ${{ steps.app-token.outputs.token || secrets.gh-access-token }} # zizmor: ignore[secrets-outside-env]
+          github-token: ${{ secrets.gh-access-token }} # zizmor: ignore[secrets-outside-env] -- PAT passed via workflow_call, not a repo secret


### PR DESCRIPTION
## Summary

Reverts #98 — removes the GitHub App token minting path from the reusable workflow (\`.github/workflows/auto-approve-bot-prs.yaml\`). The reusable workflow is back to requiring a single \`gh-access-token\` (PAT) secret from callers, matching its pre-#98 shape.

The **composite action** at \`.github/actions/auto-approve-bot-prs\` is **not touched** — none of its hardening (bats-tested eligibility logic, never-block guards, self-approval skip, mergeable retry, prerelease guard, etc.) is affected.

## Why

#98 added optional GitHub App auth so \`auto-approve\` could run under an identity distinct from \`loft-bot\` — \`loft-bot\` is the backport PR author and cannot approve its own PRs. The identity switch itself works, but the review the App leaves does **not** satisfy \`required_approving_review_count\` on rulesets or classic branch protection.

GitHub only counts reviews from users with repo write access, and App reviews always land with \`authorAssociation: NONE\` regardless of the installation's declared permissions. This is confirmed by the public GitHub docs and was reproduced on \`loft-sh/vcluster-docs\` PRs #1930 and #1931 — the App left \`APPROVED\` reviews on the current head sha, the API returned them as valid, and \`reviewDecision\` stayed \`REVIEW_REQUIRED\`:

\`\`\`
reviews:
  vcluster-pr-approver (Bot)   APPROVED   (authorAssoc: NONE)
  vcluster-pr-approver (Bot)   APPROVED   (authorAssoc: NONE)
reviewDecision: REVIEW_REQUIRED
\`\`\`

Restoring the pre-#98 shape (PAT-only, \`gh-access-token\` required) lets callers use a real-user token whose approval is actually counted. Backport auto-approval itself is being redesigned separately; the App-backed path is not coming back as-is.

## References

- Linear: DEVOPS-714 (also undoes a piece of DEVOPS-751)
- Caller change: [loft-sh/vcluster-docs#1939](https://github.com/loft-sh/vcluster-docs/pull/1939) stops passing the now-removed \`app-id\` and \`app-private-key\` secrets.

## Compat with existing callers

| Repo | Passes \`app-id\`/\`app-private-key\`? | Action required |
| --- | --- | --- |
| vcluster-docs | yes (being removed in #1939) | merge #1939 alongside this |
| vcluster | no | none |
| vcluster-pro | no | none |
| loft-enterprise | no | none |
| loft-prod | no | none |
| hosted-platform | no | none |

## Test plan

- [ ] Verified YAML matches the pre-#98 parent commit byte-for-byte (\`diff\` reports no differences against \`a9d1c21~1\`).
- [ ] Composite action, bats tests, and PR smoke-tests are untouched, so existing CI continues to cover the PAT path.
- [ ] After merge, re-trigger \`auto-approve\` on an open loft-bot backport PR where the PAT identity is not \`loft-bot\` and confirm the review is left and \`reviewDecision\` flips to \`APPROVED\`.