### PR TITLE
fix(publish-helm-chart): skip plugin verification for helm v4 compat

### DIFF
--- a/.github/workflows/publish-helm-chart.yaml
+++ b/.github/workflows/publish-helm-chart.yaml
@@ -99,7 +99,10 @@ jobs:
           version: ${{ inputs.helm-version }}
 
       - name: Install helm-push plugin
-        run: helm plugin install https://github.com/chartmuseum/helm-push.git
+        # --verify=false: Helm v4 verifies plugin sources by default; the
+        # chartmuseum/helm-push plugin does not ship a verification manifest,
+        # so the install fails without this flag. The flag is a no-op on v3.
+        run: helm plugin install --verify=false https://github.com/chartmuseum/helm-push.git
 
       - name: Set up yq
         uses: dcarbone/install-yq-action@4075b4dca348d74bd83f2bf82d30f25d7c54539b # v1.3.1


### PR DESCRIPTION
## Summary

- Helm v4.1.4 (installed by default since #106) verifies plugin sources on `helm plugin install`. The `chartmuseum/helm-push` plugin does not ship a verification manifest, so the install fails:
  ```
  Error: plugin source does not support verification. Use --verify=false to skip verification
  ```
- Passing `--verify=false` fixes the install. The flag is also accepted on v3 (as a no-op), so callers pinning `helm-version: v3.x` are unaffected.

## Impact

Broke the nightly head-chart publish in `loft-enterprise` after loft-sh/loft-enterprise#6673 adopted this reusable workflow. Any other caller using `publish-helm-chart/v1` is affected the same way.

## Follow-up

After merge, move the `publish-helm-chart/v1` tag to this commit:

```
git tag -f publish-helm-chart/v1 <merged-sha>
git push origin publish-helm-chart/v1 --force
```

## Test plan

- [x] `make lint` passes locally (actionlint + zizmor clean)
- [x] `make test-publish-helm-chart` runs (bats unchanged — the shell script wasn't touched)
- [ ] Verified end-to-end by the next head-chart push in `loft-enterprise` once the `publish-helm-chart/v1` tag is moved