### PR TITLE
feat: add auto-doc support for action and workflow documentation

### DIFF
--- a/.github/actions/auto-approve-bot-prs/README.md
+++ b/.github/actions/auto-approve-bot-prs/README.md
@@ -1,0 +1,39 @@
+# Auto-approve bot PRs
+
+Approves PRs from trusted bot authors whose title or branch matches a known
+safe pattern, after all other CI checks pass. Never hard-fails the job --
+every failure mode degrades to a notice-level skip.
+
+Safe patterns: `chore(` / `chore:` titles, `fix(deps):` titles,
+`backport/` / `renovate/` / `update-platform-version-` branches.
+
+## Inputs
+
+<!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
+
+|       INPUT        |  TYPE  | REQUIRED |                    DEFAULT                     |                                            DESCRIPTION                                            |
+|--------------------|--------|----------|------------------------------------------------|---------------------------------------------------------------------------------------------------|
+|     auto-merge     | string |  false   |                   `"false"`                    |                              Enable GitHub auto-merge after approval                              |
+|    github-token    | string |   true   |                                                | PAT used to read PR state, <br>approve, and enable auto-merge. Must NOT <br>match the PR author.  |
+|    merge-method    | string |  false   |                   `"squash"`                   |                         Merge method for auto-merge (squash|merge|rebase)                         |
+|  trusted-authors   | string |  false   | `"renovate[bot],loft-bot,github-actions[bot]"` |                            Comma-separated list of trusted bot logins                             |
+| wait-max-attempts  | string |  false   |                     `"90"`                     |                       Max polling attempts waiting for other <br>CI checks                        |
+| wait-sleep-seconds | string |  false   |                     `"10"`                     |                                 Seconds between polling attempts                                  |
+
+<!-- AUTO-DOC-INPUT:END -->
+
+## Usage
+
+```yaml
+- uses: loft-sh/github-actions/.github/actions/auto-approve-bot-prs@auto-approve-bot-prs/v1
+  with:
+    github-token: ${{ secrets.GH_ACCESS_TOKEN }}
+```
+
+## Testing
+
+```bash
+make test-auto-approve-bot-prs
+```
+
+Runs the bats suites in `test/` against the shell scripts in `src/`.

--- a/.github/actions/ci-notify-nightly-tests/README.md
+++ b/.github/actions/ci-notify-nightly-tests/README.md
@@ -4,15 +4,19 @@ Sends a Slack notification with E2E nightly test results, including a summary, r
 
 ## Inputs
 
-| Name | Description | Required | Default |
-|------|-------------|----------|---------|
-| `test_results` | Test results summary text | yes | |
-| `run_id` | GitHub Actions run ID | yes | |
-| `run_number` | GitHub Actions run number | yes | |
-| `status` | Test status: `success` or `failure` | yes | |
-| `source_repo` | Source repository (e.g. `loft-sh/vcluster`) | yes | |
-| `failed_tests` | List of failed test suites, if any | yes | `''` |
-| `webhook_url` | Slack incoming webhook URL | yes | |
+<!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
+
+|    INPUT     |  TYPE  | REQUIRED | DEFAULT |               DESCRIPTION               |
+|--------------|--------|----------|---------|-----------------------------------------|
+| failed_tests | string |   true   |         | List of failed test suites, if <br>any  |
+|    run_id    | string |   true   |         |          GitHub Actions run ID          |
+|  run_number  | string |   true   |         |        GitHub Actions run number        |
+| source_repo  | string |   true   |         |            Source repository            |
+|    status    | string |   true   |         |     Test status (success, failure)      |
+| test_results | string |   true   |         |          Test results summary           |
+| webhook_url  | string |   true   |         |            Slack Webhook URL            |
+
+<!-- AUTO-DOC-INPUT:END -->
 
 ## Usage
 

--- a/.github/actions/ci-test-notify/README.md
+++ b/.github/actions/ci-test-notify/README.md
@@ -6,12 +6,16 @@ Replaces the nightly-specific `ci-notify-nightly-tests` action with a generic in
 
 ## Inputs
 
-| Name | Description | Required | Default |
-|------|-------------|----------|---------|
-| `test-name` | Test suite name for the header (e.g. "E2E Ginkgo Nightly Tests"). Keep under ~130 chars (Slack header limit is 150 chars; status suffix uses ~15). | yes | |
-| `status` | Test status: `success`, `failure`, `cancelled`, or `skipped` | yes | |
-| `details` | Markdown text appended after the build URL | no | `''` |
-| `webhook-url` | Slack incoming webhook URL | yes | |
+<!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
+
+|    INPUT    |  TYPE  | REQUIRED | DEFAULT |                                                                                         DESCRIPTION                                                                                         |
+|-------------|--------|----------|---------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|   details   | string |  false   |         |                                               Markdown text appended after the build <br>URL (test results, versions, artifact links, etc.)                                                 |
+|   status    | string |   true   |         |                                                                  Test status: success, failure, cancelled, or <br>skipped                                                                   |
+|  test-name  | string |   true   |         | Test suite name for the header <br>(e.g. "E2E Ginkgo Nightly Tests"). Keep under ~130 chars — <br>Slack header blocks have a 150-char <br>limit and the status suffix takes <br>~15 chars.  |
+| webhook-url | string |   true   |         |                                                                                 Slack incoming webhook URL                                                                                  |
+
+<!-- AUTO-DOC-INPUT:END -->
 
 ## Message format
 

--- a/.github/actions/go-licenses/README.md
+++ b/.github/actions/go-licenses/README.md
@@ -9,20 +9,24 @@ Both modes share the same setup (setup-go, install go-licenses, optional private
 
 ## Inputs
 
-| Name | Description | Required | Default |
-|------|-------------|----------|---------|
-| `mode` | `check` or `report` | yes | — |
-| `go-licenses-version` | go-licenses version to install. `v1.0.0` lacks `--ignore`; use `package-mode: go-work` with it | no | `v1.6.0` |
-| `go-version-file` | Passed to `actions/setup-go` | no | `go.mod` |
-| `ignored-packages` | Comma-separated package path prefixes to skip. In `all` mode → `--ignore` flags; in `go-work` mode → substring-matched against `go.work` DiskPaths | no | `github.com/loft-sh` |
-| `package-mode` | `all` (pass `./...` + `--ignore`) or `go-work` (enumerate workspace modules — required for go-licenses < v1.6.0) | no | `all` |
-| `fail-on-error` | [check] When `"false"`, non-zero go-licenses exit is surfaced as a warning; the step still succeeds | no | `"true"` |
-| `template-path` | [report] Path to the go-licenses .tmpl template | no | `.github/licenses.tmpl` |
-| `output-path` | [report] File path to write the rendered report to | required for `report` | `""` |
-| `pr-branch` | [report] Branch name for the generated PR | required for `report` | `""` |
-| `pr-title` | [report] PR title | required for `report` | `""` |
-| `pr-commit-message` | [report] Commit message; defaults to `pr-title` | no | `""` |
-| `gh-access-token` | GitHub PAT — fetches private loft-sh modules (both modes) and opens the PR (report mode) | required for `report`, optional for private-module `check` | `""` |
+<!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
+
+|        INPUT        |  TYPE  | REQUIRED |          DEFAULT          |                                                                                                       DESCRIPTION                                                                                                       |
+|---------------------|--------|----------|---------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|    fail-on-error    | string |  false   |         `"true"`          | [check mode] When `false`, non-zero exit <br>codes from go-licenses are surfaced as <br>a workflow warning instead of a <br>failure. Use only as a temporary <br>escape hatch when upstream go-licenses is <br>broken.  |
+|   gh-access-token   | string |  false   |                           |                                         GitHub PAT used to fetch private <br>loft-sh modules (both modes) and to open <br>the generated pull request (report mode, required).                                           |
+| go-licenses-version | string |  false   |        `"v1.6.0"`         |                                    Version of go-licenses to install (e.g. v1.6.0, v1.0.0). <br>v1.0.0 does not support `--ignore` — <br>set `package-mode: go-work` when using it.                                     |
+|   go-version-file   | string |  false   |        `"go.mod"`         |                                                                                      Path to go.mod or go.work for <br>setup-go.                                                                                        |
+|  ignored-packages   | string |  false   |  `"github.com/loft-sh"`   |                    Comma-separated package path prefixes to skip. <br>In `all` mode these become `--ignore` <br>flags; in `go-work` mode they are <br>substring-matched against go.work DiskPaths.                      |
+|        mode         | string |   true   |                           |                                  `check` — run `go-licenses check` against the module. <br>`report` — render a license report with <br>a template and open a PR <br>with the output.                                    |
+|     output-path     | string |  false   |                           |                                         [report mode, required] File path in <br>the caller repo to write the <br>rendered report to, e.g. `docs/pages/licenses/vcluster.mdx`.                                          |
+|    package-mode     | string |  false   |          `"all"`          |           Package selection strategy: `all` (pass `./...` with `--ignore` flags) or <br>`go-work` (enumerate modules via `go work edit` and filter at the package list — required for go-licenses < v1.6.0).            |
+|      pr-branch      | string |  false   |                           |                                                                       [report mode, required] Branch name to <br>push the rendered report onto.                                                                         |
+|  pr-commit-message  | string |  false   |                           |                                                                [report mode] Commit message for the <br>generated pull request. Defaults to `pr-title`.                                                                 |
+|      pr-title       | string |  false   |                           |                                                                          [report mode, required] PR title for <br>the generated pull request.                                                                           |
+|    template-path    | string |  false   | `".github/licenses.tmpl"` |                                                                [report mode] Path to the go-licenses <br>.tmpl template used to render the <br>report.                                                                  |
+
+<!-- AUTO-DOC-INPUT:END -->
 
 ## Usage
 

--- a/.github/actions/govulncheck/README.md
+++ b/.github/actions/govulncheck/README.md
@@ -6,18 +6,22 @@ On scheduled runs, posts a Slack notification via `ci-test-notify` when vulnerab
 
 ## Inputs
 
-| Name | Description | Required | Default |
-|------|-------------|----------|---------|
-| `scan-paths` | Space-separated Go package patterns to scan, e.g. `./... ./cmd/...` | no | `./...` |
-| `test-flag` | Pass `-test` to govulncheck (include test files in the scan) | no | `"true"` |
-| `go-version-file` | Path to `go.mod` or `go.work`, passed to `actions/setup-go` | no | `go.mod` |
-| `private-repo` | When `"true"`, rewrites git URLs with `gh-access-token` and sets `GOPRIVATE` for private-module resolution | no | `"false"` |
-| `goprivate` | Value of `GOPRIVATE` when `private-repo: "true"` | no | `github.com/loft-sh/*` |
-| `govulncheck-version` | Version of `golang.org/x/vuln/cmd/govulncheck` to install | no | `latest` |
-| `test-name` | Slack notification header (passed to `ci-test-notify`) | no | `govulncheck` |
-| `notify` | Send a Slack notification on vulnerabilities. Only fires on `schedule` events — PR/manual runs never notify | no | `"true"` |
-| `gh-access-token` | PAT with access to private loft-sh repos. Required when `private-repo: "true"` | no | `""` |
-| `slack-webhook-url` | Slack incoming webhook URL. Required when `notify: "true"` and the run is on `schedule` | no | `""` |
+<!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
+
+|        INPUT        |  TYPE  | REQUIRED |         DEFAULT          |                                                                         DESCRIPTION                                                                          |
+|---------------------|--------|----------|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|   gh-access-token   | string |  false   |                          |                                      PAT with access to private loft-sh <br>repos. Required when `private-repo: true`.                                       |
+|   go-version-file   | string |  false   |        `"go.mod"`        |                                                 Path to go.mod (or go.work) passed to <br>actions/setup-go.                                                  |
+|      goprivate      | string |  false   | `"github.com/loft-sh/*"` |                                               Value of the GOPRIVATE env var <br>when `private-repo` is true.                                                |
+| govulncheck-version | string |  false   |        `"latest"`        |                                                   Version of golang.org/x/vuln/cmd/govulncheck to install.                                                   |
+|       notify        | string |  false   |         `"true"`         |                    Send a Slack notification on vulnerabilities. <br>Only fires on `schedule` events — <br>PR/manual runs never notify.                      |
+|    private-repo     | string |  false   |        `"false"`         | When true, configures `git` url rewriting <br>with `gh-access-token` and sets `GOPRIVATE=github.com/loft-sh/*` so <br>the scan can resolve private modules.  |
+|     scan-paths      | string |  false   |        `"./..."`         |                                        Space-separated Go package patterns to scan. <br>Example: `./... ./cmd/...`.                                          |
+|  slack-webhook-url  | string |  false   |                          |             Slack incoming webhook URL for the <br>ci-test-notify action. Required when `notify: true` and <br>the workflow runs on `schedule`.              |
+|      test-flag      | string |  false   |         `"true"`         |                                                Pass `-test` to govulncheck (include test files in the scan).                                                 |
+|      test-name      | string |  false   |     `"govulncheck"`      |                                                    Slack notification header (passed to ci-test-notify).                                                     |
+
+<!-- AUTO-DOC-INPUT:END -->
 
 ## Usage
 

--- a/.github/actions/linear-pr-commenter/README.md
+++ b/.github/actions/linear-pr-commenter/README.md
@@ -34,17 +34,19 @@ jobs:
           linear-token: ${{ secrets.LINEAR_TOKEN }}
 ```
 
-## Configuration
+## Inputs
 
-### Required Inputs
+<!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
 
-| Input         | Description                                     |
-|---------------|-------------------------------------------------|
-| pr-number     | The pull request number                         |
-| repo-owner    | The owner of the repository                     |
-| repo-name     | The name of the repository                      |
-| github-token  | GitHub token with permissions to comment on PRs |
-| linear-token  | Linear API token for retrieving issue details   |
+|    INPUT     |  TYPE  | REQUIRED | DEFAULT |                     DESCRIPTION                      |
+|--------------|--------|----------|---------|------------------------------------------------------|
+| github-token | string |   true   |         | GitHub token with permissions to comment <br>on PRs  |
+| linear-token | string |   true   |         |  Linear API token for retrieving issue <br>details   |
+|  pr-number   | string |   true   |         |               The pull request number                |
+|  repo-name   | string |   true   |         |              The name of the repository              |
+|  repo-owner  | string |   true   |         |             The owner of the repository              |
+
+<!-- AUTO-DOC-INPUT:END -->
 
 ## Example
 

--- a/.github/actions/linear-release-sync/README.md
+++ b/.github/actions/linear-release-sync/README.md
@@ -32,30 +32,27 @@ sync_linear:
         linear-token: ${{ secrets.LINEAR_TOKEN }}
 ```
 
-## Configuration
+## Inputs
 
-### Required Inputs
+<!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
 
-| Input         | Description                                     |
-|---------------|-------------------------------------------------|
-| release-tag   | The tag of the new release (e.g. `v1.2.0`)     |
-| repo-name     | The GitHub repository name                      |
-| github-token  | GitHub token with read access to the repository |
-| linear-token  | Linear API token for updating issues            |
+|            INPUT             |  TYPE  | REQUIRED |        DEFAULT        |                                      DESCRIPTION                                      |
+|------------------------------|--------|----------|-----------------------|---------------------------------------------------------------------------------------|
+|            debug             | string |  false   |       `"false"`       |                                 Enable debug logging                                  |
+|           dry-run            | string |  false   |       `"false"`       |                       Preview changes without modifying Linear                        |
+|         github-token         | string |   true   |                       |                 GitHub token with read access to <br>the repository                   |
+|       linear-projects        | string |  false   |                       | Comma-separated list of Linear project names <br>to process (optional, default: all)  |
+|         linear-teams         | string |  false   |                       |  Comma-separated list of Linear team names <br>to process (optional, default: all)    |
+|         linear-token         | string |   true   |                       |                         Linear API token for updating issues                          |
+|         previous-tag         | string |  false   |                       |                 The previous release tag (auto-detected if not set)                   |
+| ready-for-release-state-name | string |  false   | `"Ready for Release"` |            The Linear workflow state name for <br>issues ready to release             |
+|         release-tag          | string |   true   |                       |                     The tag of the new release <br>(e.g. v1.2.0)                      |
+|     released-state-name      | string |  false   |     `"Released"`      |                The Linear workflow state name for <br>released issues                 |
+|          repo-name           | string |   true   |                       |                              The GitHub repository name                               |
+|          repo-owner          | string |  false   |      `"loft-sh"`      |                          The GitHub owner of the repository                           |
+|       strict-filtering       | string |  false   |       `"true"`        |      Only include PRs merged before the <br>release was published (recommended)       |
 
-### Optional Inputs
-
-| Input                        | Default              | Description                                                |
-|------------------------------|----------------------|------------------------------------------------------------|
-| repo-owner                   | `loft-sh`            | The GitHub owner of the repository                         |
-| previous-tag                 | *(auto-detected)*    | The previous release tag                                   |
-| released-state-name          | `Released`           | The Linear workflow state name for released issues         |
-| ready-for-release-state-name | `Ready for Release`  | The Linear workflow state name for issues ready to release |
-| linear-teams                 | *(all teams)*        | Comma-separated list of Linear team names to process       |
-| linear-projects              | *(all projects)*     | Comma-separated list of Linear project names to process    |
-| strict-filtering             | `true`               | Only include PRs merged before the release was published   |
-| dry-run                      | `false`              | Preview changes without modifying Linear                   |
-| debug                        | `false`              | Enable debug logging                                       |
+<!-- AUTO-DOC-INPUT:END -->
 
 ## Development
 

--- a/.github/actions/publish-helm-chart/README.md
+++ b/.github/actions/publish-helm-chart/README.md
@@ -4,19 +4,23 @@ Packages a Helm chart and pushes it to ChartMuseum. Handles multi-version publis
 
 ## Inputs
 
-| Name | Description | Required | Default |
-|------|-------------|----------|---------|
-| `chart-name` | Written to `.name` in `Chart.yaml`; also determines the packaged tarball filename | yes | — |
-| `chart-description` | Optional value written to `.description` in `Chart.yaml`. Preserved when empty | no | `""` |
-| `app-version` | Passed as `--app-version` to `helm package`. When empty, the chart's existing `appVersion` is used | no | `""` |
-| `chart-versions` | JSON array of chart versions. Each entry is packaged and pushed as `<chart-name>-<version>.tgz`. Examples: `'["1.2.3"]'`, `'["0.0.0-latest","0.0.0-abc1234"]'` | yes | — |
-| `chart-directory` | Path to the Helm chart source directory | no | `chart` |
-| `values-edits` | Newline-separated `jsonpath=value` pairs applied via yq to `<chart-directory>/values.yaml`. Values are written as strings | no | `""` |
-| `helm-version` | Helm CLI version to install | no | `v4.1.4` |
-| `republish-latest` | When `"true"`, after pushing, re-push the highest semver so it becomes the most recently uploaded entry (for stable release streams) | no | `"false"` |
-| `chart-museum-url` | ChartMuseum base URL | no | `https://charts.loft.sh/` |
-| `chart-museum-user` | ChartMuseum username | yes | — |
-| `chart-museum-password` | ChartMuseum password | yes | — |
+<!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
+
+|         INPUT         |  TYPE  | REQUIRED |           DEFAULT           |                                                                                                                DESCRIPTION                                                                                                                 |
+|-----------------------|--------|----------|-----------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|      app-version      | string |  false   |                             |                                                          Optional value passed as --app-version to <br>`helm package`. When empty, the chart's existing <br>appVersion is used.                                                            |
+|   chart-description   | string |  false   |                             |                                                             Optional value written to .description in <br>Chart.yaml. When empty, the existing description <br>is preserved.                                                               |
+|    chart-directory    | string |  false   |          `"chart"`          |                                                                                               Path to the Helm chart source <br>directory.                                                                                                 |
+| chart-museum-password | string |   true   |                             |                                                                                                           ChartMuseum password.                                                                                                            |
+|   chart-museum-url    | string |  false   | `"https://charts.loft.sh/"` |                                                                                                           ChartMuseum base URL.                                                                                                            |
+|   chart-museum-user   | string |   true   |                             |                                                                                                           ChartMuseum username.                                                                                                            |
+|      chart-name       | string |   true   |                             |                                                                  Helm chart name. Written to .name <br>in Chart.yaml; also determines the packaged <br>tarball filename.                                                                   |
+|    chart-versions     | string |   true   |                             |                            JSON array of chart versions to <br>publish. Each entry is packaged and <br>pushed as <chart-name>-<version>.tgz. Examples: '["1.2.3"]' or <br>'["0.0.0-latest","0.0.0-abc1234"]'.                              |
+|     helm-version      | string |  false   |         `"v4.1.4"`          |                                                                                                        Helm CLI version to install.                                                                                                        |
+|   republish-latest    | string |  false   |          `"false"`          | When true, after pushing, query ChartMuseum <br>for the highest semver of <chart-name> <br>and re-push it so it becomes <br>the most recently uploaded entry. Use <br>for stable release publishing into a <br>multi-line release stream.  |
+|     values-edits      | string |  false   |                             |                                                 Optional newline-separated `jsonpath=value` pairs applied via <br>yq to <chart-directory>/values.yaml. Values are written <br>as strings.                                                  |
+
+<!-- AUTO-DOC-INPUT:END -->
 
 ## Usage
 

--- a/.github/actions/release-notification/README.md
+++ b/.github/actions/release-notification/README.md
@@ -4,17 +4,22 @@ Sends a Slack notification when a new release is published.
 
 ## Inputs
 
-| Name | Description | Required | Default |
-|------|-------------|----------|---------|
-| `version` | Release version | yes | |
-| `previous_tag` | Previous release tag for changelog comparison | no | `''` |
-| `changes` | Release changes | no | `'See changelog link below'` |
-| `is_draft` | Is this a draft release? | no | `'false'` |
-| `is_prerelease` | Is this a pre-release? | no | `'false'` |
-| `target_repo` | Target repository (e.g. `loft-sh/vcluster`) | yes | |
-| `product` | Product name (e.g. `vCluster` or `vCluster Platform`) | yes | |
-| `base_branch` | Source branch from which the release was cut | no | |
-| `webhook_url` | Slack incoming webhook URL | yes | |
+<!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
+
+|     INPUT     |  TYPE  | REQUIRED |           DEFAULT            |                                           DESCRIPTION                                           |
+|---------------|--------|----------|------------------------------|-------------------------------------------------------------------------------------------------|
+|  base_branch  | string |  false   |                              | Source branch from which the release <br>was cut (auto-detected from git history when omitted)  |
+|    changes    | string |  false   | `"See changelog link below"` |                                         Release changes                                         |
+|   is_draft    | string |  false   |          `"false"`           |                                    Is this a draft release?                                     |
+| is_prerelease | string |  false   |          `"false"`           |                                     Is this a pre-release?                                      |
+| previous_tag  | string |  false   |                              |                          Previous release tag for changelog comparison                          |
+|    product    | string |   true   |                              |                          Product name (vCluster or vCluster Platform)                           |
+|    status     | string |  false   |         `"success"`          |                  Release status: success, failure, cancelled, or <br>skipped                    |
+|  target_repo  | string |   true   |                              |                                        Target repository                                        |
+|    version    | string |   true   |                              |                                         Release version                                         |
+|  webhook_url  | string |   true   |                              |                                        Slack Webhook URL                                        |
+
+<!-- AUTO-DOC-INPUT:END -->
 
 ## Usage
 

--- a/.github/actions/semver-validation/README.md
+++ b/.github/actions/semver-validation/README.md
@@ -11,17 +11,25 @@ This GitHub Action validates whether a given version string follows the [Semanti
 
 ## Inputs
 
-| Name | Description | Required | Default |
-|------|-------------|----------|---------|
-| `version` | Version string to validate against semver format | Yes | - |
+<!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
+
+|  INPUT  |  TYPE  | REQUIRED | DEFAULT |                      DESCRIPTION                      |
+|---------|--------|----------|---------|-------------------------------------------------------|
+| version | string |   true   |         | Version string to validate against semver <br>format  |
+
+<!-- AUTO-DOC-INPUT:END -->
 
 ## Outputs
 
-| Name | Description | Example |
-|------|-------------|---------|
-| `is_valid` | Whether the version is valid semver (`true`/`false`) | `true` |
-| `parsed_version` | JSON object with parsed version components | `{"major":1,"minor":2,"patch":3,...}` |
-| `error_message` | Error message if validation fails | `Invalid semver format: 'v1.2'` |
+<!-- AUTO-DOC-OUTPUT:START - Do not remove or modify this section -->
+
+|     OUTPUT     |  TYPE  |                                     DESCRIPTION                                     |
+|----------------|--------|-------------------------------------------------------------------------------------|
+| error_message  | string |                          Error message if validation fails                          |
+|    is_valid    | string |               Whether the version is a valid <br>semver (true/false)                |
+| parsed_version | string | Parsed version object with major, minor, <br>patch, prerelease, and build metadata  |
+
+<!-- AUTO-DOC-OUTPUT:END -->
 
 ## Usage
 

--- a/.github/workflows/check-docs.yaml
+++ b/.github/workflows/check-docs.yaml
@@ -1,0 +1,26 @@
+name: Check docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/actions/**/action.yml'
+      - '.github/workflows/*.yaml'
+      - 'docs/workflows/*.md'
+  pull_request:
+    paths:
+      - '.github/actions/**/action.yml'
+      - '.github/actions/**/README.md'
+      - '.github/workflows/*.yaml'
+      - 'docs/workflows/*.md'
+
+jobs:
+  check-docs:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - run: make check-docs

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
+.bin/
 
 # override global gitignore to track claude config
 !.claude/

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,92 @@
-.PHONY: test test-semver-validation test-linear-pr-commenter test-release-notification test-linear-release-sync test-cleanup-head-charts test-ci-test-notify test-auto-approve-bot-prs test-publish-helm-chart test-govulncheck test-go-licenses build-linear-release-sync lint help
+.PHONY: test test-semver-validation test-linear-pr-commenter test-release-notification test-linear-release-sync test-cleanup-head-charts test-ci-test-notify test-auto-approve-bot-prs test-publish-helm-chart test-govulncheck test-go-licenses build-linear-release-sync lint install-auto-doc generate-docs check-docs help
 
 ACTIONS_DIR := .github/actions
+WORKFLOWS_DIR := .github/workflows
 SCRIPTS_DIR := .github/scripts
+
+# --- auto-doc -----------------------------------------------------------
+AUTO_DOC_VERSION := 3.6.0
+
+# Detect OS and arch for binary download
+UNAME_S := $(shell uname -s)
+UNAME_M := $(shell uname -m)
+ifeq ($(UNAME_S),Darwin)
+  AUTO_DOC_OS := Darwin
+else
+  AUTO_DOC_OS := Linux
+endif
+ifeq ($(UNAME_M),arm64)
+  AUTO_DOC_ARCH := arm64
+else ifeq ($(UNAME_M),aarch64)
+  AUTO_DOC_ARCH := arm64
+else
+  AUTO_DOC_ARCH := x86_64
+endif
+
+AUTO_DOC_BIN := .bin/auto-doc
+
+$(AUTO_DOC_BIN):
+	@mkdir -p .bin
+	curl -sSfL "https://github.com/tj-actions/auto-doc/releases/download/v$(AUTO_DOC_VERSION)/auto-doc_$(AUTO_DOC_VERSION)_$(AUTO_DOC_OS)_$(AUTO_DOC_ARCH).tar.gz" \
+	  | tar xz -C .bin auto-doc
+
+install-auto-doc: $(AUTO_DOC_BIN) ## install auto-doc CLI
+
+generate-docs: $(AUTO_DOC_BIN) ## regenerate docs from action.yml / workflow YAML
+	@# Composite actions
+	@for action_yml in $(ACTIONS_DIR)/*/action.yml; do \
+	  dir=$$(dirname "$$action_yml"); \
+	  readme="$$dir/README.md"; \
+	  if [ -f "$$readme" ]; then \
+	    $(AUTO_DOC_BIN) -f "$$action_yml" -o "$$readme" && \
+	    echo "  updated $$readme"; \
+	  fi; \
+	done
+	@# Reusable workflows
+	@for doc in docs/workflows/*.md; do \
+	  name=$$(basename "$$doc" .md); \
+	  wf="$(WORKFLOWS_DIR)/$$name.yaml"; \
+	  if [ -f "$$wf" ]; then \
+	    $(AUTO_DOC_BIN) -f "$$wf" -r -o "$$doc" && \
+	    echo "  updated $$doc"; \
+	  fi; \
+	done
+
+check-docs: generate-docs ## verify docs are up to date (fails if drift detected)
+	@# Check that every action has a README with auto-doc markers
+	@fail=0; \
+	for action_yml in $(ACTIONS_DIR)/*/action.yml; do \
+	  dir=$$(dirname "$$action_yml"); \
+	  name=$$(basename "$$dir"); \
+	  readme="$$dir/README.md"; \
+	  if [ ! -f "$$readme" ]; then \
+	    echo "ERROR: $$dir has action.yml but no README.md"; \
+	    fail=1; \
+	  elif ! grep -q 'AUTO-DOC-INPUT:START' "$$readme"; then \
+	    echo "ERROR: $$readme is missing AUTO-DOC-INPUT markers"; \
+	    fail=1; \
+	  fi; \
+	done; \
+	for wf in $(WORKFLOWS_DIR)/*.yaml; do \
+	  if grep -q 'workflow_call' "$$wf"; then \
+	    name=$$(basename "$$wf" .yaml); \
+	    doc="docs/workflows/$$name.md"; \
+	    if [ ! -f "$$doc" ]; then \
+	      echo "ERROR: reusable workflow $$wf has no doc at $$doc"; \
+	      fail=1; \
+	    fi; \
+	  fi; \
+	done; \
+	if [ "$$fail" -eq 1 ]; then exit 1; fi
+	@# Check that generated content matches committed content
+	@if ! git diff --quiet -- '*.md'; then \
+	  echo ""; \
+	  echo "ERROR: Generated docs are out of date. Run 'make generate-docs' and commit the changes."; \
+	  echo ""; \
+	  git diff --stat -- '*.md'; \
+	  exit 1; \
+	fi
+	@echo "Docs are up to date."
 
 help: ## show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-30s %s\n", $$1, $$2}'

--- a/README.md
+++ b/README.md
@@ -377,6 +377,62 @@ Post-merge, `dispatch-integration-tests.yaml` triggers full E2E tests in
 5. Add a CI workflow at `.github/workflows/test-<action-name>.yaml` with a
    `paths` filter scoped to the action's directory.
 
+6. Add `AUTO-DOC-INPUT`/`AUTO-DOC-OUTPUT` markers to the action's `README.md`
+   and run `make generate-docs` (see [Documentation](#documentation)).
+
+## Documentation
+
+Action and reusable workflow documentation is auto-generated from
+`action.yml` / workflow YAML using [tj-actions/auto-doc](https://github.com/tj-actions/auto-doc).
+Each action README and each workflow doc in `docs/workflows/` contains
+`AUTO-DOC-INPUT`, `AUTO-DOC-OUTPUT`, and `AUTO-DOC-SECRETS` marker comments
+that are filled in by the tool.
+
+Regenerate all docs locally:
+
+```bash
+make generate-docs
+```
+
+Verify docs are up to date (CI runs this on every PR):
+
+```bash
+make check-docs
+```
+
+Install the auto-doc binary only (downloaded to `.bin/`):
+
+```bash
+make install-auto-doc
+```
+
+### Workflow docs
+
+Reusable workflow documentation lives in `docs/workflows/<workflow-name>.md`.
+Each file maps 1:1 to a `workflow_call` workflow in `.github/workflows/`.
+
+### Adding docs for a new action or workflow
+
+1. **Action** -- add `## Inputs` and `## Outputs` sections with marker comments
+   to the action's `README.md`:
+
+   ```markdown
+   ## Inputs
+
+   <!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
+   <!-- AUTO-DOC-INPUT:END -->
+
+   ## Outputs
+
+   <!-- AUTO-DOC-OUTPUT:START - Do not remove or modify this section -->
+   <!-- AUTO-DOC-OUTPUT:END -->
+   ```
+
+2. **Reusable workflow** -- create `docs/workflows/<name>.md` with `## Inputs`,
+   `## Outputs` (if applicable), and `## Secrets` marker sections.
+
+3. Run `make generate-docs` and commit the result.
+
 ## Versioning Actions
 
 ### Release-notification Action

--- a/docs/workflows/actionlint.md
+++ b/docs/workflows/actionlint.md
@@ -1,0 +1,19 @@
+# Actionlint
+
+Lints GitHub Actions workflow files using actionlint with reviewdog integration.
+
+## Inputs
+
+<!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
+
+|  INPUT   |  TYPE  | REQUIRED |       DEFAULT        |                          DESCRIPTION                          |
+|----------|--------|----------|----------------------|---------------------------------------------------------------|
+| reporter | string |  false   | `"github-pr-review"` | reviewdog reporter type (github-pr-review or github-pr-check) |
+
+<!-- AUTO-DOC-INPUT:END -->
+
+## Secrets
+
+<!-- AUTO-DOC-SECRETS:START - Do not remove or modify this section -->
+No secrets.
+<!-- AUTO-DOC-SECRETS:END -->

--- a/docs/workflows/auto-approve-bot-prs.md
+++ b/docs/workflows/auto-approve-bot-prs.md
@@ -1,0 +1,29 @@
+# Auto-approve bot PRs
+
+Reusable workflow that approves PRs from trusted bot accounts whose
+title or branch matches a known safe pattern. Wraps the composite action
+of the same name with GitHub App token minting and sparse checkout.
+
+## Inputs
+
+<!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
+
+|      INPUT      |  TYPE   | REQUIRED |                    DEFAULT                     |                               DESCRIPTION                               |
+|-----------------|---------|----------|------------------------------------------------|-------------------------------------------------------------------------|
+|     app-id      | string  |  false   |                                                | GitHub App ID for minting installation <br>tokens (preferred over PAT)  |
+|   auto-merge    | boolean |  false   |                     `true`                     |                    Enable auto-merge after approval                     |
+|  merge-method   | string  |  false   |                   `"squash"`                   |          Merge method for auto-merge (squash, merge, rebase)            |
+| trusted-authors | string  |  false   | `"renovate[bot],loft-bot,github-actions[bot]"` |               Comma-separated list of trusted bot logins                |
+
+<!-- AUTO-DOC-INPUT:END -->
+
+## Secrets
+
+<!-- AUTO-DOC-SECRETS:START - Do not remove or modify this section -->
+
+|     SECRET      | REQUIRED |                                  DESCRIPTION                                  |
+|-----------------|----------|-------------------------------------------------------------------------------|
+| app-private-key |  false   |       GitHub App private key (PEM) for <br>minting installation tokens        |
+| gh-access-token |  false   | GitHub PAT for approving PRs (legacy — use app-id + app-private-key instead)  |
+
+<!-- AUTO-DOC-SECRETS:END -->

--- a/docs/workflows/backport.md
+++ b/docs/workflows/backport.md
@@ -1,0 +1,19 @@
+# Backport
+
+Creates backport PRs when a merged PR is labeled with `backport/<branch>`.
+
+## Inputs
+
+<!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
+No inputs.
+<!-- AUTO-DOC-INPUT:END -->
+
+## Secrets
+
+<!-- AUTO-DOC-SECRETS:START - Do not remove or modify this section -->
+
+|     SECRET      | REQUIRED |             DESCRIPTION              |
+|-----------------|----------|--------------------------------------|
+| gh-access-token |   true   | GitHub PAT for creating backport PRs |
+
+<!-- AUTO-DOC-SECRETS:END -->

--- a/docs/workflows/claude-code-review.md
+++ b/docs/workflows/claude-code-review.md
@@ -1,0 +1,19 @@
+# Claude Code Review
+
+Runs Claude-powered code review on pull requests.
+
+## Inputs
+
+<!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
+No inputs.
+<!-- AUTO-DOC-INPUT:END -->
+
+## Secrets
+
+<!-- AUTO-DOC-SECRETS:START - Do not remove or modify this section -->
+
+|      SECRET       | REQUIRED |                  DESCRIPTION                  |
+|-------------------|----------|-----------------------------------------------|
+| anthropic-api-key |   true   | Anthropic API key for Claude Code <br>Review  |
+
+<!-- AUTO-DOC-SECRETS:END -->

--- a/docs/workflows/claude.md
+++ b/docs/workflows/claude.md
@@ -1,0 +1,19 @@
+# Claude
+
+Runs the Claude Code agent on pull request comment triggers.
+
+## Inputs
+
+<!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
+No inputs.
+<!-- AUTO-DOC-INPUT:END -->
+
+## Secrets
+
+<!-- AUTO-DOC-SECRETS:START - Do not remove or modify this section -->
+
+|      SECRET       | REQUIRED |                 DESCRIPTION                  |
+|-------------------|----------|----------------------------------------------|
+| anthropic-api-key |   true   | Anthropic API key for Claude Code <br>agent  |
+
+<!-- AUTO-DOC-SECRETS:END -->

--- a/docs/workflows/clean-github-cache.md
+++ b/docs/workflows/clean-github-cache.md
@@ -1,0 +1,15 @@
+# Clean GitHub Cache
+
+Cleans up GitHub Actions caches for closed pull requests.
+
+## Inputs
+
+<!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
+No inputs.
+<!-- AUTO-DOC-INPUT:END -->
+
+## Secrets
+
+<!-- AUTO-DOC-SECRETS:START - Do not remove or modify this section -->
+No secrets.
+<!-- AUTO-DOC-SECRETS:END -->

--- a/docs/workflows/cleanup-backport-branches.md
+++ b/docs/workflows/cleanup-backport-branches.md
@@ -1,0 +1,23 @@
+# Cleanup Backport Branches
+
+Deletes stale backport branches whose parent PR has been merged or closed.
+
+## Inputs
+
+<!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
+
+|  INPUT  |  TYPE   | REQUIRED | DEFAULT | DESCRIPTION  |
+|---------|---------|----------|---------|--------------|
+| dry-run | boolean |  false   | `false` | Dry run mode |
+
+<!-- AUTO-DOC-INPUT:END -->
+
+## Secrets
+
+<!-- AUTO-DOC-SECRETS:START - Do not remove or modify this section -->
+
+|     SECRET      | REQUIRED |                     DESCRIPTION                     |
+|-----------------|----------|-----------------------------------------------------|
+| gh-access-token |   true   | GitHub PAT with repo scope for <br>branch deletion  |
+
+<!-- AUTO-DOC-SECRETS:END -->

--- a/docs/workflows/cleanup-head-charts.md
+++ b/docs/workflows/cleanup-head-charts.md
@@ -1,0 +1,27 @@
+# Cleanup Head Charts
+
+Removes old head chart versions from ChartMuseum, keeping the N most recent.
+
+## Inputs
+
+<!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
+
+|      INPUT       |  TYPE   | REQUIRED | DEFAULT |                               DESCRIPTION                               |
+|------------------|---------|----------|---------|-------------------------------------------------------------------------|
+| chart-museum-url | string  |   true   |         |           ChartMuseum base URL (e.g. https://charts.loft.sh)            |
+|    chart-name    | string  |   true   |         |  Chart name to clean up (e.g. vcluster-head, vcluster-platform-head)    |
+|     dry-run      | boolean |  false   | `false` | List versions that would be deleted <br>without actually deleting them  |
+|   max-versions   | number  |  false   |  `50`   |                   Maximum number of versions to keep                    |
+
+<!-- AUTO-DOC-INPUT:END -->
+
+## Secrets
+
+<!-- AUTO-DOC-SECRETS:START - Do not remove or modify this section -->
+
+|        SECRET         | REQUIRED |     DESCRIPTION      |
+|-----------------------|----------|----------------------|
+| chart-museum-password |   true   | ChartMuseum password |
+|   chart-museum-user   |   true   | ChartMuseum username |
+
+<!-- AUTO-DOC-SECRETS:END -->

--- a/docs/workflows/conflict-check.md
+++ b/docs/workflows/conflict-check.md
@@ -1,0 +1,19 @@
+# Conflict Check
+
+Labels PRs that have merge conflicts and posts a comment asking the author to rebase.
+
+## Inputs
+
+<!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
+No inputs.
+<!-- AUTO-DOC-INPUT:END -->
+
+## Secrets
+
+<!-- AUTO-DOC-SECRETS:START - Do not remove or modify this section -->
+
+|     SECRET      | REQUIRED |           DESCRIPTION            |
+|-----------------|----------|----------------------------------|
+| gh-access-token |   true   | GitHub PAT for commenting on PRs |
+
+<!-- AUTO-DOC-SECRETS:END -->

--- a/docs/workflows/detect-changes.md
+++ b/docs/workflows/detect-changes.md
@@ -1,0 +1,29 @@
+# Detect Changes
+
+Detects whether specified file paths have changed in a pull request.
+
+## Inputs
+
+<!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
+
+| INPUT |  TYPE  | REQUIRED | DEFAULT |                               DESCRIPTION                                |
+|-------|--------|----------|---------|--------------------------------------------------------------------------|
+| paths | string |   true   |         | Glob pattern(s) to check for changes <br>(comma-separated or YAML list)  |
+
+<!-- AUTO-DOC-INPUT:END -->
+
+## Outputs
+
+<!-- AUTO-DOC-OUTPUT:START - Do not remove or modify this section -->
+
+|   OUTPUT    |                    VALUE                    |                     DESCRIPTION                      |
+|-------------|---------------------------------------------|------------------------------------------------------|
+| has_changed | `"${{ jobs.changes.outputs.has_changed }}"` | Whether the specified directories/files have changed |
+
+<!-- AUTO-DOC-OUTPUT:END -->
+
+## Secrets
+
+<!-- AUTO-DOC-SECRETS:START - Do not remove or modify this section -->
+No secrets.
+<!-- AUTO-DOC-SECRETS:END -->

--- a/docs/workflows/notify-release.md
+++ b/docs/workflows/notify-release.md
@@ -1,0 +1,29 @@
+# Notify Release
+
+Sends a Slack notification to #product-releases when a new version is published.
+
+## Inputs
+
+<!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
+
+|      INPUT      |  TYPE   | REQUIRED |   DEFAULT   |                                   DESCRIPTION                                   |
+|-----------------|---------|----------|-------------|---------------------------------------------------------------------------------|
+|     dry-run     | boolean |  false   |   `false`   |    Validate inputs and workflow structure without <br>sending notifications     |
+|  previous_tag   | string  |  false   |             |  The previous tag for changelog comparison <br>(required when status=success)   |
+|     product     | string  |   true   |             |                 Product name (e.g. vCluster, vCluster Platform)                 |
+|       ref       | string  |  false   |             |                The git ref to checkout (defaults to github.ref)                 |
+| release_version | string  |   true   |             |                      The release version tag (e.g. v1.2.3)                      |
+|     status      | string  |  false   | `"success"` | Release status: success, failure, cancelled, or <br>skipped (default: success)  |
+|   target_repo   | string  |   true   |             |                    Target repository (e.g. loft-sh/vcluster)                    |
+
+<!-- AUTO-DOC-INPUT:END -->
+
+## Secrets
+
+<!-- AUTO-DOC-SECRETS:START - Do not remove or modify this section -->
+
+|               SECRET               | REQUIRED |                   DESCRIPTION                    |
+|------------------------------------|----------|--------------------------------------------------|
+| SLACK_WEBHOOK_URL_PRODUCT_RELEASES |   true   | Slack incoming webhook URL for #product-releases |
+
+<!-- AUTO-DOC-SECRETS:END -->

--- a/docs/workflows/validate-renovate.md
+++ b/docs/workflows/validate-renovate.md
@@ -1,0 +1,15 @@
+# Validate Renovate Config
+
+Validates Renovate configuration files when they change in a pull request.
+
+## Inputs
+
+<!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
+No inputs.
+<!-- AUTO-DOC-INPUT:END -->
+
+## Secrets
+
+<!-- AUTO-DOC-SECRETS:START - Do not remove or modify this section -->
+No secrets.
+<!-- AUTO-DOC-SECRETS:END -->


### PR DESCRIPTION
## Summary

- Integrate [tj-actions/auto-doc](https://github.com/tj-actions/auto-doc) (v3.6.0) to auto-generate input/output/secrets documentation from `action.yml` and reusable workflow YAML
- Add Makefile targets (`install-auto-doc`, `generate-docs`, `check-docs`) for local development and CI validation
- Add `check-docs.yaml` CI workflow that fails PRs when docs drift from source YAML
- Replace hand-written tables in all 10 action READMEs with auto-doc marker comments
- Create `docs/workflows/` with generated docs for all 12 reusable workflows
- Create missing README for `auto-approve-bot-prs` action

## Test plan

- [x] `make generate-docs` succeeds and is idempotent (running twice produces no further diff)
- [x] `make lint` passes (actionlint + zizmor clean on new `check-docs.yaml`)
- [ ] `check-docs.yaml` CI workflow triggers on this PR and passes