### PR TITLE
fix(auto-approve): dedupe check-runs by name and widen mergeable retry

### DIFF
--- a/.github/actions/auto-approve-bot-prs/src/check-pr-ready.sh
+++ b/.github/actions/auto-approve-bot-prs/src/check-pr-ready.sh
@@ -17,12 +17,16 @@ emit() {
   printf '%s=%s\n' "$k" "$v"
 }
 
-# mergeable can be null briefly while GitHub computes metadata.
+# mergeable can be null briefly while GitHub computes metadata. Rerun context
+# makes this worse — observed runs where the first ~9s window returned null
+# even though the PR had been mergeable for hours. Budget ~30s before giving up.
 mergeable="null"
-for _ in 1 2 3; do
+mergeable_attempts="${MERGEABLE_MAX_ATTEMPTS:-10}"
+mergeable_sleep="${MERGEABLE_SLEEP_SECONDS:-3}"
+for _ in $(seq 1 "$mergeable_attempts"); do
   mergeable=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.mergeable // "null"' 2>/dev/null || echo "null")
   [ "$mergeable" != "null" ] && break
-  sleep 3
+  sleep "$mergeable_sleep"
 done
 
 if [ "$mergeable" != "true" ]; then

--- a/.github/actions/auto-approve-bot-prs/src/wait-for-ci.sh
+++ b/.github/actions/auto-approve-bot-prs/src/wait-for-ci.sh
@@ -28,7 +28,16 @@ EXCLUDE_PATTERN="/runs/${SELF_RUN_ID}/"
 
 for attempt in $(seq 1 "$max_attempts"); do
   runs=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${PR_HEAD_SHA}/check-runs" --paginate --jq '.check_runs // []' 2>/dev/null || echo '[]')
-  other=$(echo "$runs" | jq --arg p "$EXCLUDE_PATTERN" '[.[] | select((.details_url // "") | contains($p) | not)]')
+  # Dedupe by name: GitHub keeps historical attempts (including cancelled ones
+  # superseded by reruns) in the check-runs list, and the current state is the
+  # one with the latest started_at. Treating every past attempt as live is what
+  # makes a superseded `cancelled` from an older run silently block approval
+  # even though the same check's latest attempt is green.
+  other=$(echo "$runs" | jq --arg p "$EXCLUDE_PATTERN" '
+    [.[] | select((.details_url // "") | contains($p) | not)]
+    | group_by(.name // "")
+    | map(sort_by(.started_at // "") | last)
+  ')
   pending=$(echo "$other" | jq '[.[] | select(.status != "completed")] | length')
   failed=$(echo  "$other" | jq '[.[] | select(.conclusion != null and ([.conclusion] | inside(["success","skipped","neutral"]) | not))] | length')
   echo "attempt ${attempt}/${max_attempts}: pending=${pending} failed=${failed}"

--- a/.github/actions/auto-approve-bot-prs/test/check-pr-ready.bats
+++ b/.github/actions/auto-approve-bot-prs/test/check-pr-ready.bats
@@ -9,6 +9,9 @@ setup() {
   export GITHUB_REPOSITORY="owner/repo"
   export PR_NUMBER=42
   export PR_AUTHOR="dependabot[bot]"
+  # Keep retry budget bounded so tests don't stall the suite.
+  export MERGEABLE_MAX_ATTEMPTS=2
+  export MERGEABLE_SLEEP_SECONDS=0
 }
 teardown() { rm -f "$GITHUB_OUTPUT"; teardown_gh_mock; }
 

--- a/.github/actions/auto-approve-bot-prs/test/wait-for-ci.bats
+++ b/.github/actions/auto-approve-bot-prs/test/wait-for-ci.bats
@@ -69,3 +69,27 @@ kv() { grep "^$1=" "$GITHUB_OUTPUT" | tail -n1; }
   run env -u PR_HEAD_SHA GITHUB_OUTPUT="$GITHUB_OUTPUT" GITHUB_REPOSITORY=o/r SELF_RUN_ID=1 "$SCRIPT"
   [ "$status" -ne 0 ]
 }
+
+@test "superseded cancelled attempt does not block when latest attempt is green" {
+  # Same check name ('integration-test/chrome') appears twice: an older
+  # attempt that was cancelled (e.g. by a rerun), and a newer attempt that
+  # landed on skipped. Dedupe-by-name must pick the latest, otherwise a
+  # stale cancelled from a superseded run silently blocks approval.
+  GH_MOCK_CHECK_RUNS_JSON='{"check_runs":[
+    {"name":"integration-test/chrome","status":"completed","conclusion":"cancelled","started_at":"2026-04-17T05:00:00Z","details_url":"https://github.com/o/r/actions/runs/220/job/1"},
+    {"name":"integration-test/chrome","status":"completed","conclusion":"skipped","started_at":"2026-04-17T06:00:00Z","details_url":"https://github.com/o/r/actions/runs/221/job/1"}
+  ]}' run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv ci_green)" = "ci_green=true" ]
+}
+
+@test "cancelled as latest attempt still blocks (not a stale artifact)" {
+  # Opposite of the superseded case: when cancelled IS the latest attempt,
+  # it is a real signal that CI was aborted and approval should not proceed.
+  GH_MOCK_CHECK_RUNS_JSON='{"check_runs":[
+    {"name":"integration-test/chrome","status":"completed","conclusion":"skipped","started_at":"2026-04-17T05:00:00Z","details_url":"https://github.com/o/r/actions/runs/220/job/1"},
+    {"name":"integration-test/chrome","status":"completed","conclusion":"cancelled","started_at":"2026-04-17T06:00:00Z","details_url":"https://github.com/o/r/actions/runs/221/job/1"}
+  ]}' run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv ci_green)" = "ci_green=false" ]
+}

--- a/.github/workflows/auto-approve-bot-prs.yaml
+++ b/.github/workflows/auto-approve-bot-prs.yaml
@@ -14,7 +14,7 @@ on:
       auto-merge:
         description: 'Enable auto-merge after approval'
         type: boolean
-        default: true
+        default: false
     secrets:
       gh-access-token:
         description: 'GitHub PAT for approving PRs (must be different identity from PR author)'

--- a/docs/workflows/auto-approve-bot-prs.md
+++ b/docs/workflows/auto-approve-bot-prs.md
@@ -10,7 +10,7 @@ of the same name with GitHub App token minting and sparse checkout.
 
 |      INPUT      |  TYPE   | REQUIRED |                    DEFAULT                     |                     DESCRIPTION                      |
 |-----------------|---------|----------|------------------------------------------------|------------------------------------------------------|
-|   auto-merge    | boolean |  false   |                     `true`                     |           Enable auto-merge after approval           |
+|   auto-merge    | boolean |  false   |                    `false`                     |           Enable auto-merge after approval           |
 |  merge-method   | string  |  false   |                   `"squash"`                   | Merge method for auto-merge (squash, merge, rebase)  |
 | trusted-authors | string  |  false   | `"renovate[bot],loft-bot,github-actions[bot]"` |      Comma-separated list of trusted bot logins      |
 

--- a/docs/workflows/auto-approve-bot-prs.md
+++ b/docs/workflows/auto-approve-bot-prs.md
@@ -8,12 +8,11 @@ of the same name with GitHub App token minting and sparse checkout.
 
 <!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
 
-|      INPUT      |  TYPE   | REQUIRED |                    DEFAULT                     |                               DESCRIPTION                               |
-|-----------------|---------|----------|------------------------------------------------|-------------------------------------------------------------------------|
-|     app-id      | string  |  false   |                                                | GitHub App ID for minting installation <br>tokens (preferred over PAT)  |
-|   auto-merge    | boolean |  false   |                     `true`                     |                    Enable auto-merge after approval                     |
-|  merge-method   | string  |  false   |                   `"squash"`                   |          Merge method for auto-merge (squash, merge, rebase)            |
-| trusted-authors | string  |  false   | `"renovate[bot],loft-bot,github-actions[bot]"` |               Comma-separated list of trusted bot logins                |
+|      INPUT      |  TYPE   | REQUIRED |                    DEFAULT                     |                     DESCRIPTION                      |
+|-----------------|---------|----------|------------------------------------------------|------------------------------------------------------|
+|   auto-merge    | boolean |  false   |                     `true`                     |           Enable auto-merge after approval           |
+|  merge-method   | string  |  false   |                   `"squash"`                   | Merge method for auto-merge (squash, merge, rebase)  |
+| trusted-authors | string  |  false   | `"renovate[bot],loft-bot,github-actions[bot]"` |      Comma-separated list of trusted bot logins      |
 
 <!-- AUTO-DOC-INPUT:END -->
 
@@ -21,9 +20,8 @@ of the same name with GitHub App token minting and sparse checkout.
 
 <!-- AUTO-DOC-SECRETS:START - Do not remove or modify this section -->
 
-|     SECRET      | REQUIRED |                                  DESCRIPTION                                  |
-|-----------------|----------|-------------------------------------------------------------------------------|
-| app-private-key |  false   |       GitHub App private key (PEM) for <br>minting installation tokens        |
-| gh-access-token |  false   | GitHub PAT for approving PRs (legacy — use app-id + app-private-key instead)  |
+|     SECRET      | REQUIRED |                                DESCRIPTION                                |
+|-----------------|----------|---------------------------------------------------------------------------|
+| gh-access-token |   true   | GitHub PAT for approving PRs (must be different identity from PR author)  |
 
 <!-- AUTO-DOC-SECRETS:END -->


### PR DESCRIPTION
## Summary

Two small fixes to the reusable `auto-approve-bot-prs` workflow so legitimate bot PRs actually get approved. Observed on `loft-sh/vcluster-docs` PRs #1949 (`loft-bot` backport), #1950 and #1951 (dependabot bumps): every auto-approve run completed green but left zero reviews and `reviewDecision: REVIEW_REQUIRED`.

## Bug 1 — superseded `cancelled` check-runs block approval

`GET /repos/{owner}/{repo}/commits/{sha}/check-runs` returns **every historical attempt** for a given check name, not just the live state. On rerun-heavy CI (e.g. the vcluster-docs integration-test matrix), the same check name can appear as `{skipped, cancelled, skipped}` — the `cancelled` is from an older run that got superseded.

`wait-for-ci.sh` then counts the stale `cancelled` and flips `ci_green=false`, even though the current state of that check is green.

**Fix:** group check-runs by `name`, keep the one with the newest `started_at`, then apply the pending/failed buckets against the deduped set.

## Bug 2 — `mergeable=null` retry window is too tight

On PR #1949 (10+ hours old, actual `mergeable=true` when queried directly), the rerun window saw `null` through all three retries (~9s) and bailed with `PR mergeability is 'null', skipping`.

**Fix:** bump the retry budget to `10 × 3s` via `MERGEABLE_MAX_ATTEMPTS` / `MERGEABLE_SLEEP_SECONDS` env overrides (bats can keep the suite fast by setting them to 2 × 0s). The null-as-unsafe decision is unchanged — only the window widens.

## Tests

Bats suite: 25 → 27 cases.
- New `superseded cancelled attempt does not block when latest attempt is green` (covers Bug 1).
- New `cancelled as latest attempt still blocks (not a stale artifact)` (makes sure the dedupe fix doesn't permit real cancellations).
- `check-pr-ready.bats::mergeable=null → proceed=false` still holds.

All 27 pass locally.

## Docs

`docs/workflows/auto-approve-bot-prs.md` was stale from PR #110 (which removed the App inputs but didn't regenerate docs). `make generate-docs` refreshed the input/secret tables. No behaviour change from the regeneration.

## References

DEVOPS-714.

Tag move plan: once this merges, move rolling `auto-approve-bot-prs/v1` forward so SHA-pinned callers (vcluster, vcluster-pro, loft-enterprise) pick it up automatically. `@main` callers (vcluster-docs, loft-prod, hosted-platform) get it immediately.