### PR TITLE
chore(run-ginkgo): drop --poll-progress-after/--poll-progress-interval flags

### DIFF
--- a/.github/actions/run-ginkgo/src/execute-tests.sh
+++ b/.github/actions/run-ginkgo/src/execute-tests.sh
@@ -13,8 +13,6 @@ GINKGO_ARGS=(
   "run"
   "--timeout=${TIMEOUT}"
   "--procs=${PROCS}"
-  "--poll-progress-after=20s"
-  "--poll-progress-interval=10s"
   "--github-output"
   "--json-report=${REPORTS_DIR}/report.json"
 )

--- a/.github/actions/run-ginkgo/test/execute-tests.bats
+++ b/.github/actions/run-ginkgo/test/execute-tests.bats
@@ -126,14 +126,6 @@ has_arg() {
   grep -q "\-\-json-report=" "$MOCK_ARGS_FILE"
 }
 
-@test "always includes --poll-progress-after" {
-  cd "$WORK_DIR"
-  export GINKGO_LABEL="suite"
-  run bash "$SCRIPT"
-  [ "$status" -eq 0 ]
-  has_arg "--poll-progress-after=20s"
-}
-
 # --- Additional flags ---
 
 @test "additional-ginkgo-flags are appended" {


### PR DESCRIPTION
## Summary
- Remove hardcoded `--poll-progress-after=20s` and `--poll-progress-interval=10s` from the ginkgo invocation in `run-ginkgo`.
- Drop the now-obsolete bats assertion that checked for `--poll-progress-after=20s`.

Callers who still want progress polling can pass it via `additional-ginkgo-flags`.

## Test plan
- [x] `make test-run-ginkgo` (32/32 pass)