### PR TITLE
feat(ai-pr-review): wire up openai provider via codex-action

### DIFF
--- a/.github/actions/ai-pr-review/README.md
+++ b/.github/actions/ai-pr-review/README.md
@@ -66,16 +66,16 @@ use the companion reusable workflow at
 
 <!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
 
-|       INPUT       |  TYPE  | REQUIRED |                     DEFAULT                     |                                                       DESCRIPTION                                                        |
-|-------------------|--------|----------|-------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------|
-|   allowed-bots    | string |  false   | `"renovate,dependabot,loft-bot,github-actions"` | Comma-separated bot logins this review runs <br>for (passed to claude-code-action `allowed_bots`). `*` allows all bots.  |
-| anthropic-api-key | string |  false   |                                                 |                                   Anthropic API key. Required when provider=anthropic.                                   |
-|      effort       | string |  false   |                   `"medium"`                    |                       Effort level (low | medium | high) — maps to <br>a provider-specific model.                        |
-|   github-token    | string |   true   |                                                 |                        Token used by claude-code-action to post <br>comments and read PR state.                          |
-|  openai-api-key   | string |  false   |                                                 |                                      OpenAI API key. Required when provider=openai.                                      |
-|      outcome      | string |   true   |                                                 | What the AI produces: `pr-comment` (single sticky comment) <br>or `inline-review` (inline comments on specific lines).   |
-|      prompt       | string |   true   |                                                 |                                Review instructions passed verbatim as the <br>AI prompt.                                 |
-|     provider      | string |   true   |                                                 |                                          AI provider: `anthropic` or `openai`.                                           |
+|       INPUT       |  TYPE  | REQUIRED |                     DEFAULT                     |                                                                                     DESCRIPTION                                                                                     |
+|-------------------|--------|----------|-------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|   allowed-bots    | string |  false   | `"renovate,dependabot,loft-bot,github-actions"` |                              Comma-separated bot logins this review runs <br>for (passed to claude-code-action `allowed_bots`). `*` allows all bots.                                |
+| anthropic-api-key | string |  false   |                                                 |                                                                Anthropic API key. Required when provider=anthropic.                                                                 |
+|      effort       | string |  false   |                   `"medium"`                    |                                                    Effort level (low | medium | high) — maps to <br>a provider-specific model.                                                      |
+|   github-token    | string |   true   |                                                 |                                                      Token used by claude-code-action to post <br>comments and read PR state.                                                       |
+|  openai-api-key   | string |  false   |                                                 |                                                                   OpenAI API key. Required when provider=openai.                                                                    |
+|      outcome      | string |   true   |                                                 | What the AI produces: `pr-comment` (a summary PR comment — sticky on anthropic, new per run on openai) or <br>`inline-review` (inline comments on specific lines, anthropic only).  |
+|      prompt       | string |   true   |                                                 |                                                             Review instructions passed verbatim as the <br>AI prompt.                                                               |
+|     provider      | string |   true   |                                                 |                                                                        AI provider: `anthropic` or `openai`.                                                                        |
 
 <!-- AUTO-DOC-INPUT:END -->
 

--- a/.github/actions/ai-pr-review/README.md
+++ b/.github/actions/ai-pr-review/README.md
@@ -16,14 +16,15 @@ Callers should set `continue-on-error: true` on the job.
 
 ## Effort → model
 
-| Effort | Anthropic            |
-|--------|----------------------|
-| low    | `claude-haiku-4-5`   |
-| medium | `claude-sonnet-4-6`  |
-| high   | `claude-opus-4-7`    |
+| Effort | Anthropic            | OpenAI          |
+|--------|----------------------|-----------------|
+| low    | `claude-haiku-4-5`   | `gpt-5.4-mini`  |
+| medium | `claude-sonnet-4-6`  | `gpt-5.3-codex` |
+| high   | `claude-opus-4-7`    | `gpt-5.4`       |
 
-`provider: openai` is reserved — selecting it today emits a notice and
-skips the review.
+`openai` + `inline-review` is unsupported (codex-action has no
+inline-comment surface) and degrades to a notice-level skip. Use
+`openai` + `pr-comment` or switch to `anthropic` for inline reviews.
 
 ## Usage
 
@@ -71,10 +72,10 @@ use the companion reusable workflow at
 | anthropic-api-key | string |  false   |                                                 |                                   Anthropic API key. Required when provider=anthropic.                                   |
 |      effort       | string |  false   |                   `"medium"`                    |                       Effort level (low | medium | high) — maps to <br>a provider-specific model.                        |
 |   github-token    | string |   true   |                                                 |                        Token used by claude-code-action to post <br>comments and read PR state.                          |
-|  openai-api-key   | string |  false   |                                                 |                                      OpenAI API key. Reserved for provider=openai.                                       |
+|  openai-api-key   | string |  false   |                                                 |                                      OpenAI API key. Required when provider=openai.                                      |
 |      outcome      | string |   true   |                                                 | What the AI produces: `pr-comment` (single sticky comment) <br>or `inline-review` (inline comments on specific lines).   |
 |      prompt       | string |   true   |                                                 |                                Review instructions passed verbatim as the <br>AI prompt.                                 |
-|     provider      | string |   true   |                                                 |                        AI provider. `anthropic` is implemented; `openai` <br>is reserved (stub).                         |
+|     provider      | string |   true   |                                                 |                                          AI provider: `anthropic` or `openai`.                                           |
 
 <!-- AUTO-DOC-INPUT:END -->
 
@@ -82,10 +83,10 @@ use the companion reusable workflow at
 
 <!-- AUTO-DOC-OUTPUT:START - Do not remove or modify this section -->
 
-|   OUTPUT   |  TYPE  |                                   DESCRIPTION                                   |
-|------------|--------|---------------------------------------------------------------------------------|
-| conclusion | string | `success` when the AI review ran; <br>`skipped` when stubbed or invalid input.  |
-|   reason   | string |                  One-line explanation when conclusion=skipped.                  |
+|   OUTPUT   |  TYPE  |                                                                     DESCRIPTION                                                                      |
+|------------|--------|------------------------------------------------------------------------------------------------------------------------------------------------------|
+| conclusion | string | `success` when the AI review ran; <br>`skipped` when the resolver vetoed the <br>run (invalid input, unsupported combo, or non-allowlisted author).  |
+|   reason   | string |                                                    One-line explanation when conclusion=skipped.                                                     |
 
 <!-- AUTO-DOC-OUTPUT:END -->
 

--- a/.github/actions/ai-pr-review/action.yml
+++ b/.github/actions/ai-pr-review/action.yml
@@ -16,7 +16,7 @@ inputs:
     description: 'Review instructions passed verbatim as the AI prompt.'
     required: true
   outcome:
-    description: 'What the AI produces: `pr-comment` (single sticky comment) or `inline-review` (inline comments on specific lines).'
+    description: 'What the AI produces: `pr-comment` (a summary PR comment — sticky on anthropic, new per run on openai) or `inline-review` (inline comments on specific lines, anthropic only).'
     required: true
   allowed-bots:
     description: 'Comma-separated bot logins this review runs for (passed to claude-code-action `allowed_bots`). `*` allows all bots.'
@@ -38,7 +38,7 @@ outputs:
     value: ${{ steps.conclusion.outputs.conclusion }}
   reason:
     description: 'One-line explanation when conclusion=skipped.'
-    value: ${{ steps.cfg.outputs.reason }}
+    value: ${{ steps.cfg.outputs.reason != '' && steps.cfg.outputs.reason || steps.author.outputs.reason }}
 
 runs:
   using: composite
@@ -114,27 +114,26 @@ runs:
         fi
         if [ "$allowed" = "true" ]; then
           echo "run=true" >> "$GITHUB_OUTPUT"
+          echo "reason=" >> "$GITHUB_OUTPUT"
           echo "::notice::ai-pr-review: author '$PR_AUTHOR' allowed — running codex review"
         else
+          skip_reason="author '$PR_AUTHOR' not in allowed-bots"
           echo "run=false" >> "$GITHUB_OUTPUT"
-          echo "::notice::ai-pr-review: author '$PR_AUTHOR' not in allowed-bots — skipping"
+          echo "reason=$skip_reason" >> "$GITHUB_OUTPUT"
+          echo "::notice::ai-pr-review: $skip_reason — skipping"
         fi
 
-    - name: Checkout PR merge ref (openai)
+    # head.sha is used (not refs/pull/N/merge) because merge refs are absent on
+    # conflicted PRs — common for the renovate/dependabot audience this targets.
+    # fetch-depth: 0 + default persist-credentials=true means the base branch is
+    # available for `git diff base...head` and no follow-up authenticated fetch
+    # is needed (would break on private caller repos with persist-credentials=false).
+    - name: Checkout PR head (openai)
       if: steps.cfg.outputs.proceed == 'true' && inputs.provider == 'openai' && steps.author.outputs.run == 'true'
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
-        ref: refs/pull/${{ github.event.pull_request.number }}/merge
-        persist-credentials: false
-
-    - name: Pre-fetch base and head refs (openai)
-      if: steps.cfg.outputs.proceed == 'true' && inputs.provider == 'openai' && steps.author.outputs.run == 'true'
-      shell: bash
-      env:
-        BASE_REF: ${{ github.event.pull_request.base.ref }}
-        PR_NUMBER: ${{ github.event.pull_request.number }}
-      run: |
-        git fetch --no-tags origin "$BASE_REF" "+refs/pull/${PR_NUMBER}/head"
+        ref: ${{ github.event.pull_request.head.sha }}
+        fetch-depth: 0
 
     - name: Codex PR review
       id: codex
@@ -169,9 +168,13 @@ runs:
       shell: bash
       env:
         PROCEED: ${{ steps.cfg.outputs.proceed }}
+        PROVIDER: ${{ inputs.provider }}
+        AUTHOR_RUN: ${{ steps.author.outputs.run }}
       run: |
-        if [ "$PROCEED" = "true" ]; then
-          echo "conclusion=success" >> "$GITHUB_OUTPUT"
-        else
+        if [ "$PROCEED" != "true" ]; then
           echo "conclusion=skipped" >> "$GITHUB_OUTPUT"
+        elif [ "$PROVIDER" = "openai" ] && [ "$AUTHOR_RUN" != "true" ]; then
+          echo "conclusion=skipped" >> "$GITHUB_OUTPUT"
+        else
+          echo "conclusion=success" >> "$GITHUB_OUTPUT"
         fi

--- a/.github/actions/ai-pr-review/action.yml
+++ b/.github/actions/ai-pr-review/action.yml
@@ -125,15 +125,16 @@ runs:
 
     # head.sha is used (not refs/pull/N/merge) because merge refs are absent on
     # conflicted PRs — common for the renovate/dependabot audience this targets.
-    # fetch-depth: 0 + default persist-credentials=true means the base branch is
-    # available for `git diff base...head` and no follow-up authenticated fetch
-    # is needed (would break on private caller repos with persist-credentials=false).
+    # fetch-depth: 0 pulls the base branch during the authenticated checkout
+    # itself (for `git diff base...head`), so no follow-up fetch is needed and
+    # persist-credentials: false is safe (zizmor: avoid artipacked).
     - name: Checkout PR head (openai)
       if: steps.cfg.outputs.proceed == 'true' && inputs.provider == 'openai' && steps.author.outputs.run == 'true'
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
+        persist-credentials: false
 
     - name: Codex PR review
       id: codex

--- a/.github/actions/ai-pr-review/action.yml
+++ b/.github/actions/ai-pr-review/action.yml
@@ -6,7 +6,7 @@ description: |
   every failure mode degrades to a notice-level skip.
 inputs:
   provider:
-    description: 'AI provider. `anthropic` is implemented; `openai` is reserved (stub).'
+    description: 'AI provider: `anthropic` or `openai`.'
     required: true
   effort:
     description: 'Effort level (low | medium | high) — maps to a provider-specific model.'
@@ -26,7 +26,7 @@ inputs:
     description: 'Anthropic API key. Required when provider=anthropic.'
     required: false
   openai-api-key:
-    description: 'OpenAI API key. Reserved for provider=openai.'
+    description: 'OpenAI API key. Required when provider=openai.'
     required: false
   github-token:
     description: 'Token used by claude-code-action to post comments and read PR state.'
@@ -34,7 +34,7 @@ inputs:
 
 outputs:
   conclusion:
-    description: '`success` when the AI review ran; `skipped` when stubbed or invalid input.'
+    description: '`success` when the AI review ran; `skipped` when the resolver vetoed the run (invalid input, unsupported combo, or non-allowlisted author).'
     value: ${{ steps.conclusion.outputs.conclusion }}
   reason:
     description: 'One-line explanation when conclusion=skipped.'
@@ -84,6 +84,84 @@ runs:
           --model ${{ steps.cfg.outputs.model }}
           --mcp-config '{"mcpServers":{"context7":{"command":"npx","args":["-y","@upstash/context7-mcp"]},"sequential-thinking":{"command":"npx","args":["-y","@modelcontextprotocol/server-sequential-thinking"]}}}'
           --allowedTools "Read,Glob,Grep,LS,Bash(git diff:*),Bash(git log:*),Bash(gh pr view:*),Bash(gh pr diff:*),mcp__context7__*,mcp__sequential-thinking__*${{ steps.cfg.outputs.tools_suffix }}"
+
+    # --- openai branch ----------------------------------------------------
+    # claude-code-action applies `allowed_bots` internally; codex-action
+    # doesn't have an equivalent (its `allow-bots` is boolean), so we
+    # reproduce the bot-author filter here before spending tokens.
+    - name: Check PR author against allowed-bots (openai)
+      id: author
+      if: steps.cfg.outputs.proceed == 'true' && inputs.provider == 'openai'
+      shell: bash
+      env:
+        PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        ALLOWED_BOTS: ${{ inputs.allowed-bots }}
+      run: |
+        set -eo pipefail
+        allowed=false
+        if [ "$ALLOWED_BOTS" = "*" ]; then
+          allowed=true
+        else
+          IFS=',' read -ra bots <<< "$ALLOWED_BOTS"
+          for bot in "${bots[@]}"; do
+            bot="${bot// /}"
+            [ -z "$bot" ] && continue
+            if [ "$PR_AUTHOR" = "$bot" ] || [ "$PR_AUTHOR" = "${bot}[bot]" ]; then
+              allowed=true
+              break
+            fi
+          done
+        fi
+        if [ "$allowed" = "true" ]; then
+          echo "run=true" >> "$GITHUB_OUTPUT"
+          echo "::notice::ai-pr-review: author '$PR_AUTHOR' allowed — running codex review"
+        else
+          echo "run=false" >> "$GITHUB_OUTPUT"
+          echo "::notice::ai-pr-review: author '$PR_AUTHOR' not in allowed-bots — skipping"
+        fi
+
+    - name: Checkout PR merge ref (openai)
+      if: steps.cfg.outputs.proceed == 'true' && inputs.provider == 'openai' && steps.author.outputs.run == 'true'
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        ref: refs/pull/${{ github.event.pull_request.number }}/merge
+        persist-credentials: false
+
+    - name: Pre-fetch base and head refs (openai)
+      if: steps.cfg.outputs.proceed == 'true' && inputs.provider == 'openai' && steps.author.outputs.run == 'true'
+      shell: bash
+      env:
+        BASE_REF: ${{ github.event.pull_request.base.ref }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+      run: |
+        git fetch --no-tags origin "$BASE_REF" "+refs/pull/${PR_NUMBER}/head"
+
+    - name: Codex PR review
+      id: codex
+      if: steps.cfg.outputs.proceed == 'true' && inputs.provider == 'openai' && steps.author.outputs.run == 'true'
+      uses: openai/codex-action@c25d10f3f498316d4b2496cc4c6dd58057a7b031 # v1.6
+      with:
+        openai-api-key: ${{ inputs.openai-api-key }} # zizmor: ignore[secrets-outside-env] -- API key passed via composite input, not a repo secret
+        model: ${{ steps.cfg.outputs.model }}
+        effort: ${{ inputs.effort }}
+        sandbox: read-only
+        safety-strategy: drop-sudo
+        allow-bots: 'true'
+        prompt: |
+          ${{ inputs.prompt }}
+
+          ${{ steps.cfg.outputs.guidance }}
+
+    - name: Post Codex feedback as PR comment
+      if: steps.cfg.outputs.proceed == 'true' && inputs.provider == 'openai' && steps.author.outputs.run == 'true' && steps.codex.outputs.final-message != ''
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        REPO: ${{ github.repository }}
+        BODY: ${{ steps.codex.outputs.final-message }}
+      run: |
+        printf '%s\n' "$BODY" | gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file -
 
     - name: Emit conclusion
       id: conclusion

--- a/.github/actions/ai-pr-review/src/resolve-config.sh
+++ b/.github/actions/ai-pr-review/src/resolve-config.sh
@@ -53,8 +53,9 @@ case "$INPUT_PROVIDER:$INPUT_EFFORT" in
   anthropic:medium) model='claude-sonnet-4-6' ;;
   anthropic:high)   model='claude-opus-4-7' ;;
   anthropic:*)      skip "invalid effort '$INPUT_EFFORT' — valid: low, medium, high" ;;
-  openai:low|openai:medium|openai:high)
-                    skip "provider=openai not yet implemented — use provider=anthropic" ;;
+  openai:low)       model='gpt-5.4-mini' ;;
+  openai:medium)    model='gpt-5.3-codex' ;;
+  openai:high)      model='gpt-5.4' ;;
   openai:*)         skip "invalid effort '$INPUT_EFFORT' — valid: low, medium, high" ;;
   *)                skip "invalid provider '$INPUT_PROVIDER' — valid: anthropic, openai" ;;
 esac
@@ -66,6 +67,12 @@ case "$INPUT_OUTCOME" in
     tools_suffix=''
     ;;
   inline-review)
+    # Inline comments require the github-inline-comment MCP surface that
+    # only claude-code-action wires up. codex-action has no equivalent,
+    # so openai+inline-review degrades to a skip (contract: never hard-fail).
+    if [ "$INPUT_PROVIDER" = "openai" ]; then
+      skip "outcome=inline-review not supported for provider=openai — use outcome=pr-comment"
+    fi
     guidance='Outcome policy: post inline comments on specific lines for concrete, actionable findings. A short summary comment is optional.'
     tools_suffix=',mcp__github_inline_comment__create_inline_comment'
     ;;

--- a/.github/actions/ai-pr-review/test/resolve-config.bats
+++ b/.github/actions/ai-pr-review/test/resolve-config.bats
@@ -78,27 +78,36 @@ assert_guidance_contains() {
   assert_guidance_contains "inline comments on specific lines"
 }
 
-# --- openai stub -------------------------------------------------------------
+# --- openai happy path -------------------------------------------------------
 
-@test "openai:low → proceed=false, reason mentions not yet implemented" {
+@test "openai:low → model=gpt-5.4-mini, proceed=true" {
   run_script openai low pr-comment
   [ "$status" -eq 0 ]
-  assert_kv proceed false
-  grep -q 'reason=.*not yet implemented' "$GITHUB_OUTPUT" || {
-    cat "$GITHUB_OUTPUT"; return 1;
-  }
+  assert_kv proceed true
+  assert_kv model gpt-5.4-mini
 }
 
-@test "openai:medium → proceed=false (stubbed)" {
+@test "openai:medium → model=gpt-5.3-codex, proceed=true" {
+  run_script openai medium pr-comment
+  [ "$status" -eq 0 ]
+  assert_kv proceed true
+  assert_kv model gpt-5.3-codex
+}
+
+@test "openai:high → model=gpt-5.4, proceed=true" {
+  run_script openai high pr-comment
+  [ "$status" -eq 0 ]
+  assert_kv proceed true
+  assert_kv model gpt-5.4
+}
+
+@test "openai + inline-review → proceed=false, reason mentions unsupported outcome" {
   run_script openai medium inline-review
   [ "$status" -eq 0 ]
   assert_kv proceed false
-}
-
-@test "openai:high → proceed=false (stubbed)" {
-  run_script openai high pr-comment
-  [ "$status" -eq 0 ]
-  assert_kv proceed false
+  grep -q 'reason=.*inline-review not supported for provider=openai' "$GITHUB_OUTPUT" || {
+    cat "$GITHUB_OUTPUT"; return 1;
+  }
 }
 
 # --- input validation --------------------------------------------------------

--- a/.github/workflows/ai-pr-review.yaml
+++ b/.github/workflows/ai-pr-review.yaml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       provider:
-        description: 'AI provider: `anthropic` (implemented) or `openai` (reserved stub).'
+        description: 'AI provider: `anthropic` or `openai`.'
         type: string
         required: true
       effort:
@@ -30,13 +30,10 @@ on:
         type: number
         required: false
         default: 15
-    secrets:
-      anthropic-api-key:
-        description: 'Anthropic API key. Required when provider=anthropic.'
-        required: false
-      openai-api-key:
-        description: 'OpenAI API key. Reserved for provider=openai.'
-        required: false
+    # API keys are not declared here — callers must use `secrets: inherit`
+    # so the reusable workflow can read the org-level ANTHROPIC_API_KEY /
+    # OPENAI_API_KEY secrets directly. This avoids every caller having to
+    # plumb the key through their own `secrets:` block.
 
 concurrency:
   group: ai-pr-review-${{ github.event.pull_request.number }}
@@ -69,6 +66,6 @@ jobs:
           prompt: ${{ inputs.prompt }}
           outcome: ${{ inputs.outcome }}
           allowed-bots: ${{ inputs.allowed-bots }}
-          anthropic-api-key: ${{ secrets.anthropic-api-key }} # zizmor: ignore[secrets-outside-env] -- API key passed via workflow_call, not a repo secret
-          openai-api-key: ${{ secrets.openai-api-key }} # zizmor: ignore[secrets-outside-env] -- API key passed via workflow_call, not a repo secret
+          anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }} # zizmor: ignore[secrets-outside-env] -- inherited org secret, not a workflow_call input
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }} # zizmor: ignore[secrets-outside-env] -- inherited org secret, not a workflow_call input
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ai-pr-review.yaml
+++ b/.github/workflows/ai-pr-review.yaml
@@ -30,10 +30,17 @@ on:
         type: number
         required: false
         default: 15
-    # API keys are not declared here — callers must use `secrets: inherit`
-    # so the reusable workflow can read the org-level ANTHROPIC_API_KEY /
-    # OPENAI_API_KEY secrets directly. This avoids every caller having to
-    # plumb the key through their own `secrets:` block.
+    # This repo is public — callers must pass the provider API key
+    # explicitly via `secrets:`. Do NOT `secrets: inherit`, and do NOT
+    # access `secrets.*` directly here; both would forward every caller's
+    # org secrets into this workflow.
+    secrets:
+      anthropic-api-key:
+        description: 'Anthropic API key. Required when provider=anthropic.'
+        required: false
+      openai-api-key:
+        description: 'OpenAI API key. Required when provider=openai.'
+        required: false
 
 concurrency:
   group: ai-pr-review-${{ github.event.pull_request.number }}
@@ -66,6 +73,6 @@ jobs:
           prompt: ${{ inputs.prompt }}
           outcome: ${{ inputs.outcome }}
           allowed-bots: ${{ inputs.allowed-bots }}
-          anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }} # zizmor: ignore[secrets-outside-env] -- inherited org secret, not a workflow_call input
-          openai-api-key: ${{ secrets.OPENAI_API_KEY }} # zizmor: ignore[secrets-outside-env] -- inherited org secret, not a workflow_call input
+          anthropic-api-key: ${{ secrets.anthropic-api-key }} # zizmor: ignore[secrets-outside-env] -- API key passed via workflow_call, not a repo secret
+          openai-api-key: ${{ secrets.openai-api-key }} # zizmor: ignore[secrets-outside-env] -- API key passed via workflow_call, not a repo secret
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-ai-pr-review.yaml
+++ b/.github/workflows/test-ai-pr-review.yaml
@@ -26,7 +26,7 @@ jobs:
   # during this PR's CI. Human-authored PRs hit claude-code-action's
   # allowed_bots filter and short-circuit before the API call, so the job
   # reports success without spending tokens.
-  composite-smoke:
+  composite-smoke-anthropic:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -45,4 +45,28 @@ jobs:
           prompt: |
             Smoke test. Do not post any review comments.
           anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  # Smoke test the openai branch. The composite's own bot-author filter
+  # short-circuits before calling codex-action on human-authored PRs,
+  # so this reports success without spending tokens.
+  composite-smoke-openai:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/ai-pr-review
+        with:
+          provider: openai
+          effort: low
+          outcome: pr-comment
+          prompt: |
+            Smoke test. Do not post any review comments.
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/workflows/ai-pr-review.md
+++ b/docs/workflows/ai-pr-review.md
@@ -11,7 +11,6 @@ handles checkout, permissions, and secret plumbing for a job-level call.
 jobs:
   risk-review:
     uses: loft-sh/github-actions/.github/workflows/ai-pr-review.yaml@main
-    secrets: inherit
     with:
       provider: anthropic
       effort: medium
@@ -20,11 +19,14 @@ jobs:
         Review this PR for risk CI cannot catch: major version bumps
         where the diff is more than a version number, removed public
         exports, breaking API changes, changed defaults.
+    secrets:
+      anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+      # openai-api-key: ${{ secrets.OPENAI_API_KEY }}   # when provider=openai
 ```
 
-`secrets: inherit` lets the reusable workflow read the org-level
-`ANTHROPIC_API_KEY` / `OPENAI_API_KEY` secrets directly — callers don't
-need to plumb them through `with:` or `secrets:`.
+Pass only the provider-specific key your job needs. This repo is
+public — do **not** use `secrets: inherit`, which would forward every
+org-level secret into the reusable workflow.
 
 Compose with `auto-approve-bot-prs.yaml` as a sibling job to get an AI
 review alongside auto-approve on bot PRs.
@@ -63,5 +65,10 @@ review alongside auto-approve on bot PRs.
 ## Secrets
 
 <!-- AUTO-DOC-SECRETS:START - Do not remove or modify this section -->
-No secrets.
+
+|      SECRET       | REQUIRED |                     DESCRIPTION                      |
+|-------------------|----------|------------------------------------------------------|
+| anthropic-api-key |  false   | Anthropic API key. Required when provider=anthropic. |
+|  openai-api-key   |  false   |    OpenAI API key. Required when provider=openai.    |
+
 <!-- AUTO-DOC-SECRETS:END -->

--- a/docs/workflows/ai-pr-review.md
+++ b/docs/workflows/ai-pr-review.md
@@ -11,6 +11,7 @@ handles checkout, permissions, and secret plumbing for a job-level call.
 jobs:
   risk-review:
     uses: loft-sh/github-actions/.github/workflows/ai-pr-review.yaml@main
+    secrets: inherit
     with:
       provider: anthropic
       effort: medium
@@ -19,25 +20,30 @@ jobs:
         Review this PR for risk CI cannot catch: major version bumps
         where the diff is more than a version number, removed public
         exports, breaking API changes, changed defaults.
-    secrets:
-      anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
 ```
+
+`secrets: inherit` lets the reusable workflow read the org-level
+`ANTHROPIC_API_KEY` / `OPENAI_API_KEY` secrets directly — callers don't
+need to plumb them through `with:` or `secrets:`.
 
 Compose with `auto-approve-bot-prs.yaml` as a sibling job to get an AI
 review alongside auto-approve on bot PRs.
 
 ## Effort → model
 
-| Effort | Anthropic            |
-|--------|----------------------|
-| low    | `claude-haiku-4-5`   |
-| medium | `claude-sonnet-4-6`  |
-| high   | `claude-opus-4-7`    |
+| Effort | Anthropic            | OpenAI          |
+|--------|----------------------|-----------------|
+| low    | `claude-haiku-4-5`   | `gpt-5.4-mini`  |
+| medium | `claude-sonnet-4-6`  | `gpt-5.3-codex` |
+| high   | `claude-opus-4-7`    | `gpt-5.4`       |
 
 ## Outcome
 
-- `pr-comment` — one sticky summary PR comment.
-- `inline-review` — inline comments on specific lines.
+- `pr-comment` — one summary PR comment (sticky for `anthropic`,
+  new comment per run for `openai`).
+- `inline-review` — inline comments on specific lines. **Anthropic only**;
+  `openai` + `inline-review` degrades to a notice-level skip because
+  `openai/codex-action` has no inline-comment surface.
 
 ## Inputs
 
@@ -49,7 +55,7 @@ review alongside auto-approve on bot PRs.
 |     effort      | string |  false   |                   `"medium"`                    | Effort level (low | medium | high) — maps to <br>a provider-specific model.  |
 |     outcome     | string |   true   |                                                 |         What the AI produces: `pr-comment` or <br>`inline-review`.           |
 |     prompt      | string |   true   |                                                 |          Review instructions passed verbatim as the <br>AI prompt.           |
-|    provider     | string |   true   |                                                 |   AI provider: `anthropic` (implemented) or `openai` <br>(reserved stub).    |
+|    provider     | string |   true   |                                                 |                    AI provider: `anthropic` or `openai`.                     |
 | timeout-minutes | number |  false   |                      `15`                       |                           Job timeout in minutes.                            |
 
 <!-- AUTO-DOC-INPUT:END -->
@@ -57,10 +63,5 @@ review alongside auto-approve on bot PRs.
 ## Secrets
 
 <!-- AUTO-DOC-SECRETS:START - Do not remove or modify this section -->
-
-|      SECRET       | REQUIRED |                     DESCRIPTION                      |
-|-------------------|----------|------------------------------------------------------|
-| anthropic-api-key |  false   | Anthropic API key. Required when provider=anthropic. |
-|  openai-api-key   |  false   |    OpenAI API key. Reserved for provider=openai.     |
-
+No secrets.
 <!-- AUTO-DOC-SECRETS:END -->


### PR DESCRIPTION
## Summary

- Replace the `openai` provider stub in the `ai-pr-review` composite with a real execution path: resolver maps `openai:{low,medium,high}` to `gpt-5.4-mini` / `gpt-5.3-codex` / `gpt-5.4`; `action.yml` runs a bot-author filter, checks out the PR merge ref, invokes `openai/codex-action@v1.6`, and posts the `final-message` as a PR comment.
- Degrade `openai` + `inline-review` to a notice-level skip — `codex-action` has no inline-comment surface, so `pr-comment` is the only supported outcome for that provider.
- Drop `workflow_call.secrets` from the reusable workflow — callers use `secrets: inherit` and the workflow reads org-level `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` directly, removing per-caller secret-plumbing boilerplate.

## Why

`openai` has been an input-visible stub since the composite landed in #117. This closes the gap so `provider: openai` actually runs a review, using the current Codex model tier recommended by OpenAI's own docs (Q2 2026). Dropping `workflow_call.secrets` addresses feedback that every caller having to restate the API key was needless boilerplate when the secret already exists at the org level.

## Test plan

- [x] bats suite updated and green (openai happy path + openai/inline-review skip)
- [x] docs regenerated via `make generate-docs` (new OpenAI column in Effort→model, new `secrets: inherit` usage example)
- [ ] CI `composite-smoke-openai` short-circuits on this (human-authored) PR via the bot-author filter, reporting success without spending tokens
- [ ] CI `composite-smoke-anthropic` unchanged and green

Closes DEVOPS-793