### PR TITLE
fix(run-ginkgo): restore emoji prefixes in failure-summary

### DIFF
--- a/.github/actions/run-ginkgo/src/generate-summary.sh
+++ b/.github/actions/run-ginkgo/src/generate-summary.sh
@@ -47,32 +47,32 @@ RUNTIME=$(echo "$STATS" | jq -r '.runtime')
   echo "failure-summary<<EOF"
 
   echo "*Test Results Summary:*"
-  echo "Executed: ${SPECS_TO_RUN}/${TOTAL_SPECS} tests"
+  echo "📊 Executed: ${SPECS_TO_RUN}/${TOTAL_SPECS} tests"
 
   if [[ "$FAILED_COUNT" -gt 0 ]]; then
-    echo "Failed: ${FAILED_COUNT}"
-    echo "Passed: ${PASSED_COUNT}"
+    echo "❌ Failed: ${FAILED_COUNT}"
+    echo "✅ Passed: ${PASSED_COUNT}"
   else
-    echo "All tests passed! (${PASSED_COUNT}/${SPECS_TO_RUN})"
+    echo "✅ All tests passed! (${PASSED_COUNT}/${SPECS_TO_RUN})"
   fi
 
   if [[ "$SKIPPED_COUNT" -gt 0 ]]; then
-    echo "Skipped: ${SKIPPED_COUNT}"
+    echo "⏭️ Skipped: ${SKIPPED_COUNT}"
   fi
   if [[ "$PENDING_COUNT" -gt 0 ]]; then
-    echo "Pending: ${PENDING_COUNT}"
+    echo "⏸️ Pending: ${PENDING_COUNT}"
   fi
-  echo "Duration: ${RUNTIME}s"
+  echo "⏱️ Duration: ${RUNTIME}s"
 
   if [[ "$FAILED_COUNT" -gt 0 ]]; then
     echo ""
     echo "*Failed Tests:*"
     jq -r '[.[].SpecReports[] | select(.State | IN("passed", "skipped", "pending") | not)] |
       .[] |
-      "[" + (.State | ascii_upcase) + "] [" + .LeafNodeType + "]" +
+      "❌ [" + (.State | ascii_upcase) + "] [" + .LeafNodeType + "]" +
       (if .ContainerHierarchyTexts then " " + (.ContainerHierarchyTexts | join(" ")) else "" end) +
       (if .LeafNodeText != "" then " " + .LeafNodeText else "" end) +
-      "\n  " + .LeafNodeLocation.FileName + ":" + (.LeafNodeLocation.LineNumber | tostring)' \
+      "\n   📍 " + .LeafNodeLocation.FileName + ":" + (.LeafNodeLocation.LineNumber | tostring)' \
       "$REPORT_FILE"
   fi
 

--- a/.github/actions/run-ginkgo/test/generate-summary.bats
+++ b/.github/actions/run-ginkgo/test/generate-summary.bats
@@ -203,3 +203,49 @@ get_summary_line() {
   [[ "$summary" == *"VCluster Sync"* ]]
   [[ "$summary" == *"VCluster Networking"* ]]
 }
+
+# --- Emoji prefixes ---
+
+@test "all-passed summary uses emoji prefixes" {
+  REPORT_FILE="$FIXTURES/all-passed.json" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+
+  local summary
+  summary="$(get_summary)"
+  [[ "$summary" == *"📊 Executed:"* ]]
+  [[ "$summary" == *"✅ All tests passed!"* ]]
+  [[ "$summary" == *"⏱️ Duration:"* ]]
+}
+
+@test "failure summary uses emoji prefixes on counts" {
+  REPORT_FILE="$FIXTURES/with-failures.json" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+
+  local summary
+  summary="$(get_summary)"
+  [[ "$summary" == *"📊 Executed:"* ]]
+  [[ "$summary" == *"❌ Failed:"* ]]
+  [[ "$summary" == *"✅ Passed:"* ]]
+  [[ "$summary" == *"⏭️ Skipped:"* ]]
+  [[ "$summary" == *"⏱️ Duration:"* ]]
+}
+
+@test "failed test lines are prefixed with ❌ and location with 📍" {
+  REPORT_FILE="$FIXTURES/with-failures.json" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+
+  local summary
+  summary="$(get_summary)"
+  [[ "$summary" == *"❌ [FAILED]"* ]]
+  [[ "$summary" == *"❌ [PANICKED]"* ]]
+  [[ "$summary" == *"📍 "* ]]
+}
+
+@test "pending summary uses ⏸️ prefix" {
+  REPORT_FILE="$FIXTURES/with-pending.json" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+
+  local summary
+  summary="$(get_summary)"
+  [[ "$summary" == *"⏸️ Pending:"* ]]
+}


### PR DESCRIPTION
## Summary

- Restore the status emoji prefixes that the pre-migration local action emitted on each summary line (📊 Executed, ❌ Failed, ✅ Passed, ⏭️ Skipped, ⏸️ Pending, ⏱️ Duration, plus ❌ on failed-test entries and 📍 on location lines).
- Add four bats tests pinning the emoji format so the next refactor can't silently drop them again.

## Why

The migration of `run-ginkgo-e2e` from `loft-sh/loft-enterprise` into this repo (PR loft-sh/loft-enterprise#6697) dropped every emoji from the `failure-summary` output. Downstream consumers (e.g. the nightly E2E Slack notification in loft-enterprise) now render a flat wall of text with only the header emoji from `ci-test-notify`, which is noticeably harder to scan at 3am.

## Test plan

- [x] `make test-run-ginkgo` — 36/36 bats tests pass (4 new)
- [x] shellcheck on `generate-summary.sh` — clean
- [ ] After merge, move the `run-ginkgo/v1` tag to this commit so downstream consumers (`loft-sh/loft-enterprise` nightly) pick it up automatically
- [ ] Verify on the next nightly E2E run in `loft-enterprise` that the Slack message has emoji prefixes restored