### PR TITLE
fix(ai-pr-review): check openai PR head into subdir to preserve action.yml

### DIFF
--- a/.github/actions/ai-pr-review/action.yml
+++ b/.github/actions/ai-pr-review/action.yml
@@ -128,6 +128,9 @@ runs:
     # fetch-depth: 0 pulls the base branch during the authenticated checkout
     # itself (for `git diff base...head`), so no follow-up fetch is needed and
     # persist-credentials: false is safe (zizmor: avoid artipacked).
+    # path: _pr checks out into a subdirectory — the reusable workflow wrapper
+    # sparse-checked-out this composite's own action.yml into the workspace
+    # root, and clobbering it breaks GitHub's late-stage action resolution.
     - name: Checkout PR head (openai)
       if: steps.cfg.outputs.proceed == 'true' && inputs.provider == 'openai' && steps.author.outputs.run == 'true'
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -135,6 +138,7 @@ runs:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
         persist-credentials: false
+        path: _pr
 
     - name: Codex PR review
       id: codex
@@ -147,6 +151,7 @@ runs:
         sandbox: read-only
         safety-strategy: drop-sudo
         allow-bots: 'true'
+        working-directory: _pr
         prompt: |
           ${{ inputs.prompt }}
 


### PR DESCRIPTION
## Summary

Adds `path: _pr` to the openai-branch checkout so the caller's PR head doesn't clobber the composite action's own `action.yml` in the workspace root. Sets `working-directory: _pr` on `openai/codex-action` to point it at the new location.

## Why

End-to-end test against a real caller (loft-sh/vcluster-docs#1962) revealed the openai job was exiting red despite codex running successfully and posting its review comment. Root cause:

1. Reusable workflow wrapper does `actions/checkout repository: loft-sh/github-actions sparse-checkout: .github/actions/ai-pr-review` — puts the composite's files at the workspace root.
2. The composite loads, runs `Resolve config` + `Check author`, then does its own `actions/checkout` of `pull_request.head.sha` — overwrites the workspace root with the caller's PR contents, deleting `.github/actions/ai-pr-review/action.yml`.
3. Codex runs fine (it's an external action, not affected).
4. Late-stage action resolution (post-step cleanup, roughly) tries to re-read the composite's `action.yml` and fails: `Can't find 'action.yml' ... under '.github/actions/ai-pr-review'. Did you forget to run actions/checkout before running your local action?`

The composite's own smoke test in this repo (`composite-smoke-openai`) didn't catch it because that path doesn't go through the reusable workflow wrapper — the workspace is already this repo, and re-checking it out doesn't lose any files.

Only the openai branch is patched; the anthropic branch has the same potential shape, but `claude-code-action` behaves differently internally and the anthropic smoke path has been green in caller contexts historically. Leaving it alone to avoid scope creep.

## Test plan

- [x] bats suite still green
- [ ] CI green on this PR
- [ ] After merge, retrigger loft-sh/vcluster-docs#1962 and verify the `review / ai-review` job ends green (not red) while still posting the codex summary