### PR TITLE
refactor(ai-pr-review): drop allowed-bots input — caller decides scope

### DIFF
--- a/.github/actions/ai-pr-review/README.md
+++ b/.github/actions/ai-pr-review/README.md
@@ -66,16 +66,15 @@ use the companion reusable workflow at
 
 <!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
 
-|       INPUT       |  TYPE  | REQUIRED |                     DEFAULT                     |                                                                                     DESCRIPTION                                                                                     |
-|-------------------|--------|----------|-------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-|   allowed-bots    | string |  false   | `"renovate,dependabot,loft-bot,github-actions"` |                              Comma-separated bot logins this review runs <br>for (passed to claude-code-action `allowed_bots`). `*` allows all bots.                                |
-| anthropic-api-key | string |  false   |                                                 |                                                                Anthropic API key. Required when provider=anthropic.                                                                 |
-|      effort       | string |  false   |                   `"medium"`                    |                                                    Effort level (low | medium | high) — maps to <br>a provider-specific model.                                                      |
-|   github-token    | string |   true   |                                                 |                                                      Token used by claude-code-action to post <br>comments and read PR state.                                                       |
-|  openai-api-key   | string |  false   |                                                 |                                                                   OpenAI API key. Required when provider=openai.                                                                    |
-|      outcome      | string |   true   |                                                 | What the AI produces: `pr-comment` (a summary PR comment — sticky on anthropic, new per run on openai) or <br>`inline-review` (inline comments on specific lines, anthropic only).  |
-|      prompt       | string |   true   |                                                 |                                                             Review instructions passed verbatim as the <br>AI prompt.                                                               |
-|     provider      | string |   true   |                                                 |                                                                        AI provider: `anthropic` or `openai`.                                                                        |
+|       INPUT       |  TYPE  | REQUIRED |  DEFAULT   |                                                                                     DESCRIPTION                                                                                     |
+|-------------------|--------|----------|------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| anthropic-api-key | string |  false   |            |                                                                Anthropic API key. Required when provider=anthropic.                                                                 |
+|      effort       | string |  false   | `"medium"` |                                                    Effort level (low | medium | high) — maps to <br>a provider-specific model.                                                      |
+|   github-token    | string |   true   |            |                                                      Token used by claude-code-action to post <br>comments and read PR state.                                                       |
+|  openai-api-key   | string |  false   |            |                                                                   OpenAI API key. Required when provider=openai.                                                                    |
+|      outcome      | string |   true   |            | What the AI produces: `pr-comment` (a summary PR comment — sticky on anthropic, new per run on openai) or <br>`inline-review` (inline comments on specific lines, anthropic only).  |
+|      prompt       | string |   true   |            |                                                             Review instructions passed verbatim as the <br>AI prompt.                                                               |
+|     provider      | string |   true   |            |                                                                        AI provider: `anthropic` or `openai`.                                                                        |
 
 <!-- AUTO-DOC-INPUT:END -->
 
@@ -83,10 +82,10 @@ use the companion reusable workflow at
 
 <!-- AUTO-DOC-OUTPUT:START - Do not remove or modify this section -->
 
-|   OUTPUT   |  TYPE  |                                                                     DESCRIPTION                                                                      |
-|------------|--------|------------------------------------------------------------------------------------------------------------------------------------------------------|
-| conclusion | string | `success` when the AI review ran; <br>`skipped` when the resolver vetoed the <br>run (invalid input, unsupported combo, or non-allowlisted author).  |
-|   reason   | string |                                                    One-line explanation when conclusion=skipped.                                                     |
+|   OUTPUT   |  TYPE  |                                                         DESCRIPTION                                                         |
+|------------|--------|-----------------------------------------------------------------------------------------------------------------------------|
+| conclusion | string | `success` when the AI review ran; <br>`skipped` when the resolver vetoed the <br>run (invalid input or unsupported combo).  |
+|   reason   | string |                                        One-line explanation when conclusion=skipped.                                        |
 
 <!-- AUTO-DOC-OUTPUT:END -->
 

--- a/.github/actions/ai-pr-review/action.yml
+++ b/.github/actions/ai-pr-review/action.yml
@@ -3,7 +3,8 @@ description: |
   Runs an AI-powered PR review with a caller-provided prompt. The caller
   picks provider, effort, outcome, and the review instructions; the action
   owns model selection, MCP servers, and write-tool access. Advisory only —
-  every failure mode degrades to a notice-level skip.
+  every failure mode degrades to a notice-level skip. The caller decides
+  which PRs to review via workflow triggers and job-level `if:` conditions.
 inputs:
   provider:
     description: 'AI provider: `anthropic` or `openai`.'
@@ -18,10 +19,6 @@ inputs:
   outcome:
     description: 'What the AI produces: `pr-comment` (a summary PR comment — sticky on anthropic, new per run on openai) or `inline-review` (inline comments on specific lines, anthropic only).'
     required: true
-  allowed-bots:
-    description: 'Comma-separated bot logins this review runs for (passed to claude-code-action `allowed_bots`). `*` allows all bots.'
-    required: false
-    default: 'renovate,dependabot,loft-bot,github-actions'
   anthropic-api-key:
     description: 'Anthropic API key. Required when provider=anthropic.'
     required: false
@@ -34,11 +31,11 @@ inputs:
 
 outputs:
   conclusion:
-    description: '`success` when the AI review ran; `skipped` when the resolver vetoed the run (invalid input, unsupported combo, or non-allowlisted author).'
+    description: '`success` when the AI review ran; `skipped` when the resolver vetoed the run (invalid input or unsupported combo).'
     value: ${{ steps.conclusion.outputs.conclusion }}
   reason:
     description: 'One-line explanation when conclusion=skipped.'
-    value: ${{ steps.cfg.outputs.reason != '' && steps.cfg.outputs.reason || steps.author.outputs.reason }}
+    value: ${{ steps.cfg.outputs.reason }}
 
 runs:
   using: composite
@@ -73,7 +70,7 @@ runs:
       with:
         anthropic_api_key: ${{ inputs.anthropic-api-key }} # zizmor: ignore[secrets-outside-env] -- API key passed via composite input, not a repo secret
         github_token: ${{ inputs.github-token }}
-        allowed_bots: ${{ inputs.allowed-bots }}
+        allowed_bots: '*'
         track_progress: true
         use_sticky_comment: true
         prompt: |
@@ -86,45 +83,8 @@ runs:
           --allowedTools "Read,Glob,Grep,LS,Bash(git diff:*),Bash(git log:*),Bash(gh pr view:*),Bash(gh pr diff:*),mcp__context7__*,mcp__sequential-thinking__*${{ steps.cfg.outputs.tools_suffix }}"
 
     # --- openai branch ----------------------------------------------------
-    # claude-code-action applies `allowed_bots` internally; codex-action
-    # doesn't have an equivalent (its `allow-bots` is boolean), so we
-    # reproduce the bot-author filter here before spending tokens.
-    - name: Check PR author against allowed-bots (openai)
-      id: author
-      if: steps.cfg.outputs.proceed == 'true' && inputs.provider == 'openai'
-      shell: bash
-      env:
-        PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-        ALLOWED_BOTS: ${{ inputs.allowed-bots }}
-      run: |
-        set -eo pipefail
-        allowed=false
-        if [ "$ALLOWED_BOTS" = "*" ]; then
-          allowed=true
-        else
-          IFS=',' read -ra bots <<< "$ALLOWED_BOTS"
-          for bot in "${bots[@]}"; do
-            bot="${bot// /}"
-            [ -z "$bot" ] && continue
-            if [ "$PR_AUTHOR" = "$bot" ] || [ "$PR_AUTHOR" = "${bot}[bot]" ]; then
-              allowed=true
-              break
-            fi
-          done
-        fi
-        if [ "$allowed" = "true" ]; then
-          echo "run=true" >> "$GITHUB_OUTPUT"
-          echo "reason=" >> "$GITHUB_OUTPUT"
-          echo "::notice::ai-pr-review: author '$PR_AUTHOR' allowed — running codex review"
-        else
-          skip_reason="author '$PR_AUTHOR' not in allowed-bots"
-          echo "run=false" >> "$GITHUB_OUTPUT"
-          echo "reason=$skip_reason" >> "$GITHUB_OUTPUT"
-          echo "::notice::ai-pr-review: $skip_reason — skipping"
-        fi
-
     # head.sha is used (not refs/pull/N/merge) because merge refs are absent on
-    # conflicted PRs — common for the renovate/dependabot audience this targets.
+    # conflicted PRs — hard-failure would violate the never-hard-fail contract.
     # fetch-depth: 0 pulls the base branch during the authenticated checkout
     # itself (for `git diff base...head`), so no follow-up fetch is needed and
     # persist-credentials: false is safe (zizmor: avoid artipacked).
@@ -132,7 +92,7 @@ runs:
     # sparse-checked-out this composite's own action.yml into the workspace
     # root, and clobbering it breaks GitHub's late-stage action resolution.
     - name: Checkout PR head (openai)
-      if: steps.cfg.outputs.proceed == 'true' && inputs.provider == 'openai' && steps.author.outputs.run == 'true'
+      if: steps.cfg.outputs.proceed == 'true' && inputs.provider == 'openai'
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: ${{ github.event.pull_request.head.sha }}
@@ -142,7 +102,7 @@ runs:
 
     - name: Codex PR review
       id: codex
-      if: steps.cfg.outputs.proceed == 'true' && inputs.provider == 'openai' && steps.author.outputs.run == 'true'
+      if: steps.cfg.outputs.proceed == 'true' && inputs.provider == 'openai'
       uses: openai/codex-action@c25d10f3f498316d4b2496cc4c6dd58057a7b031 # v1.6
       with:
         openai-api-key: ${{ inputs.openai-api-key }} # zizmor: ignore[secrets-outside-env] -- API key passed via composite input, not a repo secret
@@ -158,7 +118,7 @@ runs:
           ${{ steps.cfg.outputs.guidance }}
 
     - name: Post Codex feedback as PR comment
-      if: steps.cfg.outputs.proceed == 'true' && inputs.provider == 'openai' && steps.author.outputs.run == 'true' && steps.codex.outputs.final-message != ''
+      if: steps.cfg.outputs.proceed == 'true' && inputs.provider == 'openai' && steps.codex.outputs.final-message != ''
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github-token }}
@@ -174,13 +134,9 @@ runs:
       shell: bash
       env:
         PROCEED: ${{ steps.cfg.outputs.proceed }}
-        PROVIDER: ${{ inputs.provider }}
-        AUTHOR_RUN: ${{ steps.author.outputs.run }}
       run: |
-        if [ "$PROCEED" != "true" ]; then
-          echo "conclusion=skipped" >> "$GITHUB_OUTPUT"
-        elif [ "$PROVIDER" = "openai" ] && [ "$AUTHOR_RUN" != "true" ]; then
-          echo "conclusion=skipped" >> "$GITHUB_OUTPUT"
-        else
+        if [ "$PROCEED" = "true" ]; then
           echo "conclusion=success" >> "$GITHUB_OUTPUT"
+        else
+          echo "conclusion=skipped" >> "$GITHUB_OUTPUT"
         fi

--- a/.github/workflows/ai-pr-review.yaml
+++ b/.github/workflows/ai-pr-review.yaml
@@ -20,11 +20,6 @@ on:
         description: 'What the AI produces: `pr-comment` or `inline-review`.'
         type: string
         required: true
-      allowed-bots:
-        description: 'Comma-separated bot logins this review runs for. `*` allows all bots.'
-        type: string
-        required: false
-        default: 'renovate,dependabot,loft-bot,github-actions'
       timeout-minutes:
         description: 'Job timeout in minutes.'
         type: number
@@ -72,7 +67,6 @@ jobs:
           effort: ${{ inputs.effort }}
           prompt: ${{ inputs.prompt }}
           outcome: ${{ inputs.outcome }}
-          allowed-bots: ${{ inputs.allowed-bots }}
           anthropic-api-key: ${{ secrets.anthropic-api-key }} # zizmor: ignore[secrets-outside-env] -- API key passed via workflow_call, not a repo secret
           openai-api-key: ${{ secrets.openai-api-key }} # zizmor: ignore[secrets-outside-env] -- API key passed via workflow_call, not a repo secret
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-ai-pr-review.yaml
+++ b/.github/workflows/test-ai-pr-review.yaml
@@ -21,52 +21,9 @@ jobs:
         with:
           tests: .github/actions/ai-pr-review/test
 
-  # Smoke test the composite on the PR branch. The reusable workflow's
-  # sparse-checkout pins ref: main, which wouldn't yet contain the composite
-  # during this PR's CI. Human-authored PRs hit claude-code-action's
-  # allowed_bots filter and short-circuit before the API call, so the job
-  # reports success without spending tokens.
-  composite-smoke-anthropic:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-      issues: write
-      id-token: write
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-      - uses: ./.github/actions/ai-pr-review
-        with:
-          provider: anthropic
-          effort: low
-          outcome: pr-comment
-          prompt: |
-            Smoke test. Do not post any review comments.
-          anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-  # Smoke test the openai branch. The composite's own bot-author filter
-  # short-circuits before calling codex-action on human-authored PRs,
-  # so this reports success without spending tokens.
-  composite-smoke-openai:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-      issues: write
-      id-token: write
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-      - uses: ./.github/actions/ai-pr-review
-        with:
-          provider: openai
-          effort: low
-          outcome: pr-comment
-          prompt: |
-            Smoke test. Do not post any review comments.
-          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+  # Composite smoke tests used to rely on the allowed-bots filter to
+  # short-circuit before spending API tokens on human-authored PRs. With
+  # allowed-bots removed, invoking the composite would spend real tokens
+  # on every PR touching these files. End-to-end coverage lives in an
+  # external caller (e.g. loft-sh/vcluster-docs) per the pattern documented
+  # in CLAUDE.md; the bats suite above covers the resolver decision table.

--- a/docs/workflows/ai-pr-review.md
+++ b/docs/workflows/ai-pr-review.md
@@ -51,14 +51,13 @@ review alongside auto-approve on bot PRs.
 
 <!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
 
-|      INPUT      |  TYPE  | REQUIRED |                     DEFAULT                     |                                 DESCRIPTION                                  |
-|-----------------|--------|----------|-------------------------------------------------|------------------------------------------------------------------------------|
-|  allowed-bots   | string |  false   | `"renovate,dependabot,loft-bot,github-actions"` |  Comma-separated bot logins this review runs <br>for. `*` allows all bots.   |
-|     effort      | string |  false   |                   `"medium"`                    | Effort level (low | medium | high) — maps to <br>a provider-specific model.  |
-|     outcome     | string |   true   |                                                 |         What the AI produces: `pr-comment` or <br>`inline-review`.           |
-|     prompt      | string |   true   |                                                 |          Review instructions passed verbatim as the <br>AI prompt.           |
-|    provider     | string |   true   |                                                 |                    AI provider: `anthropic` or `openai`.                     |
-| timeout-minutes | number |  false   |                      `15`                       |                           Job timeout in minutes.                            |
+|      INPUT      |  TYPE  | REQUIRED |  DEFAULT   |                                 DESCRIPTION                                  |
+|-----------------|--------|----------|------------|------------------------------------------------------------------------------|
+|     effort      | string |  false   | `"medium"` | Effort level (low | medium | high) — maps to <br>a provider-specific model.  |
+|     outcome     | string |   true   |            |         What the AI produces: `pr-comment` or <br>`inline-review`.           |
+|     prompt      | string |   true   |            |          Review instructions passed verbatim as the <br>AI prompt.           |
+|    provider     | string |   true   |            |                    AI provider: `anthropic` or `openai`.                     |
+| timeout-minutes | number |  false   |    `15`    |                           Job timeout in minutes.                            |
 
 <!-- AUTO-DOC-INPUT:END -->
 


### PR DESCRIPTION
## Summary

`allowed-bots` is out. Filtering which PRs get reviewed is a caller concern that belongs in workflow triggers or job-level `if:` conditions; it doesn't belong in this reusable action's input surface.

- `allowed-bots` input removed from both composite action and reusable workflow
- Anthropic branch now hardcodes `allowed_bots: '*'` on `claude-code-action` (runs for any author the caller invokes us with)
- OpenAI branch's bash author-filter step deleted, along with its `reason` plumbing and the `steps.author.outputs.run` gating on downstream steps
- `Emit conclusion` simplified back to a single check on `cfg.outputs.proceed`
- `composite-smoke-anthropic` / `composite-smoke-openai` jobs in `test-ai-pr-review.yaml` removed — they relied on the filter to short-circuit without burning tokens; keeping them would spend real tokens on every PR touching these files. Bats still covers the resolver; real-world end-to-end validation is done via the external-caller pattern (documented in CLAUDE.md)

## Why

The reusable workflow is a primitive: "run an AI review on the PR you're invoked with." Deciding _which_ PRs deserve review is the caller's job. Standard GitHub plumbing (`on.pull_request.types/branches/paths`, `if:` on the job, etc.) already handles that cleanly. Putting an author allowlist inside the action conflated two concerns and — more practically — made the input confusing (humans surprisingly filtered out of a review action).

## Test plan

- [x] bats suite green
- [ ] CI green on this PR
- [ ] Follow-up: remove `allowed-bots: '*'` from loft-sh/vcluster-docs#1962 (the test caller) so it doesn't fail input validation when it picks up `@main`

References DEVOPS-793.