### PR TITLE
fix(ai-pr-review): preserve composite action dir across anthropic checkout

### DIFF
--- a/.github/actions/ai-pr-review/action.yml
+++ b/.github/actions/ai-pr-review/action.yml
@@ -49,13 +49,44 @@ runs:
         INPUT_OUTCOME: ${{ inputs.outcome }}
       run: ${{ github.action_path }}/src/resolve-config.sh
 
+    # The anthropic branch needs the PR tree at the workspace ROOT because
+    # claude-code-action has no working-directory input — Read/Glob/Grep and
+    # the git CLI invoked by the Claude session all resolve paths against
+    # $GITHUB_WORKSPACE. But the reusable workflow wrapper sparse-checked-out
+    # this composite action's own src/ and action.yml into the same root, and
+    # `actions/checkout` wipes untracked files (`git clean -ffdx`) during
+    # checkout of the PR head — deleting the scripts we're about to invoke
+    # and the action.yml the Post step needs. Stash the composite dir to
+    # $RUNNER_TEMP before checkout and restore it afterward. `path: _pr`
+    # (the openai-branch fix) isn't viable here because claude-code-action
+    # has no equivalent `working-directory` input.
+    - name: Stash composite action files before PR checkout
+      if: steps.cfg.outputs.proceed == 'true' && inputs.provider == 'anthropic'
+      shell: bash
+      run: |
+        stash_dir="$RUNNER_TEMP/ai-pr-review-stash"
+        rm -rf "$stash_dir"
+        mkdir -p "$stash_dir"
+        cp -R .github/actions/ai-pr-review/. "$stash_dir/"
+
+    # fetch-depth: 0 so restore-claude-md.sh can resolve origin/$BASE_REF.
+    # Previously fetch-depth was 1, which silently no-oped the restore
+    # (script 2>/dev/null || rm -f CLAUDE.md) on every run.
     - name: Checkout PR head
       if: steps.cfg.outputs.proceed == 'true' && inputs.provider == 'anthropic'
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: ${{ github.event.pull_request.head.sha }}
-        fetch-depth: 1
+        fetch-depth: 0
         persist-credentials: false
+
+    - name: Restore composite action files after PR checkout
+      if: steps.cfg.outputs.proceed == 'true' && inputs.provider == 'anthropic'
+      shell: bash
+      run: |
+        stash_dir="$RUNNER_TEMP/ai-pr-review-stash"
+        mkdir -p .github/actions/ai-pr-review
+        cp -R "$stash_dir/." .github/actions/ai-pr-review/
 
     - name: Restore CLAUDE.md from base branch
       if: steps.cfg.outputs.proceed == 'true' && inputs.provider == 'anthropic'


### PR DESCRIPTION
## Summary

Every anthropic invocation of the ai-pr-review composite fails identically today:

```
/home/runner/work/_temp/.../restore-claude-md.sh: line 1:
/home/runner/.../.github/actions/ai-pr-review/src/restore-claude-md.sh:
No such file or directory
##[error]Process completed with exit code 127.
##[error]Can't find 'action.yml' ... under '.github/actions/ai-pr-review'.
Did you forget to run actions/checkout before running your local action?
```

Root cause: the PR-head `actions/checkout` step runs `git clean -ffdx` on
`$GITHUB_WORKSPACE`, which wipes the sparse-checkout of this composite
action's own `src/` + `action.yml` that the reusable workflow wrapper put
there one step earlier. By the time `restore-claude-md.sh` is invoked the
script is gone; by the time GitHub re-reads `action.yml` for the Post phase
it's gone too.

The openai branch avoided this via `path: _pr` + `working-directory: _pr`
on codex-action (#123). That trick doesn't port here — `claude-code-action`
has no `working-directory` input, and the Claude session's `Read`/`Glob`/
`Grep` tools plus the `git` CLI it spawns all resolve paths against
`$GITHUB_WORKSPACE`. The PR tree must live at the workspace root.

## Fix

Two new steps, both gated on `provider == 'anthropic'`, bracket the checkout:

1. **Stash** the composite action dir to `\$RUNNER_TEMP/ai-pr-review-stash`
   **before** the PR-head checkout.
2. **Restore** it from the stash **after** the checkout, so subsequent
   steps (`restore-claude-md.sh`, the Post phase) can still find
   `action.yml` and `src/`.

Also bumps `fetch-depth: 1 → 0` on the anthropic checkout. Under the old
depth, `origin/\$BASE_REF` was never fetched locally, and
`restore-claude-md.sh` silently \`rm -f\`'d CLAUDE.md on every run (the
script swallows \`git show\` failures). With full depth the base-branch
CLAUDE.md actually gets restored, which **strengthens** the prompt-
injection guard, not weakens it. Mirrors the openai branch's `fetch-depth: 0`.

## Safety

- Stash dir is `\$RUNNER_TEMP/ai-pr-review-stash` — runner-provided,
  cleaned between jobs, outside the workspace.
- Openai path is entirely unchanged (both new steps + fetch-depth change
  are `if: provider == 'anthropic'`-gated).
- `persist-credentials: false` preserved.
- If restore fails, we land in today's failure mode — not worse. The
  composite is \`continue-on-error: true\` in the reusable wrapper so it
  stays advisory.
- No new secret surfaces, no \`zizmor: ignore\` needed.

## Test plan

- [ ] Sibling PRs loft-sh/vcluster-docs#1968–#1973 (anthropic × low/medium/high × pr-comment/inline-review) currently fail with the crash above. Repoint them temporarily at \`@devops-793/ai-pr-review-anthropic-subdir\`, observe all 6 go green, observe a sticky (pr-comment) or inline comment posted per outcome.
- [ ] Sibling PRs loft-sh/vcluster-docs#1965, #1966, #1967, #1974 (openai × all configs) must stay green after repoint — proves no openai regression.
- [ ] Post-verification: revert docs PRs to \`@main\` and close them.

Context: loft-sh/vcluster-docs#1962 is a permanent test-bed PR tracking
this sweep in `.github/ai-review-test-matrix.md`.

References DEVOPS-793.