### PR TITLE
fix(ai-pr-review): bump claude-code-action to v1.0.101 for opus-4-7 support

### DIFF
--- a/.github/actions/ai-pr-review/action.yml
+++ b/.github/actions/ai-pr-review/action.yml
@@ -97,7 +97,7 @@ runs:
 
     - name: Claude PR review
       if: steps.cfg.outputs.proceed == 'true' && inputs.provider == 'anthropic'
-      uses: anthropics/claude-code-action@5fb899572b81d2bb648d4d187173a2f423a9677c # v1
+      uses: anthropics/claude-code-action@38ec876110f9fbf8b950c79f534430740c3ac009 # v1.0.101
       with:
         anthropic_api_key: ${{ inputs.anthropic-api-key }} # zizmor: ignore[secrets-outside-env] -- API key passed via composite input, not a repo secret
         github_token: ${{ inputs.github-token }}


### PR DESCRIPTION
## Summary

Bumps the pinned \`anthropics/claude-code-action\` SHA from
\`5fb8995\` (2.1.109, 2026-04-15) to \`38ec876\` (v1.0.101 /
2.1.114, 2026-04-18). One-line change.

## Why

Claude Opus 4.7 (released 2026-04-16) removed manual extended-thinking.
On 4.7, \`thinking: {type: "enabled", budget_tokens: N}\` is no longer
supported and returns a **400**:

> \"thinking.type.enabled\" is not supported for this model. Use
> \"thinking.type.adaptive\" and \"output_config.effort\" to control
> thinking behavior.

Our pinned SHA predates the release and still sends the deprecated
shape. Every call the resolver maps to \`claude-opus-4-7\` (i.e.
\`provider: anthropic\` + \`effort: high\`) crashes. Haiku 4.5 and
Sonnet 4.6 still accept the old shape (deprecated but functional),
which is why \`low\`/\`medium\` cells kept working.

Anthropic tracked the identical bug at
anthropics/claude-code-action#1225 (closed 2026-04-17), resolved by a
Claude Code SDK bump. Confirmed fixed at v1.0.99 and later.

## Evidence

Reproduced on the same parallel test sweep as #125:

- loft-sh/vcluster-docs#1970 — \`anthropic\` × \`high\` × \`pr-comment\` → 400 on \`thinking.type.enabled\`
- loft-sh/vcluster-docs#1973 — \`anthropic\` × \`high\` × \`inline-review\` → same 400
- loft-sh/vcluster-docs#1968, #1969, #1971, #1972 — \`anthropic\` × \`low\`/\`medium\` → green on current SHA (as expected, those models still accept the old shape)

## Safety

- No input / output surface change. Same action, same contract.
- No caller needs to update anything.
- Release notes for v1.0.99–v1.0.101 are all Claude Code / SDK bumps;
  no API-shape changes introduced on our side.
- zizmor: clean (2 suppressed = pre-existing \`secrets-outside-env\`
  ignores on the api-key lines, unchanged).

## Test plan

- [ ] Retrigger loft-sh/vcluster-docs#1970 and #1973; confirm
  \`review / ai-review\` goes green and the bot posts a
  sticky comment / inline comments respectively.
- [ ] Confirm #1968, #1969, #1971, #1972 still pass (no regression
  on haiku/sonnet paths).

References DEVOPS-793. Follow-up to #125.