### PR TITLE
feat(ai-pr-review): attribute every PR comment with provider / model / effort

### DIFF
--- a/.github/actions/ai-pr-review/action.yml
+++ b/.github/actions/ai-pr-review/action.yml
@@ -108,6 +108,9 @@ runs:
           ${{ inputs.prompt }}
 
           ${{ steps.cfg.outputs.guidance }}
+
+          Provenance: the very last line of the comment you post MUST be this line verbatim (keep the leading `> ` and underscores so it renders as an italic blockquote):
+          > _🤖 ai-pr-review — provider: anthropic · model: ${{ steps.cfg.outputs.model }} · effort: ${{ inputs.effort }}_
         claude_args: |
           --model ${{ steps.cfg.outputs.model }}
           --mcp-config '{"mcpServers":{"context7":{"command":"npx","args":["-y","@upstash/context7-mcp"]},"sequential-thinking":{"command":"npx","args":["-y","@modelcontextprotocol/server-sequential-thinking"]}}}'
@@ -156,8 +159,17 @@ runs:
         PR_NUMBER: ${{ github.event.pull_request.number }}
         REPO: ${{ github.repository }}
         BODY: ${{ steps.codex.outputs.final-message }}
+        MODEL: ${{ steps.cfg.outputs.model }}
+        EFFORT: ${{ inputs.effort }}
       run: |
-        printf '%s\n' "$BODY" | gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file -
+        # Provenance footer is emitted deterministically here (unlike the
+        # anthropic path which has to rely on prompt compliance) so every
+        # openai PR comment carries attribution even if the model's body
+        # text doesn't.
+        {
+          printf '%s\n\n' "$BODY"
+          printf '> _🤖 ai-pr-review — provider: openai · model: %s · effort: %s_\n' "$MODEL" "$EFFORT"
+        } | gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file -
 
     - name: Emit conclusion
       id: conclusion


### PR DESCRIPTION
## Summary

Every comment posted by this action shows up as \`github-actions[bot]\`.
When a repo runs multiple configurations (matrix smoke tests, retries, or
just two side-by-side callers) it is impossible to tell which comment
came from which provider/model/effort. Add a one-line attribution footer:

> _🤖 ai-pr-review — provider: openai · model: gpt-5.3-codex · effort: medium_

Same format on both providers → greppable across any aggregated view.

## Why the two paths look different in the diff

**openai** — deterministic: the composite owns the \`gh pr comment\` step,
so the footer is appended in bash right before \`--body-file\`. Attribution
never depends on model cooperation.

**anthropic** — \`claude-code-action\` writes the sticky/inline comment
itself, so the composite cannot intercept the body. Instead, append a
prompt-level instruction that names the exact footer string verbatim.
Claude 4.x models follow verbatim-line directives reliably; sticky-comment
reruns overwrite the previous body so the footer always reflects the
current config. If the model ever skips the line, the comment looks
like today's behaviour — no regression.

## Safety

- No input / output surface change.
- No caller needs to update anything.
- zizmor: clean (2 suppressed = pre-existing \`secrets-outside-env\`
  ignores, unchanged).
- Failure mode on anthropic = current behaviour.

## Test plan

- [ ] Retrigger loft-sh/vcluster-docs#1966 (openai/high/pr-comment) — verify footer reads \`provider: openai · model: gpt-5.4 · effort: high\`.
- [ ] Retrigger loft-sh/vcluster-docs#1973 (anthropic/high/inline-review) — verify the inline comment(s) end with \`provider: anthropic · model: claude-opus-4-7 · effort: high\`.

Context: loft-sh/vcluster-docs#1962 matrix. Follow-up to #125 and #126.
References DEVOPS-793.