### PR TITLE
refactor(ai-pr-review): drop outcome input, let model pick comment shape + add provenance footer

### DIFF
--- a/.github/actions/ai-pr-review/README.md
+++ b/.github/actions/ai-pr-review/README.md
@@ -1,18 +1,22 @@
 # AI PR review
 
 Runs an AI-powered PR review. Callers control what the AI looks at
-(`prompt`), how hard it thinks (`effort`), and what it produces
-(`outcome`). The action owns model selection, MCP servers, and the
-write-tool surface.
+(`prompt`) and how hard it thinks (`effort`). The action owns model
+selection, comment shape, MCP servers, and the write-tool surface.
+
+The model decides how to post findings — inline comments on specific
+lines, a sticky summary comment, or both — based on the shape of the
+review. Callers who want a specific shape can ask for it inside
+`prompt`. Provider asymmetry: `openai` (via `codex-action`) has no
+inline-comment surface, so the openai path is always summary-only.
+
+Every posted comment ends with a provenance footer:
+
+> _🤖 ai-pr-review — provider: anthropic · model: claude-opus-4-7 · effort: high_
 
 Advisory only — every failure mode (invalid input, stubbed provider,
 API error inside claude-code-action) degrades to a notice-level skip.
 Callers should set `continue-on-error: true` on the job.
-
-## Outcomes
-
-- `pr-comment` — one sticky summary PR comment. No inline comments.
-- `inline-review` — inline comments on specific lines (summary optional).
 
 ## Effort → model
 
@@ -21,10 +25,6 @@ Callers should set `continue-on-error: true` on the job.
 | low    | `claude-haiku-4-5`   | `gpt-5.4-mini`  |
 | medium | `claude-sonnet-4-6`  | `gpt-5.3-codex` |
 | high   | `claude-opus-4-7`    | `gpt-5.4`       |
-
-`openai` + `inline-review` is unsupported (codex-action has no
-inline-comment surface) and degrades to a notice-level skip. Use
-`openai` + `pr-comment` or switch to `anthropic` for inline reviews.
 
 ## Usage
 
@@ -49,7 +49,6 @@ jobs:
         with:
           provider: anthropic
           effort: medium
-          outcome: pr-comment
           prompt: |
             Review this PR for risk CI cannot catch: major version bumps
             where the diff is more than a version number, removed public
@@ -72,7 +71,6 @@ use the companion reusable workflow at
 |      effort       | string |  false   | `"medium"` |                                                    Effort level (low | medium | high) — maps to <br>a provider-specific model.                                                      |
 |   github-token    | string |   true   |            |                                                      Token used by claude-code-action to post <br>comments and read PR state.                                                       |
 |  openai-api-key   | string |  false   |            |                                                                   OpenAI API key. Required when provider=openai.                                                                    |
-|      outcome      | string |   true   |            | What the AI produces: `pr-comment` (a summary PR comment — sticky on anthropic, new per run on openai) or <br>`inline-review` (inline comments on specific lines, anthropic only).  |
 |      prompt       | string |   true   |            |                                                             Review instructions passed verbatim as the <br>AI prompt.                                                               |
 |     provider      | string |   true   |            |                                                                        AI provider: `anthropic` or `openai`.                                                                        |
 
@@ -84,7 +82,7 @@ use the companion reusable workflow at
 
 |   OUTPUT   |  TYPE  |                                                         DESCRIPTION                                                         |
 |------------|--------|-----------------------------------------------------------------------------------------------------------------------------|
-| conclusion | string | `success` when the AI review ran; <br>`skipped` when the resolver vetoed the <br>run (invalid input or unsupported combo).  |
+| conclusion | string | `success` when the AI review ran; <br>`skipped` when the resolver vetoed the <br>run (invalid input).  |
 |   reason   | string |                                        One-line explanation when conclusion=skipped.                                        |
 
 <!-- AUTO-DOC-OUTPUT:END -->

--- a/.github/actions/ai-pr-review/README.md
+++ b/.github/actions/ai-pr-review/README.md
@@ -65,14 +65,14 @@ use the companion reusable workflow at
 
 <!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
 
-|       INPUT       |  TYPE  | REQUIRED |  DEFAULT   |                                                                                     DESCRIPTION                                                                                     |
-|-------------------|--------|----------|------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| anthropic-api-key | string |  false   |            |                                                                Anthropic API key. Required when provider=anthropic.                                                                 |
-|      effort       | string |  false   | `"medium"` |                                                    Effort level (low | medium | high) — maps to <br>a provider-specific model.                                                      |
-|   github-token    | string |   true   |            |                                                      Token used by claude-code-action to post <br>comments and read PR state.                                                       |
-|  openai-api-key   | string |  false   |            |                                                                   OpenAI API key. Required when provider=openai.                                                                    |
-|      prompt       | string |   true   |            |                                                             Review instructions passed verbatim as the <br>AI prompt.                                                               |
-|     provider      | string |   true   |            |                                                                        AI provider: `anthropic` or `openai`.                                                                        |
+|       INPUT       |  TYPE  | REQUIRED |  DEFAULT   |                                 DESCRIPTION                                  |
+|-------------------|--------|----------|------------|------------------------------------------------------------------------------|
+| anthropic-api-key | string |  false   |            |             Anthropic API key. Required when provider=anthropic.             |
+|      effort       | string |  false   | `"medium"` | Effort level (low | medium | high) — maps to <br>a provider-specific model.  |
+|   github-token    | string |   true   |            |  Token used by claude-code-action to post <br>comments and read PR state.    |
+|  openai-api-key   | string |  false   |            |                OpenAI API key. Required when provider=openai.                |
+|      prompt       | string |   true   |            |          Review instructions passed verbatim as the <br>AI prompt.           |
+|     provider      | string |   true   |            |                    AI provider: `anthropic` or `openai`.                     |
 
 <!-- AUTO-DOC-INPUT:END -->
 
@@ -80,10 +80,10 @@ use the companion reusable workflow at
 
 <!-- AUTO-DOC-OUTPUT:START - Do not remove or modify this section -->
 
-|   OUTPUT   |  TYPE  |                                                         DESCRIPTION                                                         |
-|------------|--------|-----------------------------------------------------------------------------------------------------------------------------|
+|   OUTPUT   |  TYPE  |                                              DESCRIPTION                                               |
+|------------|--------|--------------------------------------------------------------------------------------------------------|
 | conclusion | string | `success` when the AI review ran; <br>`skipped` when the resolver vetoed the <br>run (invalid input).  |
-|   reason   | string |                                        One-line explanation when conclusion=skipped.                                        |
+|   reason   | string |                             One-line explanation when conclusion=skipped.                              |
 
 <!-- AUTO-DOC-OUTPUT:END -->
 

--- a/.github/actions/ai-pr-review/action.yml
+++ b/.github/actions/ai-pr-review/action.yml
@@ -1,10 +1,12 @@
 name: AI PR review
 description: |
   Runs an AI-powered PR review with a caller-provided prompt. The caller
-  picks provider, effort, outcome, and the review instructions; the action
-  owns model selection, MCP servers, and write-tool access. Advisory only —
-  every failure mode degrades to a notice-level skip. The caller decides
-  which PRs to review via workflow triggers and job-level `if:` conditions.
+  picks provider, effort, and the review instructions; the action owns
+  model selection, comment shape, MCP servers, and write-tool access.
+  The LLM decides whether findings are best expressed as inline comments,
+  a sticky summary, or both. Advisory only — every failure mode degrades
+  to a notice-level skip. The caller decides which PRs to review via
+  workflow triggers and job-level `if:` conditions.
 inputs:
   provider:
     description: 'AI provider: `anthropic` or `openai`.'
@@ -15,9 +17,6 @@ inputs:
     default: 'medium'
   prompt:
     description: 'Review instructions passed verbatim as the AI prompt.'
-    required: true
-  outcome:
-    description: 'What the AI produces: `pr-comment` (a summary PR comment — sticky on anthropic, new per run on openai) or `inline-review` (inline comments on specific lines, anthropic only).'
     required: true
   anthropic-api-key:
     description: 'Anthropic API key. Required when provider=anthropic.'
@@ -31,7 +30,7 @@ inputs:
 
 outputs:
   conclusion:
-    description: '`success` when the AI review ran; `skipped` when the resolver vetoed the run (invalid input or unsupported combo).'
+    description: '`success` when the AI review ran; `skipped` when the resolver vetoed the run (invalid input).'
     value: ${{ steps.conclusion.outputs.conclusion }}
   reason:
     description: 'One-line explanation when conclusion=skipped.'
@@ -46,7 +45,6 @@ runs:
       env:
         INPUT_PROVIDER: ${{ inputs.provider }}
         INPUT_EFFORT: ${{ inputs.effort }}
-        INPUT_OUTCOME: ${{ inputs.outcome }}
       run: ${{ github.action_path }}/src/resolve-config.sh
 
     # The anthropic branch needs the PR tree at the workspace ROOT because
@@ -107,11 +105,20 @@ runs:
         prompt: |
           ${{ inputs.prompt }}
 
-          ${{ steps.cfg.outputs.guidance }}
+          Comment shape is your choice. Post inline comments on specific
+          lines for localized findings; post a summary PR comment for
+          repo-wide or cross-cutting findings; use both when useful. Do
+          not post a summary comment that only restates findings already
+          posted inline — prefer a short synthesis or skip it.
+
+          Provenance: the very last line of every comment you post MUST
+          be this line verbatim (keep the leading `> ` and underscores so
+          it renders as an italic blockquote):
+          > _🤖 ai-pr-review — provider: anthropic · model: ${{ steps.cfg.outputs.model }} · effort: ${{ inputs.effort }}_
         claude_args: |
           --model ${{ steps.cfg.outputs.model }}
           --mcp-config '{"mcpServers":{"context7":{"command":"npx","args":["-y","@upstash/context7-mcp"]},"sequential-thinking":{"command":"npx","args":["-y","@modelcontextprotocol/server-sequential-thinking"]}}}'
-          --allowedTools "Read,Glob,Grep,LS,Bash(git diff:*),Bash(git log:*),Bash(gh pr view:*),Bash(gh pr diff:*),mcp__context7__*,mcp__sequential-thinking__*${{ steps.cfg.outputs.tools_suffix }}"
+          --allowedTools "Read,Glob,Grep,LS,Bash(git diff:*),Bash(git log:*),Bash(gh pr view:*),Bash(gh pr diff:*),mcp__context7__*,mcp__sequential-thinking__*,mcp__github_inline_comment__create_inline_comment"
 
     # --- openai branch ----------------------------------------------------
     # head.sha is used (not refs/pull/N/merge) because merge refs are absent on
@@ -131,6 +138,9 @@ runs:
         persist-credentials: false
         path: _pr
 
+    # codex-action has no inline-comment surface, so the openai path is
+    # always summary-comment-only. Documented as an honest provider
+    # asymmetry in the README rather than hidden behind an input.
     - name: Codex PR review
       id: codex
       if: steps.cfg.outputs.proceed == 'true' && inputs.provider == 'openai'
@@ -146,7 +156,8 @@ runs:
         prompt: |
           ${{ inputs.prompt }}
 
-          ${{ steps.cfg.outputs.guidance }}
+          Report all findings as a single PR comment (codex-action has no
+          inline-comment surface).
 
     - name: Post Codex feedback as PR comment
       if: steps.cfg.outputs.proceed == 'true' && inputs.provider == 'openai' && steps.codex.outputs.final-message != ''
@@ -156,8 +167,17 @@ runs:
         PR_NUMBER: ${{ github.event.pull_request.number }}
         REPO: ${{ github.repository }}
         BODY: ${{ steps.codex.outputs.final-message }}
+        MODEL: ${{ steps.cfg.outputs.model }}
+        EFFORT: ${{ inputs.effort }}
       run: |
-        printf '%s\n' "$BODY" | gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file -
+        # Provenance footer is emitted deterministically here (unlike the
+        # anthropic path which relies on prompt compliance) so every
+        # openai PR comment carries attribution even if the model's body
+        # text doesn't.
+        {
+          printf '%s\n\n' "$BODY"
+          printf '> _🤖 ai-pr-review — provider: openai · model: %s · effort: %s_\n' "$MODEL" "$EFFORT"
+        } | gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file -
 
     - name: Emit conclusion
       id: conclusion

--- a/.github/actions/ai-pr-review/src/resolve-config.sh
+++ b/.github/actions/ai-pr-review/src/resolve-config.sh
@@ -1,39 +1,24 @@
 #!/usr/bin/env bash
 # Validate caller inputs and resolve them into the concrete values the
-# downstream AI review step needs: model id, outcome-specific prompt
-# guidance, and the extra allowed-tool suffix. All conditional logic
-# for the whole action lives here — YAML only dispatches on outputs.
+# downstream AI review step needs: the provider-specific model id. All
+# conditional logic for the whole action lives here — YAML only
+# dispatches on outputs.
 #
-# Required env: INPUT_PROVIDER, INPUT_EFFORT, INPUT_OUTCOME
+# Required env: INPUT_PROVIDER, INPUT_EFFORT
 # Writes to $GITHUB_OUTPUT:
-#   proceed=true|false     — whether the AI step should run
-#   reason=<string>        — one-line explanation (populated on skip)
-#   model=<string>         — provider-specific model identifier
-#   guidance=<multiline>   — appended to the caller's prompt
-#   tools_suffix=<string>  — ",<extra tool>,..." appended to base allowedTools
+#   proceed=true|false  — whether the AI step should run
+#   reason=<string>     — one-line explanation (populated on skip)
+#   model=<string>      — provider-specific model identifier
 # Always exits 0 — invalid input degrades to a skip, never hard-fails.
 set -euo pipefail
 
 : "${INPUT_PROVIDER:?INPUT_PROVIDER required}"
 : "${INPUT_EFFORT:?INPUT_EFFORT required}"
-: "${INPUT_OUTCOME:?INPUT_OUTCOME required}"
 
 emit() {
   local k="$1" v="$2"
   [ -n "${GITHUB_OUTPUT:-}" ] && printf '%s=%s\n' "$k" "$v" >> "$GITHUB_OUTPUT"
   printf '%s=%s\n' "$k" "$v"
-}
-
-emit_multiline() {
-  local k="$1" v="$2"
-  if [ -n "${GITHUB_OUTPUT:-}" ]; then
-    {
-      printf '%s<<EOF\n' "$k"
-      printf '%s\n' "$v"
-      printf 'EOF\n'
-    } >> "$GITHUB_OUTPUT"
-  fi
-  printf '%s<<\n%s\n' "$k" "$v"
 }
 
 skip() {
@@ -42,8 +27,6 @@ skip() {
   emit proceed false
   emit reason  "$reason"
   emit model   ""
-  emit tools_suffix ""
-  emit_multiline guidance ""
   exit 0
 }
 
@@ -60,29 +43,6 @@ case "$INPUT_PROVIDER:$INPUT_EFFORT" in
   *)                skip "invalid provider '$INPUT_PROVIDER' — valid: anthropic, openai" ;;
 esac
 
-# outcome → prompt guidance + extra allowed tools
-case "$INPUT_OUTCOME" in
-  pr-comment)
-    guidance='Outcome policy: report all findings as a SINGLE sticky PR comment. Do not post inline review comments.'
-    tools_suffix=''
-    ;;
-  inline-review)
-    # Inline comments require the github-inline-comment MCP surface that
-    # only claude-code-action wires up. codex-action has no equivalent,
-    # so openai+inline-review degrades to a skip (contract: never hard-fail).
-    if [ "$INPUT_PROVIDER" = "openai" ]; then
-      skip "outcome=inline-review not supported for provider=openai — use outcome=pr-comment"
-    fi
-    guidance='Outcome policy: post inline comments on specific lines for concrete, actionable findings. A short summary comment is optional.'
-    tools_suffix=',mcp__github_inline_comment__create_inline_comment'
-    ;;
-  *)
-    skip "invalid outcome '$INPUT_OUTCOME' — valid: pr-comment, inline-review"
-    ;;
-esac
-
 emit proceed true
 emit reason  ""
 emit model   "$model"
-emit tools_suffix "$tools_suffix"
-emit_multiline guidance "$guidance"

--- a/.github/actions/ai-pr-review/test/resolve-config.bats
+++ b/.github/actions/ai-pr-review/test/resolve-config.bats
@@ -15,7 +15,7 @@ teardown() {
 
 run_script() {
   run env \
-    INPUT_PROVIDER="$1" INPUT_EFFORT="$2" INPUT_OUTCOME="$3" \
+    INPUT_PROVIDER="$1" INPUT_EFFORT="$2" \
     GITHUB_OUTPUT="$GITHUB_OUTPUT" "$SCRIPT"
 }
 
@@ -30,90 +30,56 @@ assert_kv() {
   }
 }
 
-assert_guidance_contains() {
-  local needle="$1"
-  grep -q "$needle" "$GITHUB_OUTPUT" || {
-    echo "want guidance to contain: $needle"
-    cat "$GITHUB_OUTPUT"
-    return 1
-  }
-}
-
 # --- happy path: provider=anthropic × 3 effort levels ------------------------
 
 @test "anthropic:low → model=claude-haiku-4-5, proceed=true" {
-  run_script anthropic low pr-comment
+  run_script anthropic low
   [ "$status" -eq 0 ]
   assert_kv proceed true
   assert_kv model claude-haiku-4-5
 }
 
 @test "anthropic:medium → model=claude-sonnet-4-6, proceed=true" {
-  run_script anthropic medium pr-comment
+  run_script anthropic medium
   [ "$status" -eq 0 ]
   assert_kv proceed true
   assert_kv model claude-sonnet-4-6
 }
 
 @test "anthropic:high → model=claude-opus-4-7, proceed=true" {
-  run_script anthropic high pr-comment
+  run_script anthropic high
   [ "$status" -eq 0 ]
   assert_kv proceed true
   assert_kv model claude-opus-4-7
 }
 
-# --- outcome → guidance + tools_suffix --------------------------------------
-
-@test "outcome=pr-comment → empty tools_suffix, guidance mentions SINGLE" {
-  run_script anthropic medium pr-comment
-  [ "$status" -eq 0 ]
-  assert_kv tools_suffix ""
-  assert_guidance_contains "SINGLE sticky PR comment"
-}
-
-@test "outcome=inline-review → tools_suffix includes inline comment MCP" {
-  run_script anthropic medium inline-review
-  [ "$status" -eq 0 ]
-  assert_kv tools_suffix ",mcp__github_inline_comment__create_inline_comment"
-  assert_guidance_contains "inline comments on specific lines"
-}
-
 # --- openai happy path -------------------------------------------------------
 
 @test "openai:low → model=gpt-5.4-mini, proceed=true" {
-  run_script openai low pr-comment
+  run_script openai low
   [ "$status" -eq 0 ]
   assert_kv proceed true
   assert_kv model gpt-5.4-mini
 }
 
 @test "openai:medium → model=gpt-5.3-codex, proceed=true" {
-  run_script openai medium pr-comment
+  run_script openai medium
   [ "$status" -eq 0 ]
   assert_kv proceed true
   assert_kv model gpt-5.3-codex
 }
 
 @test "openai:high → model=gpt-5.4, proceed=true" {
-  run_script openai high pr-comment
+  run_script openai high
   [ "$status" -eq 0 ]
   assert_kv proceed true
   assert_kv model gpt-5.4
 }
 
-@test "openai + inline-review → proceed=false, reason mentions unsupported outcome" {
-  run_script openai medium inline-review
-  [ "$status" -eq 0 ]
-  assert_kv proceed false
-  grep -q 'reason=.*inline-review not supported for provider=openai' "$GITHUB_OUTPUT" || {
-    cat "$GITHUB_OUTPUT"; return 1;
-  }
-}
-
 # --- input validation --------------------------------------------------------
 
 @test "invalid provider → proceed=false, reason mentions valid list" {
-  run_script bedrock medium pr-comment
+  run_script bedrock medium
   [ "$status" -eq 0 ]
   assert_kv proceed false
   grep -q 'reason=.*invalid provider' "$GITHUB_OUTPUT" || {
@@ -122,7 +88,7 @@ assert_guidance_contains() {
 }
 
 @test "invalid effort on anthropic → proceed=false, reason mentions effort" {
-  run_script anthropic extreme pr-comment
+  run_script anthropic extreme
   [ "$status" -eq 0 ]
   assert_kv proceed false
   grep -q 'reason=.*invalid effort' "$GITHUB_OUTPUT" || {
@@ -131,19 +97,10 @@ assert_guidance_contains() {
 }
 
 @test "invalid effort on openai → proceed=false, reason mentions effort" {
-  run_script openai extreme pr-comment
+  run_script openai extreme
   [ "$status" -eq 0 ]
   assert_kv proceed false
   grep -q 'reason=.*invalid effort' "$GITHUB_OUTPUT" || {
-    cat "$GITHUB_OUTPUT"; return 1;
-  }
-}
-
-@test "invalid outcome → proceed=false, reason mentions outcome" {
-  run_script anthropic medium label
-  [ "$status" -eq 0 ]
-  assert_kv proceed false
-  grep -q 'reason=.*invalid outcome' "$GITHUB_OUTPUT" || {
     cat "$GITHUB_OUTPUT"; return 1;
   }
 }
@@ -152,21 +109,14 @@ assert_guidance_contains() {
 
 @test "missing INPUT_PROVIDER fails loudly" {
   run env -u INPUT_PROVIDER \
-    INPUT_EFFORT=medium INPUT_OUTCOME=pr-comment \
+    INPUT_EFFORT=medium \
     GITHUB_OUTPUT="$GITHUB_OUTPUT" "$SCRIPT"
   [ "$status" -ne 0 ]
 }
 
 @test "missing INPUT_EFFORT fails loudly" {
   run env -u INPUT_EFFORT \
-    INPUT_PROVIDER=anthropic INPUT_OUTCOME=pr-comment \
-    GITHUB_OUTPUT="$GITHUB_OUTPUT" "$SCRIPT"
-  [ "$status" -ne 0 ]
-}
-
-@test "missing INPUT_OUTCOME fails loudly" {
-  run env -u INPUT_OUTCOME \
-    INPUT_PROVIDER=anthropic INPUT_EFFORT=medium \
+    INPUT_PROVIDER=anthropic \
     GITHUB_OUTPUT="$GITHUB_OUTPUT" "$SCRIPT"
   [ "$status" -ne 0 ]
 }

--- a/.github/workflows/ai-pr-review.yaml
+++ b/.github/workflows/ai-pr-review.yaml
@@ -16,10 +16,6 @@ on:
         description: 'Review instructions passed verbatim as the AI prompt.'
         type: string
         required: true
-      outcome:
-        description: 'What the AI produces: `pr-comment` or `inline-review`.'
-        type: string
-        required: true
       timeout-minutes:
         description: 'Job timeout in minutes.'
         type: number
@@ -66,7 +62,6 @@ jobs:
           provider: ${{ inputs.provider }}
           effort: ${{ inputs.effort }}
           prompt: ${{ inputs.prompt }}
-          outcome: ${{ inputs.outcome }}
           anthropic-api-key: ${{ secrets.anthropic-api-key }} # zizmor: ignore[secrets-outside-env] -- API key passed via workflow_call, not a repo secret
           openai-api-key: ${{ secrets.openai-api-key }} # zizmor: ignore[secrets-outside-env] -- API key passed via workflow_call, not a repo secret
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/workflows/ai-pr-review.md
+++ b/docs/workflows/ai-pr-review.md
@@ -54,7 +54,6 @@ review alongside auto-approve on bot PRs.
 |      INPUT      |  TYPE  | REQUIRED |  DEFAULT   |                                 DESCRIPTION                                  |
 |-----------------|--------|----------|------------|------------------------------------------------------------------------------|
 |     effort      | string |  false   | `"medium"` | Effort level (low | medium | high) — maps to <br>a provider-specific model.  |
-|     outcome     | string |   true   |            |         What the AI produces: `pr-comment` or <br>`inline-review`.           |
 |     prompt      | string |   true   |            |          Review instructions passed verbatim as the <br>AI prompt.           |
 |    provider     | string |   true   |            |                    AI provider: `anthropic` or `openai`.                     |
 | timeout-minutes | number |  false   |    `15`    |                           Job timeout in minutes.                            |


### PR DESCRIPTION
## Summary

Supersedes #127 (provenance-only PR).

The `outcome` input conflated two ideas: the comment shape rendered
on the PR (inline vs sticky summary) and the review verdict. In
practice it made `inline-review` double up — claude-code-action
posted both inline comments AND a sticky summary because
`use_sticky_comment: true` was hard-coded, even when the caller
asked for inline-only. Reader lands on two comments on the same PR
with no clear reason for the split.

## New model

One review. The model picks the comment shape per finding.

- Hand it the full toolset (both the inline-comment MCP and the
  sticky-comment surface).
- Prompt-level direction: "inline for localized findings, summary for
  cross-cutting, both when useful."
- Caller who wants a specific shape says so in `prompt`.

OpenAI stays summary-only because `codex-action` has no inline
surface. That provider asymmetry is now documented honestly in the
README rather than papered over behind an input.

## Provenance footer

Every posted comment ends with:

> _🤖 ai-pr-review — provider: anthropic · model: claude-opus-4-7 · effort: high_

- openai path appends the footer deterministically in bash right
  before `gh pr comment --body-file`.
- anthropic path injects a verbatim-line instruction into the prompt;
  claude-code-action respects verbatim directives reliably and sticky
  reruns overwrite the previous body.

## Breaking change

`outcome` is removed from both the composite action and the reusable
workflow wrapper. Internal callers (the `loft-sh/vcluster-docs#1962`
test-bed + the few others) will be updated in follow-up PRs.

## Safety

- zizmor: clean (2 suppressed are pre-existing `secrets-outside-env`
  ignores, unchanged).
- bats: 11/11 pass locally (reduced from 14 — dropped the 3 outcome-
  specific test cases; all others carry over).
- Openai path bash unchanged except for the footer `printf` — same
  `gh pr comment --body-file`, no new subprocesses.

## Future scope (tracked elsewhere)

[DEVOPS-834 — design: generalize ai-pr-review with an output_actions array](https://linear.app/loft/issue/DEVOPS-834/design-generalize-ai-pr-review-with-an-output-actions-array) — generalize into an `output_actions` array: `pr-review`, `slack-notification`, `block-ci`, `pass-ci`. Not in this PR.

## Test plan

- [ ] Retrigger `loft-sh/vcluster-docs#1966` (openai/high) and `#1973`
  (anthropic/high/inline) after merging this + dropping `outcome`
  from the caller workflow. Expect both to pass, every bot comment
  to end with the provenance footer, and the anthropic cell to post
  inline comments with NO redundant sticky summary (model's call).

References DEVOPS-793.