### PR TITLE
feat(ai-step): new small composite action for structured AI output

### DIFF
--- a/.github/actions/ai-step/README.md
+++ b/.github/actions/ai-step/README.md
@@ -74,32 +74,58 @@ jobs:
         run: echo "needs human review"
 ```
 
-## Provider asymmetries
+## How it works
 
-- `allowed-tools` and `mcp-config` are anthropic-only. On `openai` they
-  are silently ignored — `codex-action` sandboxes tool access at the
-  process level instead of exposing an allow-list.
-- `openai`'s schema is forwarded verbatim to `codex exec --output-schema`;
-  `anthropic`'s schema is forwarded via `--json-schema` in `claude_args`.
-  Both paths accept the same JSON Schema draft syntax.
+The action installs the `anthropic` or `openai` Python SDK on the
+runner, then calls the provider's chat API directly with its native
+structured-output binding:
+
+- **Anthropic** → Messages API with `output_config.format.schema`
+- **OpenAI** → Chat Completions with `response_format.json_schema.schema`
+
+No `claude-code-action`, no `codex-action`, no bun install. End-to-end
+call is ~15s including SDK install; the LLM call itself is 2–4s. The
+action never hard-fails: API errors, empty responses, and non-JSON
+content all degrade to `conclusion=failed` with the upstream body
+preserved in the CI log. Caller decides how to react.
+
+### Schema compatibility
+
+Strict structured-output modes on both providers reject some JSON
+Schema features:
+
+- `minimum`, `maximum`, `minLength`, `maxLength`, `pattern` — rejected
+- recursive schemas, `$ref` across documents — rejected
+- objects: `additionalProperties` must be `false` (the action sets this
+  automatically on any object node where it's missing, so you don't
+  have to repeat it in every nested schema)
+
+Structured output guarantees the **shape** of the result (fields
+present, types match, enums respected). It does NOT guarantee semantic
+correctness of the values — that's the model's reasoning. Validate
+ranges and business rules in your downstream step, not in the schema.
+
+### Tool use / MCP
+
+Not supported in v1. If you need Claude Code tools, MCP servers, or
+filesystem access during the reasoning step, reach for
+`anthropics/claude-code-action` directly — `ai-step` is the minimal
+text-to-JSON primitive.
 
 ## Inputs
 
 <!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
 
-|       INPUT       |  TYPE  | REQUIRED |  DEFAULT   |                                                                                                                                          DESCRIPTION                                                                                                                                           |
-|-------------------|--------|----------|------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-|   allowed-tools   | string |  false   |            |                                                 Comma-separated allow-list forwarded to `--allowedTools` on <br>the anthropic path. Ignored on `openai` <br>(codex sandboxes tool access at the <br>process level instead of an allow-list).                                                   |
-| anthropic-api-key | string |  false   |            |                                                                                                                      Anthropic API key. Required when provider=anthropic.                                                                                                                      |
-|      effort       | string |  false   | `"medium"` |                                                                                                          Effort level (low | medium | high) — maps to <br>a provider-specific model.                                                                                                           |
-|       input       | string |  false   |            |                                                                          Optional data the model should act <br>on, appended to the prompt. Caller <br>sources it — a literal string, <br>`${{ steps.X.outputs.Y }}`,                                                                          |
-|                   |        |          |            |                                                                                                                      or the contents of a file <br>read in a prior step.                                                                                                                       |
-|    mcp-config     | string |  false   |            |                                                                                                    Optional JSON passed to `--mcp-config` on <br>the anthropic path. Ignored on `openai`.                                                                                                      |
-|  openai-api-key   | string |  false   |            |                                                                                                                         OpenAI API key. Required when provider=openai.                                                                                                                         |
-|   output-schema   | string |   true   |            | JSON Schema (string) the model output <br>must conform to. Required. Structured output <br>is the contract — without a <br>schema the action skips. For `anthropic` this <br>is forwarded via `--json-schema` in `claude_args`; for `openai` it <br>becomes `output-schema` on `codex-action`. |
-|                   |        |          |            |                                                                                                                                                                                                                                                                                                |
-|      prompt       | string |   true   |            |                                                                                                                          Instructions for the model. Passed verbatim.                                                                                                                          |
-|     provider      | string |   true   |            |                                                                                                                             AI provider: `anthropic` or `openai`.                                                                                                                              |
+|       INPUT       |  TYPE  | REQUIRED |  DEFAULT   |                                                                                                                                            DESCRIPTION                                                                                                                                            |
+|-------------------|--------|----------|------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| anthropic-api-key | string |  false   |            |                                                                                                                       Anthropic API key. Required when provider=anthropic.                                                                                                                        |
+|      effort       | string |  false   | `"medium"` |                                                                                                           Effort level (low | medium | high) — maps to <br>a provider-specific model.                                                                                                             |
+|       input       | string |  false   |            |                                                  Optional data the model should act <br>on, appended to the prompt. Caller <br>sources it — a literal string, <br>a prior step output, or the <br>contents of a file read in <br>a prior step.                                                    |
+|  openai-api-key   | string |  false   |            |                                                                                                                          OpenAI API key. Required when provider=openai.                                                                                                                           |
+|   output-schema   | string |   true   |            | JSON Schema (string) the model output <br>must conform to. Required. Structured output <br>is the contract — without a <br>schema the action skips. For `anthropic` this <br>becomes `output_format.schema` on the Messages API; for <br>`openai` it becomes `response_format.json_schema.schema` |
+|                   |        |          |            |                                                                                                                                 on the Chat Completions <br>API.                                                                                                                                  |
+|      prompt       | string |   true   |            |                                                                                                                           Instructions for the model. Passed verbatim.                                                                                                                            |
+|     provider      | string |   true   |            |                                                                                                                               AI provider: `anthropic` or `openai`.                                                                                                                               |
 
 <!-- AUTO-DOC-INPUT:END -->
 
@@ -107,11 +133,11 @@ jobs:
 
 <!-- AUTO-DOC-OUTPUT:START - Do not remove or modify this section -->
 
-|   OUTPUT   |  TYPE  |                                                             DESCRIPTION                                                             |
-|------------|--------|-------------------------------------------------------------------------------------------------------------------------------------|
-| conclusion | string |                `success` when the AI step ran; <br>`skipped` when the resolver vetoed the <br>run (invalid input).                  |
-|   reason   | string |                                            One-line explanation when conclusion=skipped.                                            |
-|   result   | string | Schema-conforming JSON string. Parse with `fromJSON(...)` <br>in downstream `if:` conditions. Empty when <br>`conclusion=skipped`.  |
+|   OUTPUT   |  TYPE  |                                                                              DESCRIPTION                                                                              |
+|------------|--------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| conclusion | string | `success` when the AI step ran <br>and returned JSON; `skipped` when the <br>resolver vetoed the input; `failed` when <br>the provider errored or returned non-JSON.  |
+|   reason   | string |                                                             One-line explanation when conclusion=skipped.                                                             |
+|   result   | string |             Schema-conforming JSON string. Parse with `fromJSON(...)` <br>in downstream `if:` conditions. Empty when <br>`conclusion` is not `success`.               |
 
 <!-- AUTO-DOC-OUTPUT:END -->
 

--- a/.github/actions/ai-step/README.md
+++ b/.github/actions/ai-step/README.md
@@ -1,0 +1,124 @@
+# AI step
+
+Small reusable building block for CI: run an AI call with a
+caller-supplied prompt and input, bind the output to a JSON Schema,
+expose the schema-conforming JSON as a step output. Downstream steps
+parse with `fromJSON(steps.<id>.outputs.result)` and branch on typed
+fields.
+
+The contract is the schema. Whatever the model returns, the action
+exposes it on `result` and sets `conclusion=success`. The action never
+emits `failed` — the caller knows what empty or unexpected output means
+for their pipeline, and decides whether to continue or `exit 1`.
+
+## When to use this vs `ai-pr-review`
+
+- **`ai-pr-review`** — job-shaped reusable workflow for reviewing PRs.
+  Owns checkout, commenting, sticky summaries, provenance footer.
+- **`ai-step`** — step-shaped primitive for any AI-in / JSON-out flow.
+  No PR awareness, no checkout, no write permissions. Classify a diff,
+  extract fields from a changelog, pick a reviewer, summarize release
+  notes — anywhere you want the model's answer as typed JSON a later
+  step can branch on.
+
+## Effort → model
+
+| Effort | Anthropic            | OpenAI          |
+|--------|----------------------|-----------------|
+| low    | `claude-haiku-4-5`   | `gpt-5.4-mini`  |
+| medium | `claude-sonnet-4-6`  | `gpt-5.3-codex` |
+| high   | `claude-opus-4-7`    | `gpt-5.4`       |
+
+## Usage
+
+```yaml
+jobs:
+  classify-diff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: loft-sh/github-actions
+          ref: ai-step/v1
+          sparse-checkout: .github/actions/ai-step
+          persist-credentials: false
+
+      - id: diff
+        run: |
+          {
+            echo 'text<<EOF'
+            git diff origin/main...HEAD
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - id: classify
+        uses: ./.github/actions/ai-step
+        with:
+          provider: anthropic
+          effort: low
+          prompt: |
+            Classify this diff. Return JSON matching the schema.
+          input: ${{ steps.diff.outputs.text }}
+          output-schema: |
+            {
+              "type": "object",
+              "required": ["severity", "areas"],
+              "properties": {
+                "severity": { "type": "string", "enum": ["low","medium","high"] },
+                "areas":    { "type": "array",  "items": { "type": "string" } }
+              }
+            }
+          anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+
+      - if: steps.classify.outputs.result != '' && fromJSON(steps.classify.outputs.result).severity == 'high'
+        run: echo "needs human review"
+```
+
+## Provider asymmetries
+
+- `allowed-tools` and `mcp-config` are anthropic-only. On `openai` they
+  are silently ignored — `codex-action` sandboxes tool access at the
+  process level instead of exposing an allow-list.
+- `openai`'s schema is forwarded verbatim to `codex exec --output-schema`;
+  `anthropic`'s schema is forwarded via `--json-schema` in `claude_args`.
+  Both paths accept the same JSON Schema draft syntax.
+
+## Inputs
+
+<!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
+
+|       INPUT       |  TYPE  | REQUIRED |  DEFAULT   |                                                                                                                                          DESCRIPTION                                                                                                                                           |
+|-------------------|--------|----------|------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|   allowed-tools   | string |  false   |            |                                                 Comma-separated allow-list forwarded to `--allowedTools` on <br>the anthropic path. Ignored on `openai` <br>(codex sandboxes tool access at the <br>process level instead of an allow-list).                                                   |
+| anthropic-api-key | string |  false   |            |                                                                                                                      Anthropic API key. Required when provider=anthropic.                                                                                                                      |
+|      effort       | string |  false   | `"medium"` |                                                                                                          Effort level (low | medium | high) — maps to <br>a provider-specific model.                                                                                                           |
+|       input       | string |  false   |            |                                                                          Optional data the model should act <br>on, appended to the prompt. Caller <br>sources it — a literal string, <br>`${{ steps.X.outputs.Y }}`,                                                                          |
+|                   |        |          |            |                                                                                                                      or the contents of a file <br>read in a prior step.                                                                                                                       |
+|    mcp-config     | string |  false   |            |                                                                                                    Optional JSON passed to `--mcp-config` on <br>the anthropic path. Ignored on `openai`.                                                                                                      |
+|  openai-api-key   | string |  false   |            |                                                                                                                         OpenAI API key. Required when provider=openai.                                                                                                                         |
+|   output-schema   | string |   true   |            | JSON Schema (string) the model output <br>must conform to. Required. Structured output <br>is the contract — without a <br>schema the action skips. For `anthropic` this <br>is forwarded via `--json-schema` in `claude_args`; for `openai` it <br>becomes `output-schema` on `codex-action`. |
+|                   |        |          |            |                                                                                                                                                                                                                                                                                                |
+|      prompt       | string |   true   |            |                                                                                                                          Instructions for the model. Passed verbatim.                                                                                                                          |
+|     provider      | string |   true   |            |                                                                                                                             AI provider: `anthropic` or `openai`.                                                                                                                              |
+
+<!-- AUTO-DOC-INPUT:END -->
+
+## Outputs
+
+<!-- AUTO-DOC-OUTPUT:START - Do not remove or modify this section -->
+
+|   OUTPUT   |  TYPE  |                                                             DESCRIPTION                                                             |
+|------------|--------|-------------------------------------------------------------------------------------------------------------------------------------|
+| conclusion | string |                `success` when the AI step ran; <br>`skipped` when the resolver vetoed the <br>run (invalid input).                  |
+|   reason   | string |                                            One-line explanation when conclusion=skipped.                                            |
+|   result   | string | Schema-conforming JSON string. Parse with `fromJSON(...)` <br>in downstream `if:` conditions. Empty when <br>`conclusion=skipped`.  |
+
+<!-- AUTO-DOC-OUTPUT:END -->
+
+## Testing
+
+```bash
+make test-ai-step
+```
+
+Runs the bats suite in `test/` against `src/resolve-config.sh`.

--- a/.github/actions/ai-step/action.yml
+++ b/.github/actions/ai-step/action.yml
@@ -87,6 +87,13 @@ runs:
       uses: anthropics/claude-code-action@38ec876110f9fbf8b950c79f534430740c3ac009 # v1.0.101
       with:
         anthropic_api_key: ${{ inputs.anthropic-api-key }} # zizmor: ignore[secrets-outside-env] -- API key passed via composite input, not a repo secret
+        # Pass the default runner token so claude-code-action doesn't
+        # try to exchange an OIDC token for a GitHub App token. Callers
+        # of ai-step shouldn't need `id-token: write` in their workflow
+        # permissions just to run a text-to-JSON call — the token is
+        # unused by the schema-output path, but the upstream action
+        # resolves one unconditionally on startup.
+        github_token: ${{ github.token }}
         prompt: |
           ${{ inputs.prompt }}
 

--- a/.github/actions/ai-step/action.yml
+++ b/.github/actions/ai-step/action.yml
@@ -1,0 +1,152 @@
+name: AI step
+description: |
+  Small reusable building block: run an AI call with a caller-supplied
+  prompt and input, bind the output to a JSON Schema, expose the
+  schema-conforming JSON as a step output. Downstream steps parse with
+  `fromJSON(steps.<id>.outputs.result)` and branch on typed fields.
+  The action never hard-fails on model errors — it always returns what
+  the model produced (empty on failure). The caller decides how to react.
+inputs:
+  provider:
+    description: 'AI provider: `anthropic` or `openai`.'
+    required: true
+  effort:
+    description: 'Effort level (low | medium | high) — maps to a provider-specific model.'
+    required: false
+    default: 'medium'
+  prompt:
+    description: 'Instructions for the model. Passed verbatim.'
+    required: true
+  input:
+    description: |
+      Optional data the model should act on, appended to the prompt.
+      Caller sources it — a literal string, `${{ steps.X.outputs.Y }}`,
+      or the contents of a file read in a prior step.
+    required: false
+    default: ''
+  output-schema:
+    description: |
+      JSON Schema (string) the model output must conform to. Required.
+      Structured output is the contract — without a schema the action
+      skips. For `anthropic` this is forwarded via `--json-schema` in
+      `claude_args`; for `openai` it becomes `output-schema` on
+      `codex-action`.
+    required: true
+  allowed-tools:
+    description: |
+      Comma-separated allow-list forwarded to `--allowedTools` on the
+      anthropic path. Ignored on `openai` (codex sandboxes tool access
+      at the process level instead of an allow-list).
+    required: false
+    default: ''
+  mcp-config:
+    description: |
+      Optional JSON passed to `--mcp-config` on the anthropic path.
+      Ignored on `openai`.
+    required: false
+    default: ''
+  anthropic-api-key:
+    description: 'Anthropic API key. Required when provider=anthropic.'
+    required: false
+  openai-api-key:
+    description: 'OpenAI API key. Required when provider=openai.'
+    required: false
+
+outputs:
+  result:
+    description: |
+      Schema-conforming JSON string. Parse with `fromJSON(...)` in
+      downstream `if:` conditions. Empty when `conclusion=skipped`.
+    value: ${{ steps.result.outputs.result }}
+  conclusion:
+    description: '`success` when the AI step ran; `skipped` when the resolver vetoed the run (invalid input).'
+    value: ${{ steps.result.outputs.conclusion }}
+  reason:
+    description: 'One-line explanation when conclusion=skipped.'
+    value: ${{ steps.cfg.outputs.reason }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve config
+      id: cfg
+      shell: bash
+      env:
+        INPUT_PROVIDER: ${{ inputs.provider }}
+        INPUT_EFFORT: ${{ inputs.effort }}
+        INPUT_OUTPUT_SCHEMA: ${{ inputs.output-schema }}
+      run: ${{ github.action_path }}/src/resolve-config.sh
+
+    # --- anthropic branch -----------------------------------------------
+    # Schema is forwarded via `--json-schema` in claude_args. The action
+    # then exposes schema-conforming JSON on `outputs.structured_output`.
+    # allowed-tools / mcp-config are appended as extra CLI flags.
+    - name: Claude AI step
+      id: claude
+      if: steps.cfg.outputs.proceed == 'true' && inputs.provider == 'anthropic'
+      uses: anthropics/claude-code-action@38ec876110f9fbf8b950c79f534430740c3ac009 # v1.0.101
+      with:
+        anthropic_api_key: ${{ inputs.anthropic-api-key }} # zizmor: ignore[secrets-outside-env] -- API key passed via composite input, not a repo secret
+        prompt: |
+          ${{ inputs.prompt }}
+
+          ${{ inputs.input }}
+        claude_args: |
+          --model ${{ steps.cfg.outputs.model }}
+          --json-schema ${{ toJSON(inputs.output-schema) }}
+          ${{ inputs.allowed-tools != '' && format('--allowedTools "{0}"', inputs.allowed-tools) || '' }}
+          ${{ inputs.mcp-config != '' && format('--mcp-config {0}', toJSON(inputs.mcp-config)) || '' }}
+
+    # --- openai branch --------------------------------------------------
+    # codex-action exposes `output-schema` as a native input and returns
+    # the schema-conforming JSON on `outputs.final-message`.
+    - name: Codex AI step
+      id: codex
+      if: steps.cfg.outputs.proceed == 'true' && inputs.provider == 'openai'
+      uses: openai/codex-action@c25d10f3f498316d4b2496cc4c6dd58057a7b031 # v1.6
+      with:
+        openai-api-key: ${{ inputs.openai-api-key }} # zizmor: ignore[secrets-outside-env] -- API key passed via composite input, not a repo secret
+        model: ${{ steps.cfg.outputs.model }}
+        effort: ${{ inputs.effort }}
+        sandbox: read-only
+        safety-strategy: drop-sudo
+        allow-bots: 'true'
+        output-schema: ${{ inputs.output-schema }}
+        prompt: |
+          ${{ inputs.prompt }}
+
+          ${{ inputs.input }}
+
+    # --- unify outputs --------------------------------------------------
+    # Both provider paths feed one `result` output so callers don't care
+    # which branch ran. `conclusion=success` even when the AI returned
+    # an empty body — caller inspects `result` and decides. The action
+    # never emits `failed`: structured output is the whole contract, and
+    # the caller is the one who knows what empty means for their pipeline.
+    - name: Emit result
+      id: result
+      if: always()
+      shell: bash
+      env:
+        PROCEED: ${{ steps.cfg.outputs.proceed }}
+        CLAUDE_OUT: ${{ steps.claude.outputs.structured_output }}
+        CODEX_OUT: ${{ steps.codex.outputs.final-message }}
+        PROVIDER: ${{ inputs.provider }}
+      run: |
+        if [ "$PROCEED" != "true" ]; then
+          {
+            echo 'result<<AISTEP_EOF'
+            echo 'AISTEP_EOF'
+            echo 'conclusion=skipped'
+          } >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        case "$PROVIDER" in
+          anthropic) body="$CLAUDE_OUT" ;;
+          openai)    body="$CODEX_OUT" ;;
+          *)         body="" ;;
+        esac
+        {
+          printf 'result<<AISTEP_EOF\n%s\nAISTEP_EOF\n' "$body"
+          echo 'conclusion=success'
+        } >> "$GITHUB_OUTPUT"

--- a/.github/actions/ai-step/action.yml
+++ b/.github/actions/ai-step/action.yml
@@ -3,9 +3,11 @@ description: |
   Small reusable building block: run an AI call with a caller-supplied
   prompt and input, bind the output to a JSON Schema, expose the
   schema-conforming JSON as a step output. Downstream steps parse with
-  `fromJSON(steps.<id>.outputs.result)` and branch on typed fields.
-  The action never hard-fails on model errors — it always returns what
-  the model produced (empty on failure). The caller decides how to react.
+  fromJSON(steps.<id>.outputs.result) and branch on typed fields.
+
+  Calls the provider's chat API directly (Anthropic Messages API or
+  OpenAI Chat Completions API) with native structured-output binding.
+  No bun, no claude-code-action wrapper, no PR-review machinery.
 inputs:
   provider:
     description: 'AI provider: `anthropic` or `openai`.'
@@ -28,23 +30,10 @@ inputs:
     description: |
       JSON Schema (string) the model output must conform to. Required.
       Structured output is the contract — without a schema the action
-      skips. For `anthropic` this is forwarded via `--json-schema` in
-      `claude_args`; for `openai` it becomes `output-schema` on
-      `codex-action`.
+      skips. For `anthropic` this becomes `output_format.schema` on the
+      Messages API; for `openai` it becomes `response_format.json_schema.schema`
+      on the Chat Completions API.
     required: true
-  allowed-tools:
-    description: |
-      Comma-separated allow-list forwarded to `--allowedTools` on the
-      anthropic path. Ignored on `openai` (codex sandboxes tool access
-      at the process level instead of an allow-list).
-    required: false
-    default: ''
-  mcp-config:
-    description: |
-      Optional JSON passed to `--mcp-config` on the anthropic path.
-      Ignored on `openai`.
-    required: false
-    default: ''
   anthropic-api-key:
     description: 'Anthropic API key. Required when provider=anthropic.'
     required: false
@@ -56,11 +45,11 @@ outputs:
   result:
     description: |
       Schema-conforming JSON string. Parse with `fromJSON(...)` in
-      downstream `if:` conditions. Empty when `conclusion=skipped`.
-    value: ${{ steps.result.outputs.result }}
+      downstream `if:` conditions. Empty when `conclusion` is not `success`.
+    value: ${{ steps.run.outputs.result }}
   conclusion:
-    description: '`success` when the AI step ran; `skipped` when the resolver vetoed the run (invalid input).'
-    value: ${{ steps.result.outputs.conclusion }}
+    description: '`success` when the AI step ran and returned JSON; `skipped` when the resolver vetoed the input; `failed` when the provider errored or returned non-JSON.'
+    value: ${{ steps.conclusion.outputs.conclusion }}
   reason:
     description: 'One-line explanation when conclusion=skipped.'
     value: ${{ steps.cfg.outputs.reason }}
@@ -77,83 +66,45 @@ runs:
         INPUT_OUTPUT_SCHEMA: ${{ inputs.output-schema }}
       run: ${{ github.action_path }}/src/resolve-config.sh
 
-    # --- anthropic branch -----------------------------------------------
-    # Schema is forwarded via `--json-schema` in claude_args. The action
-    # then exposes schema-conforming JSON on `outputs.structured_output`.
-    # allowed-tools / mcp-config are appended as extra CLI flags.
-    - name: Claude AI step
-      id: claude
-      if: steps.cfg.outputs.proceed == 'true' && inputs.provider == 'anthropic'
-      uses: anthropics/claude-code-action@38ec876110f9fbf8b950c79f534430740c3ac009 # v1.0.101
-      with:
-        anthropic_api_key: ${{ inputs.anthropic-api-key }} # zizmor: ignore[secrets-outside-env] -- API key passed via composite input, not a repo secret
-        # Pass the default runner token so claude-code-action doesn't
-        # try to exchange an OIDC token for a GitHub App token. Callers
-        # of ai-step shouldn't need `id-token: write` in their workflow
-        # permissions just to run a text-to-JSON call — the token is
-        # unused by the schema-output path, but the upstream action
-        # resolves one unconditionally on startup.
-        github_token: ${{ github.token }}
-        prompt: |
-          ${{ inputs.prompt }}
+    - name: Install provider SDK
+      if: steps.cfg.outputs.proceed == 'true'
+      shell: bash
+      env:
+        PROVIDER: ${{ inputs.provider }}
+      run: |
+        set -euo pipefail
+        case "$PROVIDER" in
+          anthropic) python3 -m pip install --quiet --disable-pip-version-check anthropic ;;
+          openai)    python3 -m pip install --quiet --disable-pip-version-check openai ;;
+          *) echo "::error::unknown provider '$PROVIDER'"; exit 1 ;;
+        esac
 
-          ${{ inputs.input }}
-        claude_args: |
-          --model ${{ steps.cfg.outputs.model }}
-          --json-schema ${{ toJSON(inputs.output-schema) }}
-          ${{ inputs.allowed-tools != '' && format('--allowedTools "{0}"', inputs.allowed-tools) || '' }}
-          ${{ inputs.mcp-config != '' && format('--mcp-config {0}', toJSON(inputs.mcp-config)) || '' }}
+    - name: Call provider
+      id: run
+      if: steps.cfg.outputs.proceed == 'true'
+      shell: bash
+      env:
+        INPUT_PROVIDER: ${{ inputs.provider }}
+        INPUT_MODEL: ${{ steps.cfg.outputs.model }}
+        INPUT_PROMPT: ${{ inputs.prompt }}
+        INPUT_INPUT: ${{ inputs.input }}
+        INPUT_OUTPUT_SCHEMA: ${{ inputs.output-schema }}
+        INPUT_ANTHROPIC_API_KEY: ${{ inputs.anthropic-api-key }}
+        INPUT_OPENAI_API_KEY: ${{ inputs.openai-api-key }}
+      run: python3 ${{ github.action_path }}/src/run.py
 
-    # --- openai branch --------------------------------------------------
-    # codex-action exposes `output-schema` as a native input and returns
-    # the schema-conforming JSON on `outputs.final-message`.
-    - name: Codex AI step
-      id: codex
-      if: steps.cfg.outputs.proceed == 'true' && inputs.provider == 'openai'
-      uses: openai/codex-action@c25d10f3f498316d4b2496cc4c6dd58057a7b031 # v1.6
-      with:
-        openai-api-key: ${{ inputs.openai-api-key }} # zizmor: ignore[secrets-outside-env] -- API key passed via composite input, not a repo secret
-        model: ${{ steps.cfg.outputs.model }}
-        effort: ${{ inputs.effort }}
-        sandbox: read-only
-        safety-strategy: drop-sudo
-        allow-bots: 'true'
-        output-schema: ${{ inputs.output-schema }}
-        prompt: |
-          ${{ inputs.prompt }}
-
-          ${{ inputs.input }}
-
-    # --- unify outputs --------------------------------------------------
-    # Both provider paths feed one `result` output so callers don't care
-    # which branch ran. `conclusion=success` even when the AI returned
-    # an empty body — caller inspects `result` and decides. The action
-    # never emits `failed`: structured output is the whole contract, and
-    # the caller is the one who knows what empty means for their pipeline.
-    - name: Emit result
-      id: result
+    - name: Emit conclusion
+      id: conclusion
       if: always()
       shell: bash
       env:
         PROCEED: ${{ steps.cfg.outputs.proceed }}
-        CLAUDE_OUT: ${{ steps.claude.outputs.structured_output }}
-        CODEX_OUT: ${{ steps.codex.outputs.final-message }}
-        PROVIDER: ${{ inputs.provider }}
+        RUN_CONCLUSION: ${{ steps.run.outputs.conclusion }}
       run: |
         if [ "$PROCEED" != "true" ]; then
-          {
-            echo 'result<<AISTEP_EOF'
-            echo 'AISTEP_EOF'
-            echo 'conclusion=skipped'
-          } >> "$GITHUB_OUTPUT"
-          exit 0
+          echo "conclusion=skipped" >> "$GITHUB_OUTPUT"
+        elif [ -n "$RUN_CONCLUSION" ]; then
+          echo "conclusion=$RUN_CONCLUSION" >> "$GITHUB_OUTPUT"
+        else
+          echo "conclusion=failed" >> "$GITHUB_OUTPUT"
         fi
-        case "$PROVIDER" in
-          anthropic) body="$CLAUDE_OUT" ;;
-          openai)    body="$CODEX_OUT" ;;
-          *)         body="" ;;
-        esac
-        {
-          printf 'result<<AISTEP_EOF\n%s\nAISTEP_EOF\n' "$body"
-          echo 'conclusion=success'
-        } >> "$GITHUB_OUTPUT"

--- a/.github/actions/ai-step/action.yml
+++ b/.github/actions/ai-step/action.yml
@@ -20,8 +20,8 @@ inputs:
   input:
     description: |
       Optional data the model should act on, appended to the prompt.
-      Caller sources it — a literal string, `${{ steps.X.outputs.Y }}`,
-      or the contents of a file read in a prior step.
+      Caller sources it — a literal string, a prior step output, or
+      the contents of a file read in a prior step.
     required: false
     default: ''
   output-schema:

--- a/.github/actions/ai-step/src/resolve-config.sh
+++ b/.github/actions/ai-step/src/resolve-config.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Validate caller inputs and resolve them into the concrete values the
+# downstream AI step needs: the provider-specific model id. All
+# conditional logic for the whole action lives here — YAML only
+# dispatches on outputs.
+#
+# Required env: INPUT_PROVIDER, INPUT_EFFORT, INPUT_OUTPUT_SCHEMA
+# Writes to $GITHUB_OUTPUT:
+#   proceed=true|false  — whether the AI step should run
+#   reason=<string>     — one-line explanation (populated on skip)
+#   model=<string>      — provider-specific model identifier
+# Always exits 0 — invalid input degrades to a skip, never hard-fails.
+set -euo pipefail
+
+: "${INPUT_PROVIDER:?INPUT_PROVIDER required}"
+: "${INPUT_EFFORT:?INPUT_EFFORT required}"
+: "${INPUT_OUTPUT_SCHEMA?INPUT_OUTPUT_SCHEMA required}"
+
+emit() {
+  local k="$1" v="$2"
+  [ -n "${GITHUB_OUTPUT:-}" ] && printf '%s=%s\n' "$k" "$v" >> "$GITHUB_OUTPUT"
+  printf '%s=%s\n' "$k" "$v"
+}
+
+skip() {
+  local reason="$1"
+  echo "::notice::ai-step: $reason"
+  emit proceed false
+  emit reason  "$reason"
+  emit model   ""
+  exit 0
+}
+
+# schema is the contract of the action — empty schema defeats the point
+if [ -z "${INPUT_OUTPUT_SCHEMA// }" ]; then
+  skip "output-schema is required — structured output is the contract"
+fi
+
+# provider + effort → model
+case "$INPUT_PROVIDER:$INPUT_EFFORT" in
+  anthropic:low)    model='claude-haiku-4-5' ;;
+  anthropic:medium) model='claude-sonnet-4-6' ;;
+  anthropic:high)   model='claude-opus-4-7' ;;
+  anthropic:*)      skip "invalid effort '$INPUT_EFFORT' — valid: low, medium, high" ;;
+  openai:low)       model='gpt-5.4-mini' ;;
+  openai:medium)    model='gpt-5.3-codex' ;;
+  openai:high)      model='gpt-5.4' ;;
+  openai:*)         skip "invalid effort '$INPUT_EFFORT' — valid: low, medium, high" ;;
+  *)                skip "invalid provider '$INPUT_PROVIDER' — valid: anthropic, openai" ;;
+esac
+
+emit proceed true
+emit reason  ""
+emit model   "$model"

--- a/.github/actions/ai-step/src/run.py
+++ b/.github/actions/ai-step/src/run.py
@@ -26,6 +26,23 @@ import os
 import sys
 
 
+def enforce_strict(node):
+    """Walk the schema and set `additionalProperties: false` on every
+    object node that doesn't already specify it. Both Anthropic and
+    OpenAI strict structured-output modes require this; making it
+    implicit means callers don't have to repeat it on every nested
+    object in their schema."""
+    if isinstance(node, dict):
+        if node.get("type") == "object" and "additionalProperties" not in node:
+            node["additionalProperties"] = False
+        for v in node.values():
+            enforce_strict(v)
+    elif isinstance(node, list):
+        for item in node:
+            enforce_strict(item)
+    return node
+
+
 def emit_block(key: str, value: str) -> None:
     path = os.environ.get("GITHUB_OUTPUT")
     if not path:
@@ -129,6 +146,8 @@ def main() -> None:
         schema = json.loads(schema_raw)
     except json.JSONDecodeError as e:
         fail_soft(f"output-schema is not valid JSON: {e}")
+
+    enforce_strict(schema)
 
     user_content = f"{prompt}\n\n{input_text}" if input_text else prompt
 

--- a/.github/actions/ai-step/src/run.py
+++ b/.github/actions/ai-step/src/run.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Call the provider's chat API with response_format / output_format
+bound to the caller's JSON Schema. Writes the model's schema-conforming
+output to $GITHUB_OUTPUT as `result`.
+
+The action is advisory-only: any failure (bad schema, API error, empty
+content, non-JSON response) degrades to `conclusion=failed` with the
+upstream body preserved in the CI log. The caller decides how to react.
+
+Env in:
+  INPUT_PROVIDER          anthropic | openai
+  INPUT_MODEL             provider-specific model id
+  INPUT_PROMPT            instructions
+  INPUT_OUTPUT_SCHEMA     JSON Schema string
+  INPUT_INPUT             optional data appended to the prompt
+  INPUT_ANTHROPIC_API_KEY required when provider=anthropic
+  INPUT_OPENAI_API_KEY    required when provider=openai
+Env out ($GITHUB_OUTPUT):
+  result                  the schema-conforming JSON string (or empty)
+  conclusion              success | failed
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+
+def emit_block(key: str, value: str) -> None:
+    path = os.environ.get("GITHUB_OUTPUT")
+    if not path:
+        return
+    with open(path, "a") as f:
+        f.write(f"{key}<<AISTEP_EOF\n{value}\nAISTEP_EOF\n")
+
+
+def emit_kv(key: str, value: str) -> None:
+    path = os.environ.get("GITHUB_OUTPUT")
+    if not path:
+        return
+    with open(path, "a") as f:
+        f.write(f"{key}={value}\n")
+
+
+def fail_soft(msg: str, body: str = "") -> None:
+    print(f"::warning::ai-step: {msg}")
+    if body:
+        print("--- upstream response ---")
+        print(body)
+        print("--- end ---")
+    emit_block("result", "")
+    emit_kv("conclusion", "failed")
+    sys.exit(0)
+
+
+def require(name: str) -> str:
+    v = os.environ.get(name, "")
+    if not v:
+        print(f"::error::missing required env {name}")
+        sys.exit(1)
+    return v
+
+
+def call_anthropic(model: str, user_content: str, schema: dict, api_key: str) -> str:
+    try:
+        from anthropic import Anthropic, APIError  # type: ignore
+    except ImportError:
+        fail_soft("anthropic SDK not installed")
+
+    client = Anthropic(api_key=api_key)
+    try:
+        resp = client.messages.create(
+            model=model,
+            max_tokens=4096,
+            messages=[{"role": "user", "content": user_content}],
+            output_config={"format": {"type": "json_schema", "schema": schema}},
+        )
+    except APIError as e:
+        fail_soft(f"anthropic API error: {e}", getattr(e, "body", ""))
+    except Exception as e:
+        fail_soft(f"anthropic request failed: {e}")
+
+    if not resp.content:
+        fail_soft("empty content from anthropic", json.dumps(resp.model_dump(), indent=2))
+    # Structured-output responses still land in content[0].text — the
+    # text payload is guaranteed to parse against the schema.
+    return resp.content[0].text
+
+
+def call_openai(model: str, user_content: str, schema: dict, api_key: str) -> str:
+    try:
+        from openai import OpenAI, APIError  # type: ignore
+    except ImportError:
+        fail_soft("openai SDK not installed")
+
+    client = OpenAI(api_key=api_key)
+    try:
+        resp = client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": user_content}],
+            response_format={
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "ai_step_output",
+                    "schema": schema,
+                    "strict": True,
+                },
+            },
+        )
+    except APIError as e:
+        fail_soft(f"openai API error: {e}", getattr(e, "body", ""))
+    except Exception as e:
+        fail_soft(f"openai request failed: {e}")
+
+    text = resp.choices[0].message.content
+    if text is None:
+        fail_soft("empty content from openai", json.dumps(resp.model_dump(), indent=2))
+    return text
+
+
+def main() -> None:
+    provider = require("INPUT_PROVIDER")
+    model = require("INPUT_MODEL")
+    prompt = require("INPUT_PROMPT")
+    schema_raw = require("INPUT_OUTPUT_SCHEMA")
+    input_text = os.environ.get("INPUT_INPUT", "")
+
+    try:
+        schema = json.loads(schema_raw)
+    except json.JSONDecodeError as e:
+        fail_soft(f"output-schema is not valid JSON: {e}")
+
+    user_content = f"{prompt}\n\n{input_text}" if input_text else prompt
+
+    if provider == "anthropic":
+        api_key = os.environ.get("INPUT_ANTHROPIC_API_KEY", "")
+        if not api_key:
+            fail_soft("anthropic-api-key required when provider=anthropic")
+        text = call_anthropic(model, user_content, schema, api_key)
+    elif provider == "openai":
+        api_key = os.environ.get("INPUT_OPENAI_API_KEY", "")
+        if not api_key:
+            fail_soft("openai-api-key required when provider=openai")
+        text = call_openai(model, user_content, schema, api_key)
+    else:
+        fail_soft(f"unknown provider: {provider}")
+
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        fail_soft("provider returned non-JSON content", text)
+
+    emit_block("result", text)
+    emit_kv("conclusion", "success")
+
+    print(f"ai-step: {provider} / {model} → success")
+    print(json.dumps(parsed, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/actions/ai-step/test/resolve-config.bats
+++ b/.github/actions/ai-step/test/resolve-config.bats
@@ -1,0 +1,158 @@
+#!/usr/bin/env bats
+# Decision-table coverage for resolve-config.sh.
+# Pure env-in, GITHUB_OUTPUT-out — no external CLIs to mock.
+
+SCRIPT="$BATS_TEST_DIRNAME/../src/resolve-config.sh"
+
+# Non-empty schema value reused across happy-path tests.
+SCHEMA='{"type":"object"}'
+
+setup() {
+  export GITHUB_OUTPUT
+  GITHUB_OUTPUT="$(mktemp)"
+}
+
+teardown() {
+  rm -f "$GITHUB_OUTPUT"
+}
+
+run_script() {
+  local provider="$1" effort="$2" schema="${3-$SCHEMA}"
+  run env \
+    INPUT_PROVIDER="$provider" \
+    INPUT_EFFORT="$effort" \
+    INPUT_OUTPUT_SCHEMA="$schema" \
+    GITHUB_OUTPUT="$GITHUB_OUTPUT" "$SCRIPT"
+}
+
+assert_kv() {
+  local want="$1=$2" actual
+  actual=$(grep "^$1=" "$GITHUB_OUTPUT" | tail -n1)
+  [ "$actual" = "$want" ] || {
+    echo "want: $want"
+    echo "got:  $actual"
+    cat "$GITHUB_OUTPUT"
+    return 1
+  }
+}
+
+# --- happy path: provider=anthropic × 3 effort levels ------------------------
+
+@test "anthropic:low → model=claude-haiku-4-5, proceed=true" {
+  run_script anthropic low
+  [ "$status" -eq 0 ]
+  assert_kv proceed true
+  assert_kv model claude-haiku-4-5
+}
+
+@test "anthropic:medium → model=claude-sonnet-4-6, proceed=true" {
+  run_script anthropic medium
+  [ "$status" -eq 0 ]
+  assert_kv proceed true
+  assert_kv model claude-sonnet-4-6
+}
+
+@test "anthropic:high → model=claude-opus-4-7, proceed=true" {
+  run_script anthropic high
+  [ "$status" -eq 0 ]
+  assert_kv proceed true
+  assert_kv model claude-opus-4-7
+}
+
+# --- openai happy path -------------------------------------------------------
+
+@test "openai:low → model=gpt-5.4-mini, proceed=true" {
+  run_script openai low
+  [ "$status" -eq 0 ]
+  assert_kv proceed true
+  assert_kv model gpt-5.4-mini
+}
+
+@test "openai:medium → model=gpt-5.3-codex, proceed=true" {
+  run_script openai medium
+  [ "$status" -eq 0 ]
+  assert_kv proceed true
+  assert_kv model gpt-5.3-codex
+}
+
+@test "openai:high → model=gpt-5.4, proceed=true" {
+  run_script openai high
+  [ "$status" -eq 0 ]
+  assert_kv proceed true
+  assert_kv model gpt-5.4
+}
+
+# --- input validation --------------------------------------------------------
+
+@test "invalid provider → proceed=false, reason mentions valid list" {
+  run_script bedrock medium
+  [ "$status" -eq 0 ]
+  assert_kv proceed false
+  grep -q 'reason=.*invalid provider' "$GITHUB_OUTPUT" || {
+    cat "$GITHUB_OUTPUT"; return 1;
+  }
+}
+
+@test "invalid effort on anthropic → proceed=false, reason mentions effort" {
+  run_script anthropic extreme
+  [ "$status" -eq 0 ]
+  assert_kv proceed false
+  grep -q 'reason=.*invalid effort' "$GITHUB_OUTPUT" || {
+    cat "$GITHUB_OUTPUT"; return 1;
+  }
+}
+
+@test "invalid effort on openai → proceed=false, reason mentions effort" {
+  run_script openai extreme
+  [ "$status" -eq 0 ]
+  assert_kv proceed false
+  grep -q 'reason=.*invalid effort' "$GITHUB_OUTPUT" || {
+    cat "$GITHUB_OUTPUT"; return 1;
+  }
+}
+
+# --- schema is the contract --------------------------------------------------
+
+@test "empty output-schema → proceed=false, reason mentions schema" {
+  run_script anthropic medium ""
+  [ "$status" -eq 0 ]
+  assert_kv proceed false
+  grep -q 'reason=.*output-schema is required' "$GITHUB_OUTPUT" || {
+    cat "$GITHUB_OUTPUT"; return 1;
+  }
+}
+
+@test "whitespace-only output-schema → proceed=false" {
+  run_script anthropic medium "   "
+  [ "$status" -eq 0 ]
+  assert_kv proceed false
+  grep -q 'reason=.*output-schema is required' "$GITHUB_OUTPUT" || {
+    cat "$GITHUB_OUTPUT"; return 1;
+  }
+}
+
+# --- missing required envs ---------------------------------------------------
+
+@test "missing INPUT_PROVIDER fails loudly" {
+  run env -u INPUT_PROVIDER \
+    INPUT_EFFORT=medium \
+    INPUT_OUTPUT_SCHEMA="$SCHEMA" \
+    GITHUB_OUTPUT="$GITHUB_OUTPUT" "$SCRIPT"
+  [ "$status" -ne 0 ]
+}
+
+@test "missing INPUT_EFFORT fails loudly" {
+  run env -u INPUT_EFFORT \
+    INPUT_PROVIDER=anthropic \
+    INPUT_OUTPUT_SCHEMA="$SCHEMA" \
+    GITHUB_OUTPUT="$GITHUB_OUTPUT" "$SCRIPT"
+  [ "$status" -ne 0 ]
+}
+
+@test "missing INPUT_OUTPUT_SCHEMA fails loudly" {
+  run env -u INPUT_OUTPUT_SCHEMA \
+    INPUT_PROVIDER=anthropic \
+    INPUT_EFFORT=medium \
+    GITHUB_OUTPUT="$GITHUB_OUTPUT" "$SCRIPT"
+  [ "$status" -ne 0 ]
+}

--- a/.github/workflows/test-ai-step.yaml
+++ b/.github/workflows/test-ai-step.yaml
@@ -57,13 +57,17 @@ jobs:
             Do not include any prose — only the JSON object.
           input: |
             The release shipped on time and the rollback runbook worked cleanly.
+          # Keep the schema constraint-free — Anthropic's strict
+          # structured-output rejects numeric min/max and a handful of
+          # other JSON Schema features. The smoke test targets the
+          # intersection of what all supported providers accept.
           output-schema: |
             {
               "type": "object",
               "required": ["sentiment", "confidence"],
               "properties": {
                 "sentiment":  { "type": "string", "enum": ["positive", "neutral", "negative"] },
-                "confidence": { "type": "number", "minimum": 0, "maximum": 1 }
+                "confidence": { "type": "number" }
               }
             }
           anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/test-ai-step.yaml
+++ b/.github/workflows/test-ai-step.yaml
@@ -1,0 +1,85 @@
+name: Test ai-step
+
+on:
+  pull_request:
+    paths:
+      - '.github/actions/ai-step/**'
+      - '.github/workflows/test-ai-step.yaml'
+  workflow_dispatch:
+    inputs:
+      provider:
+        description: 'Provider to smoke-test (anthropic | openai)'
+        type: choice
+        options: [anthropic, openai]
+        default: anthropic
+      effort:
+        description: 'Effort level'
+        type: choice
+        options: [low, medium, high]
+        default: low
+
+permissions:
+  contents: read
+
+jobs:
+  bats:
+    name: Run bats tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
+        with:
+          tests: .github/actions/ai-step/test
+
+  # Live smoke test. Spends real tokens, so gated behind workflow_dispatch
+  # only — never runs on PR events. Proves the whole pipeline: schema is
+  # forwarded to the provider, model returns JSON conforming to it, the
+  # action re-exposes it on `result`, and `fromJSON(...)` parses cleanly
+  # downstream.
+  smoke:
+    if: github.event_name == 'workflow_dispatch'
+    name: Live smoke (${{ inputs.provider }}, ${{ inputs.effort }})
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - id: classify
+        uses: ./.github/actions/ai-step
+        with:
+          provider: ${{ inputs.provider }}
+          effort: ${{ inputs.effort }}
+          prompt: |
+            Classify the sentiment of the input. Respond with JSON matching the schema.
+            Do not include any prose — only the JSON object.
+          input: |
+            The release shipped on time and the rollback runbook worked cleanly.
+          output-schema: |
+            {
+              "type": "object",
+              "required": ["sentiment", "confidence"],
+              "properties": {
+                "sentiment":  { "type": "string", "enum": ["positive", "neutral", "negative"] },
+                "confidence": { "type": "number", "minimum": 0, "maximum": 1 }
+              }
+            }
+          anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+
+      - name: Assert structured output
+        env:
+          RESULT: ${{ steps.classify.outputs.result }}
+          CONCLUSION: ${{ steps.classify.outputs.conclusion }}
+        run: |
+          echo "conclusion=$CONCLUSION"
+          echo "result=$RESULT"
+          [ "$CONCLUSION" = "success" ] || { echo "::error::expected conclusion=success, got '$CONCLUSION'"; exit 1; }
+          [ -n "$RESULT" ] || { echo "::error::empty result"; exit 1; }
+          echo "$RESULT" | jq -e '.sentiment | IN("positive","neutral","negative")' >/dev/null \
+            || { echo "::error::sentiment field missing or not in enum"; exit 1; }
+          echo "$RESULT" | jq -e '.confidence | type == "number"' >/dev/null \
+            || { echo "::error::confidence field missing or not a number"; exit 1; }
+          echo "ai-step returned schema-conforming JSON"

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 node_modules/
 .bin/
+__pycache__/
+*.pyc
 
 # override global gitignore to track claude config
 !.claude/
 !CLAUDE.md
+# but don't commit per-user permission overrides
+.claude/settings.local.json

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-semver-validation test-linear-pr-commenter test-release-notification test-linear-release-sync test-cleanup-head-charts test-ci-test-notify test-auto-approve-bot-prs test-ai-pr-review test-publish-helm-chart test-govulncheck test-go-licenses test-run-ginkgo build-linear-release-sync lint install-auto-doc generate-docs check-docs help
+.PHONY: test test-semver-validation test-linear-pr-commenter test-release-notification test-linear-release-sync test-cleanup-head-charts test-ci-test-notify test-auto-approve-bot-prs test-ai-pr-review test-ai-step test-publish-helm-chart test-govulncheck test-go-licenses test-run-ginkgo build-linear-release-sync lint install-auto-doc generate-docs check-docs help
 
 ACTIONS_DIR := .github/actions
 WORKFLOWS_DIR := .github/workflows
@@ -93,7 +93,7 @@ check-docs: generate-docs ## verify docs are up to date (fails if drift detected
 help: ## show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-30s %s\n", $$1, $$2}'
 
-test: test-semver-validation test-linear-pr-commenter test-release-notification test-linear-release-sync test-cleanup-head-charts test-auto-approve-bot-prs test-ai-pr-review test-ci-test-notify test-go-licenses test-publish-helm-chart test-govulncheck test-run-ginkgo ## run all action tests
+test: test-semver-validation test-linear-pr-commenter test-release-notification test-linear-release-sync test-cleanup-head-charts test-auto-approve-bot-prs test-ai-pr-review test-ai-step test-ci-test-notify test-go-licenses test-publish-helm-chart test-govulncheck test-run-ginkgo ## run all action tests
 
 test-semver-validation: ## run semver-validation unit tests
 	cd $(ACTIONS_DIR)/semver-validation && npm ci --silent && NODE_OPTIONS=--experimental-vm-modules npx jest --ci --coverage --watchAll=false
@@ -115,6 +115,9 @@ test-auto-approve-bot-prs: ## run auto-approve-bot-prs bats tests
 
 test-ai-pr-review: ## run ai-pr-review bats tests
 	bats $(ACTIONS_DIR)/ai-pr-review/test/*.bats
+
+test-ai-step: ## run ai-step bats tests
+	bats $(ACTIONS_DIR)/ai-step/test/*.bats
 
 test-ci-test-notify: ## run ci-test-notify bats tests
 	bats $(ACTIONS_DIR)/ci-test-notify/test/build-payload.bats

--- a/README.md
+++ b/README.md
@@ -174,6 +174,53 @@ Runs weekly and on demand. Creates real PRs exercising every decision-table
 branch (chore/fix(deps) titles, backport/renovate/update-platform-version
 branches, ineligible titles) and asserts the never-hard-fail invariant.
 
+### AI step
+
+Small reusable building block: run an AI call with a caller-supplied prompt
+and input, bind the output to a JSON Schema, expose the schema-conforming
+JSON as a step output. Downstream steps parse with `fromJSON(...)` and
+branch on typed fields.
+
+Structured output is the contract. Whatever the model returns is exposed
+on `result` and `conclusion=success`. The action never emits `failed` — the
+caller knows what empty output means for their pipeline.
+
+**Location:** `.github/actions/ai-step`
+
+**Usage:**
+
+```yaml
+- uses: actions/checkout@v4
+  with:
+    repository: loft-sh/github-actions
+    ref: ai-step/v1
+    sparse-checkout: .github/actions/ai-step
+
+- id: classify
+  uses: ./.github/actions/ai-step
+  with:
+    provider: anthropic
+    effort: low
+    prompt: 'Classify this diff. Return JSON matching the schema.'
+    input: ${{ steps.diff.outputs.text }}
+    output-schema: |
+      {
+        "type": "object",
+        "required": ["severity", "areas"],
+        "properties": {
+          "severity": { "type": "string", "enum": ["low","medium","high"] },
+          "areas":    { "type": "array",  "items": { "type": "string" } }
+        }
+      }
+    anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+
+- if: fromJSON(steps.classify.outputs.result).severity == 'high'
+  run: echo "needs human review"
+```
+
+See [ai-step README](./.github/actions/ai-step/README.md) for inputs,
+outputs, and provider asymmetries.
+
 ### Actionlint
 
 Lints GitHub Actions workflow files using actionlint with reviewdog integration.

--- a/docs/workflows/ai-step.md
+++ b/docs/workflows/ai-step.md
@@ -71,21 +71,40 @@ Flat inputs, no arrays. Conflict rules are trivial enough that shell validation 
 | `conclusion` | `success` / `skipped` / `failed`. Mirrors `ai-pr-review`'s shape. |
 | `reason`     | One-line explanation when not `success`. |
 
-### Internals (MVP)
+### Internals
 
-Wrap `anthropics/claude-code-action` with `--json-schema` in
-`claude_args`. The action surfaces the model's schema-conforming
-output as `steps.<id>.outputs.structured_output` (string); `ai-step`
-re-exposes it as `result`.
+Direct API calls via the official Python SDKs:
 
-Known upstream quirk: the first `--json-schema` call in a fresh
-runner can return an empty string ([anthropics/claude-code#23265]).
-`ai-step` wraps the call in a single retry on empty output.
+- `anthropic` SDK → Messages API with `output_config.format.schema`
+- `openai` SDK → Chat Completions with `response_format.json_schema.schema`
 
-[anthropics/claude-code#23265]: https://github.com/anthropics/claude-code/issues/23265
+The action installs the needed SDK on the runner, calls the provider,
+extracts the model's text content, and validates it parses as JSON
+before emitting `result`. Any failure (API error, empty content,
+non-JSON response) degrades to `conclusion=failed` with the upstream
+body preserved in the CI log. End-to-end ~15s including SDK install.
+
+The earlier draft of this design wrapped `anthropics/claude-code-action`
+and `openai/codex-action`, relying on their `--json-schema` /
+`output-schema` flags. Smoke testing surfaced a ~90s cold-start cost
+plus a directory-mismatch hang unrelated to schema binding — both
+rooted in the wrappers' PR-review machinery we didn't need. Direct
+SDK calls dropped that for a simpler, faster primitive.
 
 No checkout. No `GITHUB_TOKEN`. No write permissions. The caller
 provides data and decides what to do with the JSON.
+
+### Schema compatibility
+
+Both providers' strict structured-output modes reject some JSON
+Schema features. The action enforces one implicitly and documents
+the rest:
+
+- `additionalProperties: false` is set automatically on any object
+  node where it's missing (both providers require it in strict mode)
+- `minimum` / `maximum` / `minLength` / `maxLength` / `pattern` are
+  rejected by Anthropic — callers validate ranges in a downstream step
+- Recursive schemas and `$ref` across documents are rejected
 
 ## Usage
 

--- a/docs/workflows/ai-step.md
+++ b/docs/workflows/ai-step.md
@@ -1,0 +1,155 @@
+# AI step — design
+
+> Design doc backing the `ai-step` composite action (DEVOPS-834).
+> Implementation lives at `.github/actions/ai-step/` — see the
+> [action README](../../.github/actions/ai-step/README.md) for inputs,
+> outputs, and usage examples.
+
+## Problem
+
+We have `ai-pr-review`: a composite action + reusable workflow that
+drops into any CI and runs an AI-powered PR review. It owns a lot of
+context (checkout, PR comments, sticky summary, inline comments,
+provenance footer). That's the right shape for the "review a PR" job.
+
+But CI has other jobs that want the same primitive for different ends:
+classify a diff, extract fields from a changelog, decide whether to
+backport, pick a reviewer, summarize release notes into a structured
+object. The common shape is:
+
+```
+<arbitrary text or step output>  ──►  AI  ──►  <JSON matching my schema>
+```
+
+…where the downstream step reads the JSON via
+`fromJSON(steps.ai.outputs.result)` and branches on typed fields.
+
+`ai-pr-review` is the wrong entry point for this — it is PR-shaped,
+opinionated, and advisory-only. Generalizing it would bloat the input
+surface and couple unrelated concerns.
+
+## Proposal
+
+A new, **small** composite action: `ai-step`.
+
+One job: take text in, call an AI, return **schema-conforming JSON** on
+a single output. No PR awareness, no comments, no checkout. The caller
+owns everything around it (what to feed in, what to do with the JSON).
+
+`ai-pr-review` stays as-is. `ai-step` is the building block; other
+callers (including, eventually, `ai-pr-review` itself) can reuse it.
+
+## Name
+
+**`ai-step`** — reads as "an AI-powered CI step." Short, neutral,
+composable. Rejected alternatives: `ai-agent` (overloaded), `ai-transform`
+(verbose), `ai-structured` (implementation leaking into the name).
+
+## Shape
+
+### Inputs
+
+| input             | required | notes |
+|-------------------|----------|-------|
+| `provider`        | yes      | `anthropic` only for MVP. `openai` placeholder returning a skip. |
+| `effort`          | no       | `low|medium|high`; same mapping table as `ai-pr-review`. |
+| `prompt`          | yes      | Instructions for the model. |
+| `input`           | no       | Text fed to the model alongside the prompt. Caller sources it — a literal string, `${{ steps.X.outputs.Y }}`, or a file read via a prior step. No `input_file` / `step_output` dispatch inside the action. |
+| `output-schema`   | yes      | JSON Schema (string). The model's final output must conform. |
+| `tools`           | no       | Allowed-tools list passed to `--allowedTools`. Defaults to empty (pure text→JSON, no tool use). |
+| `mcp-config`      | no       | Optional MCP-server JSON passed to `--mcp-config`. |
+| `anthropic-api-key` | conditionally | Required when `provider=anthropic`. |
+| `fail-on-invalid` | no       | `false` (default) — invalid schema / empty result emits `conclusion=failed` and empty `result`, never hard-fails. `true` — exit 1 on failure so the job goes red. |
+
+Flat inputs, no arrays. Conflict rules are trivial enough that shell validation in `resolve-config.sh` covers them.
+
+### Outputs
+
+| output       | notes |
+|--------------|-------|
+| `result`     | JSON string matching `output-schema`. Consume with `fromJSON(...)`. Empty when `conclusion != success`. |
+| `conclusion` | `success` / `skipped` / `failed`. Mirrors `ai-pr-review`'s shape. |
+| `reason`     | One-line explanation when not `success`. |
+
+### Internals (MVP)
+
+Wrap `anthropics/claude-code-action` with `--json-schema` in
+`claude_args`. The action surfaces the model's schema-conforming
+output as `steps.<id>.outputs.structured_output` (string); `ai-step`
+re-exposes it as `result`.
+
+Known upstream quirk: the first `--json-schema` call in a fresh
+runner can return an empty string ([anthropics/claude-code#23265]).
+`ai-step` wraps the call in a single retry on empty output.
+
+[anthropics/claude-code#23265]: https://github.com/anthropics/claude-code/issues/23265
+
+No checkout. No `GITHUB_TOKEN`. No write permissions. The caller
+provides data and decides what to do with the JSON.
+
+## Usage
+
+```yaml
+jobs:
+  classify-diff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/actions/ai-step
+
+      - id: diff
+        run: echo "text=$(git diff origin/main...HEAD)" >> "$GITHUB_OUTPUT"
+
+      - id: classify
+        uses: ./.github/actions/ai-step
+        with:
+          provider: anthropic
+          effort: low
+          prompt: |
+            Classify this diff. Return JSON matching the schema.
+          input: ${{ steps.diff.outputs.text }}
+          output-schema: |
+            {
+              "type": "object",
+              "required": ["severity", "areas"],
+              "properties": {
+                "severity": { "type": "string", "enum": ["low","medium","high"] },
+                "areas":    { "type": "array",  "items": { "type": "string" } }
+              }
+            }
+          anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+
+      - if: fromJSON(steps.classify.outputs.result).severity == 'high'
+        run: echo "needs human review"
+```
+
+## Out of scope (intentional)
+
+- **`openai` provider.** `openai/codex-action` is unmaintained upstream,
+  and the Claude path alone delivers the primitive. Add later if a
+  caller needs provider choice.
+- **Input dispatch (`input_file`, `step_output.<id>.<name>`).** Callers
+  already have GHA expressions; adding a second dispatch layer is
+  bloat.
+- **Destinations / `output_actions` array.** The output *is* structured
+  JSON on a step output. Posting to Slack, opening an issue, commenting
+  on a PR — each is one extra step the caller writes, not a mode inside
+  this action.
+- **Reusable workflow wrapper.** `ai-step` is a composite used inside
+  a user-defined job. There is no job shape to reuse — each caller's
+  surrounding job does different things.
+
+## Testing
+
+Same pattern as `ai-pr-review`:
+- `test/resolve-config.bats` covers input validation, effort→model
+  mapping, conflict rules, and schema-present checks.
+- End-to-end coverage via a scenario workflow in a dedicated e2e repo
+  (the pattern in `docs/workflows/auto-approve-bot-prs.md`), if we want
+  signal on upstream regressions.
+
+## Release
+
+Tag `ai-step/v1` once merged and a smoke call against this repo's own
+CI returns valid JSON twice in a row (covers the cold-start quirk).


### PR DESCRIPTION
## Summary
- New `.github/actions/ai-step` composite: prompt + input + JSON Schema → schema-conforming JSON on `steps.<id>.outputs.result`. Caller parses via `fromJSON(...)` and branches on typed fields.
- Two providers, same contract: Anthropic (Messages API + `output_config.format.schema`) and OpenAI (Chat Completions + `response_format.json_schema.schema`). No wrappers, no bun, no PR-review machinery.
- Auto-enforces `additionalProperties: false` on object nodes (both providers require it in strict mode).
- Never hard-fails: API errors, empty responses, non-JSON content → `conclusion=failed` with upstream body in the CI log, caller decides.

## Why this, not generalize `ai-pr-review`
`ai-pr-review` is PR-shaped — owns checkout, commenting, sticky summaries, provenance footer. `ai-step` is the primitive for any classify/extract/route flow that doesn't need PR context. Generalizing the review action would have coupled unrelated concerns.

An earlier draft wrapped `claude-code-action` / `codex-action`. Live testing showed ~90s cold-start plus a bun directory-mismatch hang unrelated to schema binding — both rooted in the wrappers' PR-review machinery. Direct SDK calls run end-to-end in ~15s and sidestep that entirely.

## Live-tested
Both providers ran the same schema + prompt in the `devops-scratchpad` smoke workflow:

| | Anthropic haiku-4-5 | OpenAI gpt-5.4-mini |
|--|--|--|
| sentiment | positive | positive |
| confidence | 0.95 | 0.98 |
| duration | 16s | 16s |

## Test plan
- [x] `make test-ai-step` — 14/14 bats tests pass for `resolve-config.sh` (happy path per provider × effort, invalid inputs, missing envs, empty schema).
- [x] Live smoke against Anthropic (haiku-4-5) — `loft-sh/devops-scratchpad` run 24732067259: schema conformance verified, `fromJSON()` branching exercised.
- [x] Live smoke against OpenAI (gpt-5.4-mini) — `loft-sh/devops-scratchpad` run 24732244920: same schema, same contract.
- [ ] Reviewer: spot-check `docs/workflows/ai-step.md` for the design rationale (why direct-SDK won over the wrapper approach).
- [ ] Reviewer: try the snippet in `.github/actions/ai-step/README.md` against your own schema before cutting the `ai-step/v1` tag.

Closes DEVOPS-834