### PR TITLE
fix(auto-approve): tiebreak wait-for-ci dedup when started_at ties

### DIFF
--- a/.github/actions/auto-approve-bot-prs/src/wait-for-ci.sh
+++ b/.github/actions/auto-approve-bot-prs/src/wait-for-ci.sh
@@ -33,10 +33,15 @@ for attempt in $(seq 1 "$max_attempts"); do
   # one with the latest started_at. Treating every past attempt as live is what
   # makes a superseded `cancelled` from an older run silently block approval
   # even though the same check's latest attempt is green.
+  #
+  # `.id` is the tiebreaker when two attempts share an identical started_at —
+  # a common case when concurrency-group cancellation and the winning run
+  # start within the same second. GitHub allocates check-run IDs
+  # monotonically, so the larger id is always the newer attempt.
   other=$(echo "$runs" | jq --arg p "$EXCLUDE_PATTERN" '
     [.[] | select((.details_url // "") | contains($p) | not)]
     | group_by(.name // "")
-    | map(sort_by(.started_at // "") | last)
+    | map(sort_by(.started_at // "", .id // 0) | last)
   ')
   pending=$(echo "$other" | jq '[.[] | select(.status != "completed")] | length')
   failed=$(echo  "$other" | jq '[.[] | select(.conclusion != null and ([.conclusion] | inside(["success","skipped","neutral"]) | not))] | length')

--- a/.github/actions/auto-approve-bot-prs/test/wait-for-ci.bats
+++ b/.github/actions/auto-approve-bot-prs/test/wait-for-ci.bats
@@ -93,3 +93,29 @@ kv() { grep "^$1=" "$GITHUB_OUTPUT" | tail -n1; }
   [ "$status" -eq 0 ]
   [ "$(kv ci_green)" = "ci_green=false" ]
 }
+
+@test "identical started_at with differing ids → id tiebreak picks newer (higher id)" {
+  # Real-world case observed on loft-sh/vcluster-docs PR #1992: the Integration
+  # Tests workflow ran twice for the same PR head; concurrency cancellation
+  # and the winning run both started within the same second, so started_at
+  # alone is ambiguous. GitHub allocates check-run ids monotonically, so id
+  # tiebreaks unambiguously toward the newer attempt.
+  GH_MOCK_CHECK_RUNS_JSON='{"check_runs":[
+    {"name":"Safari (macOS)","id":100,"status":"completed","conclusion":"cancelled","started_at":"2026-04-23T06:35:09Z","details_url":"https://github.com/o/r/actions/runs/220/job/1"},
+    {"name":"Safari (macOS)","id":200,"status":"completed","conclusion":"skipped","started_at":"2026-04-23T06:35:09Z","details_url":"https://github.com/o/r/actions/runs/221/job/1"}
+  ]}' run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv ci_green)" = "ci_green=true" ]
+}
+
+@test "identical started_at tiebreak is deterministic regardless of api order" {
+  # Same as above but the API returned the attempts in the opposite order.
+  # A stable sort on started_at alone would let input order decide the winner
+  # and silently flip the verdict between runs.
+  GH_MOCK_CHECK_RUNS_JSON='{"check_runs":[
+    {"name":"Safari (macOS)","id":200,"status":"completed","conclusion":"skipped","started_at":"2026-04-23T06:35:09Z","details_url":"https://github.com/o/r/actions/runs/221/job/1"},
+    {"name":"Safari (macOS)","id":100,"status":"completed","conclusion":"cancelled","started_at":"2026-04-23T06:35:09Z","details_url":"https://github.com/o/r/actions/runs/220/job/1"}
+  ]}' run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv ci_green)" = "ci_green=true" ]
+}


### PR DESCRIPTION
## Why

Observed in production on [loft-sh/vcluster-docs PR #1992](https://github.com/loft-sh/vcluster-docs/pull/1992): the auto-approve workflow reported `proceed=true`, then silently emitted

> `##[notice]Other CI checks failed; skipping approval`

and exited without posting a review — even though every live check-run on the PR head had ended in `success`, `skipped`, or `neutral`. [Failing run.](https://github.com/loft-sh/vcluster-docs/actions/runs/24820718522)

### Root cause

Two \`Integration Tests\` workflow runs landed on the same PR head sha — run \`24820717785\` got cancelled by concurrency-group cancellation, run \`24820718082\` took over. That is a legitimate, common pattern.

Both runs exposed a \`Safari (macOS)\` check-run. Crucially, both check-runs carried an identical \`started_at=2026-04-23T06:35:09Z\` — GitHub timestamps at 1s granularity and concurrency cancellation often happens within the same second as the winning run starts:

\`\`\`
{"name":"Safari (macOS)","id":72644618114,"conclusion":"cancelled","started_at":"2026-04-23T06:35:09Z",...}
{"name":"Safari (macOS)","id":72644619611,"conclusion":"skipped",  "started_at":"2026-04-23T06:35:09Z",...}
\`\`\`

The dedup sort \`sort_by(.started_at // "") | last\` is *stable*, which means when timestamps tie, input order decides the winner. The check-runs API happened to return the cancelled entry last, so \`last\` picked it, \`cancelled\` is not in the allow-list \`[success,skipped,neutral]\`, \`failed=1\`, approval skipped.

### Fix

\`.id\` is the correct tiebreaker: GitHub allocates check-run IDs monotonically, so the larger id is always the newer attempt regardless of timestamp granularity.

\`\`\`diff
-    | map(sort_by(.started_at // "") | last)
+    | map(sort_by(.started_at // "", .id // 0) | last)
\`\`\`

Same ordering behavior for the common case (distinct timestamps); deterministic and correct when timestamps tie.

## Tests

Two new bats cases:
- \`identical started_at with differing ids → id tiebreak picks newer (higher id)\`
- \`identical started_at tiebreak is deterministic regardless of api order\`

The second one fails on \`main\` and passes with this patch — verified locally by stashing the src change and re-running bats:

\`\`\`
ok 10 identical started_at with differing ids → id tiebreak picks newer (higher id)
not ok 11 identical started_at tiebreak is deterministic regardless of api order
\`\`\`

Both API orderings are now covered, so future regressions in stable-sort behaviour will be caught.

## Test plan

- [x] \`bats .github/actions/auto-approve-bot-prs/test/\` — 29/29 pass
- [x] \`shellcheck .github/actions/auto-approve-bot-prs/src/*.sh\` — clean
- [x] Verified the new test #11 fails without the fix (stash src change, rerun bats)
- [x] Green CI on this PR