### PR TITLE
fix(auto-approve): block approval on failing commit statuses + enforce settle period

### DIFF
--- a/.github/actions/auto-approve-bot-prs/README.md
+++ b/.github/actions/auto-approve-bot-prs/README.md
@@ -7,18 +7,37 @@ every failure mode degrades to a notice-level skip.
 Safe patterns: `chore(` / `chore:` titles, `fix(deps):` titles,
 `backport/` / `renovate/` / `update-platform-version-` branches.
 
+## Signals treated as CI
+
+Approval is blocked unless every non-self signal on the PR head resolves to
+`success`, `skipped`, or `neutral`. The action polls both APIs GitHub uses
+to surface CI:
+
+- **Check-runs** (`/commits/:sha/check-runs`) — GitHub Actions and most
+  GitHub Apps.
+- **Commit statuses** (`/commits/:sha/status`) — legacy CI integrations
+  such as Netlify, CircleCI, Travis. A `failure`/`error` state here blocks
+  approval even when all check-runs are green.
+
+Because external systems (Netlify in particular) can take a couple of
+minutes to register their first `pending` signal, the action enforces a
+`wait-min-attempts` floor before it is allowed to emit `ci_green=true`.
+This prevents early approval against a PR that looks quiet simply because
+slow external checks have not shown up yet.
+
 ## Inputs
 
 <!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
 
-|       INPUT        |  TYPE  | REQUIRED |                    DEFAULT                     |                                            DESCRIPTION                                            |
-|--------------------|--------|----------|------------------------------------------------|---------------------------------------------------------------------------------------------------|
-|     auto-merge     | string |  false   |                   `"false"`                    |                              Enable GitHub auto-merge after approval                              |
-|    github-token    | string |   true   |                                                | PAT used to read PR state, <br>approve, and enable auto-merge. Must NOT <br>match the PR author.  |
-|    merge-method    | string |  false   |                   `"squash"`                   |                         Merge method for auto-merge (squash|merge|rebase)                         |
-|  trusted-authors   | string |  false   | `"renovate[bot],loft-bot,github-actions[bot]"` |                            Comma-separated list of trusted bot logins                             |
-| wait-max-attempts  | string |  false   |                     `"90"`                     |                       Max polling attempts waiting for other <br>CI checks                        |
-| wait-sleep-seconds | string |  false   |                     `"10"`                     |                                 Seconds between polling attempts                                  |
+|       INPUT        |  TYPE  | REQUIRED |                    DEFAULT                     |                                                                    DESCRIPTION                                                                     |
+|--------------------|--------|----------|------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
+|     auto-merge     | string |  false   |                   `"false"`                    |                                                      Enable GitHub auto-merge after approval                                                       |
+|    github-token    | string |   true   |                                                |                         PAT used to read PR state, <br>approve, and enable auto-merge. Must NOT <br>match the PR author.                           |
+|    merge-method    | string |  false   |                   `"squash"`                   |                                                 Merge method for auto-merge (squash|merge|rebase)                                                  |
+|  trusted-authors   | string |  false   | `"renovate[bot],loft-bot,github-actions[bot]"` |                                                     Comma-separated list of trusted bot logins                                                     |
+| wait-max-attempts  | string |  false   |                     `"90"`                     |                                               Max polling attempts waiting for other <br>CI checks                                                 |
+| wait-min-attempts  | string |  false   |                     `"12"`                     | Minimum polls before ci_green=true is allowed. <br>Prevents early approval while slow external <br>checks (e.g. Netlify) have not yet registered.  |
+| wait-sleep-seconds | string |  false   |                     `"10"`                     |                                                          Seconds between polling attempts                                                          |
 
 <!-- AUTO-DOC-INPUT:END -->
 

--- a/.github/actions/auto-approve-bot-prs/action.yml
+++ b/.github/actions/auto-approve-bot-prs/action.yml
@@ -23,6 +23,10 @@ inputs:
     description: 'Max polling attempts waiting for other CI checks'
     required: false
     default: '90'
+  wait-min-attempts:
+    description: 'Minimum polls before ci_green=true is allowed. Prevents early approval while slow external checks (e.g. Netlify) have not yet registered.'
+    required: false
+    default: '12'
   wait-sleep-seconds:
     description: 'Seconds between polling attempts'
     required: false
@@ -60,6 +64,7 @@ runs:
         PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         SELF_RUN_ID: ${{ github.run_id }}
         WAIT_MAX_ATTEMPTS: ${{ inputs.wait-max-attempts }}
+        WAIT_MIN_ATTEMPTS: ${{ inputs.wait-min-attempts }}
         WAIT_SLEEP_SECONDS: ${{ inputs.wait-sleep-seconds }}
       run: ${{ github.action_path }}/src/wait-for-ci.sh
 

--- a/.github/actions/auto-approve-bot-prs/src/wait-for-ci.sh
+++ b/.github/actions/auto-approve-bot-prs/src/wait-for-ci.sh
@@ -1,16 +1,22 @@
 #!/usr/bin/env bash
 # Polls non-self check-runs AND commit statuses on the PR head until they
 # complete. Outputs ci_green=true only if every non-self signal ends
-# success/skipped/neutral.
+# success/skipped/neutral AND the API answered cleanly on the deciding poll.
 #
 # Commit statuses matter because external systems (Netlify, etc.) post results
 # via the legacy statuses API, not check-runs. Without this, the script sees
-# "nothing pending" and approves while Netlify is still reporting failures.
+# "nothing pending" and approves while external CI is still reporting failures.
 #
 # A minimum number of attempts is also required before declaring green: an
 # external check that has not yet registered a "pending" signal looks
 # indistinguishable from "no check configured". Waiting one settle period
-# lets slow registrants (observed: Netlify, ~2 min) appear before approval.
+# lets slow registrants (observed: 2+ minutes in the wild) appear before
+# approval.
+#
+# API errors never degrade to silent green. Every gh/jq error is captured and
+# treated as "unknown state" — the poll does not count toward the settle
+# floor, and consecutive errors eventually time out to ci_green=false.
+# Default-deny: if we cannot prove CI is clean, we do not approve.
 #
 # Required env: GH_TOKEN, GITHUB_REPOSITORY, PR_HEAD_SHA, SELF_RUN_ID
 # Optional env:
@@ -35,13 +41,44 @@ emit() {
   printf '%s=%s\n' "$k" "$v"
 }
 
+# gh_json <api-path> — fetch json body; on any failure print empty and return 1.
+# Crucially does NOT swallow errors into "[]" — callers must distinguish
+# "API said there is nothing" from "API failed and we have no idea".
+gh_json() {
+  local path="$1" body
+  if ! body=$(gh api "$path" --paginate 2>/dev/null); then
+    return 1
+  fi
+  printf '%s' "$body"
+}
+
+# jq_or_fail [jq-flags...] <jq-expr> <json>  — run jq on $json with optional
+# flags (e.g. -r). Returns non-zero on parse failure. Callers must check
+# exit status; silent empty output here is not the same as success.
+jq_or_fail() {
+  local json="${!#}"
+  local args=( "${@:1:$#-1}" )
+  jq "${args[@]}" <<<"$json" 2>/dev/null || return 1
+}
+
 # Self-identification: exclude check-runs whose details_url contains our run id,
 # `.../runs/<SELF_RUN_ID>/...`. Works for both check-runs and statuses from
 # github-actions.
 EXCLUDE_PATTERN="/runs/${SELF_RUN_ID}/"
 
+consecutive_errors=0
+max_consecutive_errors=5
+
 for attempt in $(seq 1 "$max_attempts"); do
-  runs=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${PR_HEAD_SHA}/check-runs" --paginate --jq '.check_runs // []' 2>/dev/null || echo '[]')
+  poll_errored=0
+
+  # -- Fetch check-runs -----------------------------------------------------
+  runs_raw=""
+  if ! runs_raw=$(gh_json "repos/${GITHUB_REPOSITORY}/commits/${PR_HEAD_SHA}/check-runs"); then
+    echo "::warning::attempt ${attempt}/${max_attempts}: check-runs API failed"
+    poll_errored=1
+  fi
+
   # Dedupe by name: GitHub keeps historical attempts (including cancelled ones
   # superseded by reruns) in the check-runs list, and the current state is the
   # one with the latest started_at. Treating every past attempt as live is what
@@ -52,37 +89,88 @@ for attempt in $(seq 1 "$max_attempts"); do
   # a common case when concurrency-group cancellation and the winning run
   # start within the same second. GitHub allocates check-run IDs
   # monotonically, so the larger id is always the newer attempt.
-  other=$(echo "$runs" | jq --arg p "$EXCLUDE_PATTERN" '
-    [.[] | select((.details_url // "") | contains($p) | not)]
-    | group_by(.name // "")
-    | map(sort_by(.started_at // "", .id // 0) | last)
-  ')
-  cr_pending=$(echo "$other" | jq '[.[] | select(.status != "completed")] | length')
-  cr_failed=$( echo "$other" | jq '[.[] | select(.conclusion != null and ([.conclusion] | inside(["success","skipped","neutral"]) | not))] | length')
-  cr_failed_names=$(echo "$other" | jq -r '[.[] | select(.conclusion != null and ([.conclusion] | inside(["success","skipped","neutral"]) | not)) | .name // "unnamed"] | join(", ")')
+  other=""
+  if [ "$poll_errored" -eq 0 ]; then
+    if ! other=$(jq_or_fail '
+      (.check_runs // [])
+      | [.[] | select((.details_url // "") | contains("'"$EXCLUDE_PATTERN"'") | not)]
+      | group_by(.name // "")
+      | map(sort_by(.started_at // "", .id // 0) | last)
+    ' "$runs_raw"); then
+      echo "::warning::attempt ${attempt}/${max_attempts}: check-runs jq parse failed"
+      poll_errored=1
+    fi
+  fi
 
-  # Commit statuses API (/commits/SHA/status) returns the combined state plus
-  # one entry per context (already the latest per context). Netlify, Travis,
-  # CircleCI and similar legacy CIs report here — not via check-runs.
-  statuses=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${PR_HEAD_SHA}/status" --jq '.statuses // []' 2>/dev/null || echo '[]')
-  # Drop our own statuses (self-identification via target_url pointing at our
-  # run id) — harmless if github-actions never posts via the statuses API,
-  # but future-proofs against callers that do.
-  statuses_other=$(echo "$statuses" | jq --arg p "$EXCLUDE_PATTERN" '[.[] | select((.target_url // "") | contains($p) | not)]')
-  st_pending=$(echo "$statuses_other" | jq '[.[] | select(.state == "pending")] | length')
-  st_failed=$( echo "$statuses_other" | jq '[.[] | select(.state == "failure" or .state == "error")] | length')
-  st_failed_names=$(echo "$statuses_other" | jq -r '[.[] | select(.state == "failure" or .state == "error") | .context // "unnamed"] | join(", ")')
+  cr_pending=0 cr_failed=0 cr_failed_detail="" cr_pending_names=""
+  if [ "$poll_errored" -eq 0 ]; then
+    cr_pending=$(       jq_or_fail '[.[] | select(.status != "completed")] | length'                                                                                                  "$other" ) || poll_errored=1
+    cr_failed=$(        jq_or_fail '[.[] | select(.conclusion != null and ([.conclusion] | inside(["success","skipped","neutral"]) | not))] | length'                                 "$other" ) || poll_errored=1
+    cr_failed_detail=$( jq_or_fail -r '[.[] | select(.conclusion != null and ([.conclusion] | inside(["success","skipped","neutral"]) | not)) | "\(.name // "unnamed")=\(.conclusion)"] | join(", ")' "$other" ) || poll_errored=1
+    cr_pending_names=$( jq_or_fail -r '[.[] | select(.status != "completed") | .name // "unnamed"] | join(", ")'                                                                      "$other" ) || poll_errored=1
+  fi
+
+  # -- Fetch commit statuses ------------------------------------------------
+  statuses_raw=""
+  if [ "$poll_errored" -eq 0 ]; then
+    if ! statuses_raw=$(gh_json "repos/${GITHUB_REPOSITORY}/commits/${PR_HEAD_SHA}/status"); then
+      echo "::warning::attempt ${attempt}/${max_attempts}: statuses API failed"
+      poll_errored=1
+    fi
+  fi
+
+  statuses_other=""
+  if [ "$poll_errored" -eq 0 ]; then
+    if ! statuses_other=$(jq_or_fail '
+      (.statuses // [])
+      | [.[] | select((.target_url // "") | contains("'"$EXCLUDE_PATTERN"'") | not)]
+    ' "$statuses_raw"); then
+      echo "::warning::attempt ${attempt}/${max_attempts}: statuses jq parse failed"
+      poll_errored=1
+    fi
+  fi
+
+  st_pending=0 st_failed=0 st_failed_detail="" st_pending_names=""
+  if [ "$poll_errored" -eq 0 ]; then
+    st_pending=$(       jq_or_fail '[.[] | select(.state == "pending")] | length'                                                    "$statuses_other" ) || poll_errored=1
+    st_failed=$(        jq_or_fail '[.[] | select(.state == "failure" or .state == "error")] | length'                               "$statuses_other" ) || poll_errored=1
+    st_failed_detail=$( jq_or_fail -r '[.[] | select(.state == "failure" or .state == "error") | "\(.context // "unnamed")=\(.state)"] | join(", ")' "$statuses_other" ) || poll_errored=1
+    st_pending_names=$( jq_or_fail -r '[.[] | select(.state == "pending") | .context // "unnamed"] | join(", ")'                     "$statuses_other" ) || poll_errored=1
+  fi
+
+  # -- Consume the poll -----------------------------------------------------
+  if [ "$poll_errored" -eq 1 ]; then
+    # Default-deny on API/parse errors: this poll does not count toward the
+    # settle floor, and too many consecutive errors exit non-green.
+    consecutive_errors=$(( consecutive_errors + 1 ))
+    if [ "$consecutive_errors" -ge "$max_consecutive_errors" ]; then
+      echo "::notice::Too many consecutive API errors (${consecutive_errors}); refusing to approve"
+      emit ci_green false
+      exit 0
+    fi
+    sleep "$sleep_seconds"
+    continue
+  fi
+  consecutive_errors=0
 
   pending=$(( cr_pending + st_pending ))
   failed=$(( cr_failed + st_failed ))
   echo "attempt ${attempt}/${max_attempts}: check_runs(pending=${cr_pending} failed=${cr_failed}) statuses(pending=${st_pending} failed=${st_failed})"
 
   if [ "$failed" -gt 0 ]; then
-    failed_all=$(printf '%s\n%s' "$cr_failed_names" "$st_failed_names" | awk 'NF' | paste -sd, - | sed 's/,/, /g')
-    echo "::notice::Other CI checks failed; skipping approval. Failing: ${failed_all:-unknown}"
+    details=$(printf '%s\n%s' "$cr_failed_detail" "$st_failed_detail" | awk 'NF' | paste -sd, - | sed 's/,/, /g')
+    echo "::notice::Other CI checks failed; skipping approval. Failing: ${details:-unknown}"
     emit ci_green false
     exit 0
   fi
+
+  # Surface which signals we are still waiting on. Helps operators diagnose
+  # "why is this job still running?" without enabling step debug logging.
+  if [ "$pending" -gt 0 ]; then
+    waiting=$(printf '%s\n%s' "$cr_pending_names" "$st_pending_names" | awk 'NF' | paste -sd, - | sed 's/,/, /g')
+    echo "  pending: ${waiting:-<unnamed>}"
+  fi
+
   # Hold the "green" verdict until the settle floor. A first-poll "pending=0"
   # can simply mean external checks have not registered yet (e.g. Netlify
   # webhook still in flight). Waiting min_attempts polls before the first

--- a/.github/actions/auto-approve-bot-prs/src/wait-for-ci.sh
+++ b/.github/actions/auto-approve-bot-prs/src/wait-for-ci.sh
@@ -1,9 +1,22 @@
 #!/usr/bin/env bash
-# Polls non-self check-runs on the PR head until they complete.
-# Outputs ci_green=true only if every non-self check ends success/skipped/neutral.
+# Polls non-self check-runs AND commit statuses on the PR head until they
+# complete. Outputs ci_green=true only if every non-self signal ends
+# success/skipped/neutral.
+#
+# Commit statuses matter because external systems (Netlify, etc.) post results
+# via the legacy statuses API, not check-runs. Without this, the script sees
+# "nothing pending" and approves while Netlify is still reporting failures.
+#
+# A minimum number of attempts is also required before declaring green: an
+# external check that has not yet registered a "pending" signal looks
+# indistinguishable from "no check configured". Waiting one settle period
+# lets slow registrants (observed: Netlify, ~2 min) appear before approval.
 #
 # Required env: GH_TOKEN, GITHUB_REPOSITORY, PR_HEAD_SHA, SELF_RUN_ID
-# Optional env: WAIT_MAX_ATTEMPTS (default 90), WAIT_SLEEP_SECONDS (default 10)
+# Optional env:
+#   WAIT_MAX_ATTEMPTS  (default 90)  – hard ceiling on polls
+#   WAIT_MIN_ATTEMPTS  (default 12)  – floor before ci_green=true is allowed
+#   WAIT_SLEEP_SECONDS (default 10)  – seconds between polls
 # Writes: ci_green=true|false to $GITHUB_OUTPUT (and stdout).
 # Always exits 0.
 set -euo pipefail
@@ -13,6 +26,7 @@ set -euo pipefail
 : "${SELF_RUN_ID:?SELF_RUN_ID required}"
 
 max_attempts="${WAIT_MAX_ATTEMPTS:-90}"
+min_attempts="${WAIT_MIN_ATTEMPTS:-12}"
 sleep_seconds="${WAIT_SLEEP_SECONDS:-10}"
 
 emit() {
@@ -43,16 +57,37 @@ for attempt in $(seq 1 "$max_attempts"); do
     | group_by(.name // "")
     | map(sort_by(.started_at // "", .id // 0) | last)
   ')
-  pending=$(echo "$other" | jq '[.[] | select(.status != "completed")] | length')
-  failed=$(echo  "$other" | jq '[.[] | select(.conclusion != null and ([.conclusion] | inside(["success","skipped","neutral"]) | not))] | length')
-  echo "attempt ${attempt}/${max_attempts}: pending=${pending} failed=${failed}"
+  cr_pending=$(echo "$other" | jq '[.[] | select(.status != "completed")] | length')
+  cr_failed=$( echo "$other" | jq '[.[] | select(.conclusion != null and ([.conclusion] | inside(["success","skipped","neutral"]) | not))] | length')
+  cr_failed_names=$(echo "$other" | jq -r '[.[] | select(.conclusion != null and ([.conclusion] | inside(["success","skipped","neutral"]) | not)) | .name // "unnamed"] | join(", ")')
 
-  if [ "${failed:-0}" -gt 0 ]; then
-    echo "::notice::Other CI checks failed; skipping approval"
+  # Commit statuses API (/commits/SHA/status) returns the combined state plus
+  # one entry per context (already the latest per context). Netlify, Travis,
+  # CircleCI and similar legacy CIs report here — not via check-runs.
+  statuses=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${PR_HEAD_SHA}/status" --jq '.statuses // []' 2>/dev/null || echo '[]')
+  # Drop our own statuses (self-identification via target_url pointing at our
+  # run id) — harmless if github-actions never posts via the statuses API,
+  # but future-proofs against callers that do.
+  statuses_other=$(echo "$statuses" | jq --arg p "$EXCLUDE_PATTERN" '[.[] | select((.target_url // "") | contains($p) | not)]')
+  st_pending=$(echo "$statuses_other" | jq '[.[] | select(.state == "pending")] | length')
+  st_failed=$( echo "$statuses_other" | jq '[.[] | select(.state == "failure" or .state == "error")] | length')
+  st_failed_names=$(echo "$statuses_other" | jq -r '[.[] | select(.state == "failure" or .state == "error") | .context // "unnamed"] | join(", ")')
+
+  pending=$(( cr_pending + st_pending ))
+  failed=$(( cr_failed + st_failed ))
+  echo "attempt ${attempt}/${max_attempts}: check_runs(pending=${cr_pending} failed=${cr_failed}) statuses(pending=${st_pending} failed=${st_failed})"
+
+  if [ "$failed" -gt 0 ]; then
+    failed_all=$(printf '%s\n%s' "$cr_failed_names" "$st_failed_names" | awk 'NF' | paste -sd, - | sed 's/,/, /g')
+    echo "::notice::Other CI checks failed; skipping approval. Failing: ${failed_all:-unknown}"
     emit ci_green false
     exit 0
   fi
-  if [ "${pending:-0}" -eq 0 ]; then
+  # Hold the "green" verdict until the settle floor. A first-poll "pending=0"
+  # can simply mean external checks have not registered yet (e.g. Netlify
+  # webhook still in flight). Waiting min_attempts polls before the first
+  # green verdict gives slow registrants a chance to show up.
+  if [ "$pending" -eq 0 ] && [ "$attempt" -ge "$min_attempts" ]; then
     emit ci_green true
     exit 0
   fi

--- a/.github/actions/auto-approve-bot-prs/test/gh_mock.bash
+++ b/.github/actions/auto-approve-bot-prs/test/gh_mock.bash
@@ -15,6 +15,7 @@ setup_gh_mock() {
 # GH_MOCK_MERGEABLE          → response for `gh api ...pulls/N`
 # GH_MOCK_APPROVER           → response for `gh api user`
 # GH_MOCK_CHECK_RUNS_JSON    → response for `gh api .../check-runs` (full object)
+# GH_MOCK_STATUSES_JSON      → response for `gh api .../status` (combined status)
 # GH_MOCK_PR_MERGE_EXIT      → exit code for `gh pr merge`
 # GH_MOCK_PR_MERGE_OUT       → stdout for `gh pr merge`
 # GH_MOCK_CALLS              → path; each invocation appends one line of args
@@ -24,7 +25,7 @@ setup_gh_mock() {
 # Emit the raw response that matches the api path, then apply --jq/--paginate
 # like real gh does, so callers see exactly what they'd see in production.
 emit_api_response() {
-  local path="$1" default_runs='{"check_runs":[]}'
+  local path="$1" default_runs='{"check_runs":[]}' default_statuses='{"state":"success","statuses":[]}'
   case "$path" in
     user)
       printf '{"login":"%s"}\n' "${GH_MOCK_APPROVER:-}"
@@ -36,6 +37,11 @@ emit_api_response() {
       ;;
     *"/check-runs"*)
       printf '%s\n' "${GH_MOCK_CHECK_RUNS_JSON:-$default_runs}"
+      ;;
+    *"/status"*)
+      # Trailing /status (combined) — must come after /check-runs because
+      # /check-runs also happens to contain "/runs/" but not "/status".
+      printf '%s\n' "${GH_MOCK_STATUSES_JSON:-$default_statuses}"
       ;;
     *) printf '{}\n' ;;
   esac

--- a/.github/actions/auto-approve-bot-prs/test/gh_mock.bash
+++ b/.github/actions/auto-approve-bot-prs/test/gh_mock.bash
@@ -16,11 +16,29 @@ setup_gh_mock() {
 # GH_MOCK_APPROVER           → response for `gh api user`
 # GH_MOCK_CHECK_RUNS_JSON    → response for `gh api .../check-runs` (full object)
 # GH_MOCK_STATUSES_JSON      → response for `gh api .../status` (combined status)
+# GH_MOCK_CHECK_RUNS_SEQ     → path to file with one JSON per line; call N reads
+#                              line N (falls through to GH_MOCK_CHECK_RUNS_JSON
+#                              when exhausted). Lets a test model "signal
+#                              arrived between polls" without wiring a real clock.
+# GH_MOCK_STATUSES_SEQ       → same, for the commit-statuses endpoint.
 # GH_MOCK_PR_MERGE_EXIT      → exit code for `gh pr merge`
 # GH_MOCK_PR_MERGE_OUT       → stdout for `gh pr merge`
 # GH_MOCK_CALLS              → path; each invocation appends one line of args
 
 [ -n "${GH_MOCK_CALLS:-}" ] && printf '%s\n' "$*" >> "$GH_MOCK_CALLS"
+
+# Read the Nth line of a sequence file ($1) where N is tracked in $2 (counter
+# file incremented in place). When the sequence is exhausted, the caller falls
+# back to the static env var — returning empty stdout here signals "use fallback".
+read_sequenced() {
+  local file="$1" counter="$2"
+  [ -z "$file" ] || [ ! -f "$file" ] && return 0
+  local n=0
+  [ -f "$counter" ] && n="$(cat "$counter")"
+  n=$((n + 1))
+  printf '%d' "$n" > "$counter"
+  sed -n "${n}p" "$file"
+}
 
 # Emit the raw response that matches the api path, then apply --jq/--paginate
 # like real gh does, so callers see exactly what they'd see in production.
@@ -36,12 +54,24 @@ emit_api_response() {
       printf '{"mergeable":%s}\n' "$m"
       ;;
     *"/check-runs"*)
-      printf '%s\n' "${GH_MOCK_CHECK_RUNS_JSON:-$default_runs}"
+      local seq
+      seq="$(read_sequenced "${GH_MOCK_CHECK_RUNS_SEQ:-}" "${MOCK_DIR:-/tmp}/cr_n")"
+      if [ -n "$seq" ]; then
+        printf '%s\n' "$seq"
+      else
+        printf '%s\n' "${GH_MOCK_CHECK_RUNS_JSON:-$default_runs}"
+      fi
       ;;
     *"/status"*)
       # Trailing /status (combined) — must come after /check-runs because
       # /check-runs also happens to contain "/runs/" but not "/status".
-      printf '%s\n' "${GH_MOCK_STATUSES_JSON:-$default_statuses}"
+      local seq
+      seq="$(read_sequenced "${GH_MOCK_STATUSES_SEQ:-}" "${MOCK_DIR:-/tmp}/st_n")"
+      if [ -n "$seq" ]; then
+        printf '%s\n' "$seq"
+      else
+        printf '%s\n' "${GH_MOCK_STATUSES_JSON:-$default_statuses}"
+      fi
       ;;
     *) printf '{}\n' ;;
   esac

--- a/.github/actions/auto-approve-bot-prs/test/gh_mock.bash
+++ b/.github/actions/auto-approve-bot-prs/test/gh_mock.bash
@@ -11,6 +11,7 @@ setup_gh_mock() {
   cat > "$MOCK_DIR/gh" <<'EOF'
 #!/usr/bin/env bash
 # Mock `gh`. Only covers the subset used by auto-approve scripts.
+set -o pipefail
 #
 # GH_MOCK_MERGEABLE          → response for `gh api ...pulls/N`
 # GH_MOCK_APPROVER           → response for `gh api user`
@@ -20,7 +21,10 @@ setup_gh_mock() {
 #                              line N (falls through to GH_MOCK_CHECK_RUNS_JSON
 #                              when exhausted). Lets a test model "signal
 #                              arrived between polls" without wiring a real clock.
+#                              Special line value 'ERROR' → exit non-zero (API fail).
 # GH_MOCK_STATUSES_SEQ       → same, for the commit-statuses endpoint.
+# GH_MOCK_CHECK_RUNS_FAIL    → if 'always', /check-runs exits 1 every call.
+# GH_MOCK_STATUSES_FAIL      → if 'always', /status exits 1 every call.
 # GH_MOCK_PR_MERGE_EXIT      → exit code for `gh pr merge`
 # GH_MOCK_PR_MERGE_OUT       → stdout for `gh pr merge`
 # GH_MOCK_CALLS              → path; each invocation appends one line of args
@@ -54,8 +58,16 @@ emit_api_response() {
       printf '{"mergeable":%s}\n' "$m"
       ;;
     *"/check-runs"*)
+      if [ "${GH_MOCK_CHECK_RUNS_FAIL:-}" = "always" ]; then
+        echo "mock: check-runs forced failure" >&2
+        exit 22
+      fi
       local seq
       seq="$(read_sequenced "${GH_MOCK_CHECK_RUNS_SEQ:-}" "${MOCK_DIR:-/tmp}/cr_n")"
+      if [ "$seq" = "ERROR" ]; then
+        echo "mock: sequenced check-runs error" >&2
+        exit 22
+      fi
       if [ -n "$seq" ]; then
         printf '%s\n' "$seq"
       else
@@ -65,8 +77,16 @@ emit_api_response() {
     *"/status"*)
       # Trailing /status (combined) — must come after /check-runs because
       # /check-runs also happens to contain "/runs/" but not "/status".
+      if [ "${GH_MOCK_STATUSES_FAIL:-}" = "always" ]; then
+        echo "mock: statuses forced failure" >&2
+        exit 22
+      fi
       local seq
       seq="$(read_sequenced "${GH_MOCK_STATUSES_SEQ:-}" "${MOCK_DIR:-/tmp}/st_n")"
+      if [ "$seq" = "ERROR" ]; then
+        echo "mock: sequenced statuses error" >&2
+        exit 22
+      fi
       if [ -n "$seq" ]; then
         printf '%s\n' "$seq"
       else

--- a/.github/actions/auto-approve-bot-prs/test/wait-for-ci.bats
+++ b/.github/actions/auto-approve-bot-prs/test/wait-for-ci.bats
@@ -10,6 +10,7 @@ setup() {
   export PR_HEAD_SHA="deadbeef"
   export SELF_RUN_ID="111111"
   export WAIT_MAX_ATTEMPTS=2
+  export WAIT_MIN_ATTEMPTS=1
   export WAIT_SLEEP_SECONDS=1
 }
 teardown() { rm -f "$GITHUB_OUTPUT"; teardown_gh_mock; }
@@ -118,4 +119,75 @@ kv() { grep "^$1=" "$GITHUB_OUTPUT" | tail -n1; }
   ]}' run "$SCRIPT"
   [ "$status" -eq 0 ]
   [ "$(kv ci_green)" = "ci_green=true" ]
+}
+
+# ---------------------------------------------------------------------------
+# Commit-status polling (catches Netlify and other legacy-CI signals)
+
+@test "commit status failure blocks approval even when check-runs are clean" {
+  # Real-world case observed on loft-sh/vcluster-docs PR #2009: Netlify's
+  # "deploy/netlify" commit status was failing while every GitHub-native
+  # check-run passed. Ignoring the statuses API let the bot approve broken CI.
+  GH_MOCK_CHECK_RUNS_JSON='{"check_runs":[
+    {"name":"lint","status":"completed","conclusion":"success","details_url":"https://github.com/o/r/actions/runs/222/job/1"}
+  ]}' \
+  GH_MOCK_STATUSES_JSON='{"state":"failure","statuses":[
+    {"context":"deploy/netlify","state":"failure","target_url":"https://app.netlify.com/projects/x/deploys/abc"}
+  ]}' \
+    run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv ci_green)" = "ci_green=false" ]
+  [[ "$output" == *"deploy/netlify"* ]]
+}
+
+@test "commit status error also blocks approval" {
+  GH_MOCK_STATUSES_JSON='{"state":"error","statuses":[
+    {"context":"ci/circleci","state":"error","target_url":"https://circleci.com/x/1"}
+  ]}' run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv ci_green)" = "ci_green=false" ]
+  [[ "$output" == *"ci/circleci"* ]]
+}
+
+@test "pending commit status keeps the job waiting past first poll" {
+  # With MIN_ATTEMPTS=1 we'd otherwise declare green immediately. A pending
+  # commit status must behave just like a pending check-run: keep polling.
+  GH_MOCK_STATUSES_JSON='{"state":"pending","statuses":[
+    {"context":"deploy/netlify","state":"pending","target_url":"https://app.netlify.com/x/1"}
+  ]}' run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv ci_green)" = "ci_green=false" ]
+}
+
+@test "successful commit status combined with clean check-runs → ci_green=true" {
+  GH_MOCK_STATUSES_JSON='{"state":"success","statuses":[
+    {"context":"deploy/netlify","state":"success","target_url":"https://app.netlify.com/x/1"}
+  ]}' run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv ci_green)" = "ci_green=true" ]
+}
+
+# ---------------------------------------------------------------------------
+# Minimum-attempt settle period (keeps slow external checks from being missed)
+
+@test "min_attempts floor forces extra polls before declaring green" {
+  # With MAX=2 and MIN=2 we should never short-circuit on the first poll;
+  # the run must poll at least twice before green. If min_attempts is not
+  # honored the loop would exit at attempt 1 because pending=0.
+  export WAIT_MIN_ATTEMPTS=2
+  GH_MOCK_CHECK_RUNS_JSON='{"check_runs":[]}' run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv ci_green)" = "ci_green=true" ]
+  # Two check-runs calls + two statuses calls = 4 api calls total.
+  [ "$(grep -c '^api' "$GH_MOCK_CALLS")" -eq 4 ]
+}
+
+@test "min_attempts cannot exceed max_attempts (timeout wins)" {
+  # If min > max, the loop exhausts attempts before ever being eligible to
+  # declare green, so the timeout branch emits ci_green=false. This models
+  # the caller-misconfiguration case (min=99, max=2) defensively.
+  export WAIT_MIN_ATTEMPTS=99
+  GH_MOCK_CHECK_RUNS_JSON='{"check_runs":[]}' run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv ci_green)" = "ci_green=false" ]
 }

--- a/.github/actions/auto-approve-bot-prs/test/wait-for-ci.bats
+++ b/.github/actions/auto-approve-bot-prs/test/wait-for-ci.bats
@@ -272,6 +272,61 @@ kv() { grep "^$1=" "$GITHUB_OUTPUT" | tail -n1; }
   [ "$(kv ci_green)" = "ci_green=false" ]
 }
 
+@test "default-deny: check-runs API failure must never emit ci_green=true" {
+  # Silent API errors are the same defect class as #2009: absence of signal
+  # treated as absence of problem. If gh can't reach the API, we cannot prove
+  # CI is clean — we must refuse to approve rather than default to green.
+  export WAIT_MAX_ATTEMPTS=3
+  export WAIT_MIN_ATTEMPTS=1
+  GH_MOCK_CHECK_RUNS_FAIL=always run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv ci_green)" = "ci_green=false" ]
+}
+
+@test "default-deny: statuses API failure must never emit ci_green=true" {
+  export WAIT_MAX_ATTEMPTS=3
+  export WAIT_MIN_ATTEMPTS=1
+  GH_MOCK_STATUSES_FAIL=always run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv ci_green)" = "ci_green=false" ]
+}
+
+@test "default-deny: transient API errors do not count toward the settle floor" {
+  # On the pre-TDD script an errored poll silently fell back to '[]' and still
+  # counted as a settle attempt — with min_attempts=2 it would approve after
+  # two failed polls because attempt>=min and 'pending=0'. The new contract:
+  # errored polls do NOT advance the settle counter.
+  export WAIT_MAX_ATTEMPTS=2
+  export WAIT_MIN_ATTEMPTS=2
+  GH_MOCK_CHECK_RUNS_FAIL=always run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv ci_green)" = "ci_green=false" ]
+}
+
+@test "pending check-run name is logged so operators can see what we are waiting on" {
+  export WAIT_MAX_ATTEMPTS=1
+  export WAIT_MIN_ATTEMPTS=1
+  GH_MOCK_CHECK_RUNS_JSON='{"check_runs":[
+    {"name":"integration-tests","status":"in_progress","conclusion":null,"details_url":"https://github.com/o/r/actions/runs/222/job/1"}
+  ]}' run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  # We expect the pending check name to appear somewhere in the output.
+  [[ "$output" == *"integration-tests"* ]]
+}
+
+@test "failed check-run output includes the conclusion, not just the name" {
+  # cancelled vs failure vs timed_out carry different debugging meaning. The
+  # audit log should surface which kind of unsuccessful conclusion blocked
+  # approval, so operators can tell a rerun-candidate from a real failure.
+  GH_MOCK_CHECK_RUNS_JSON='{"check_runs":[
+    {"name":"e2e","status":"completed","conclusion":"timed_out","details_url":"https://github.com/o/r/actions/runs/222/job/1"}
+  ]}' run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv ci_green)" = "ci_green=false" ]
+  [[ "$output" == *"e2e"* ]]
+  [[ "$output" == *"timed_out"* ]]
+}
+
 @test "regression: mixed signal — check-run green + commit status failure blocks" {
   # Defensive case: all GitHub-native check-runs are clean, but a single
   # commit-status context is failing. Pre-fix code saw only the check-runs

--- a/.github/actions/auto-approve-bot-prs/test/wait-for-ci.bats
+++ b/.github/actions/auto-approve-bot-prs/test/wait-for-ci.bats
@@ -191,3 +191,99 @@ kv() { grep "^$1=" "$GITHUB_OUTPUT" | tail -n1; }
   [ "$status" -eq 0 ]
   [ "$(kv ci_green)" = "ci_green=false" ]
 }
+
+# ---------------------------------------------------------------------------
+# Regression tests — these are the tests that SHOULD have existed before
+# loft-sh/vcluster-docs#2009 shipped a false-green approval. Each one fails
+# against the pre-fix script (either because commit statuses were ignored or
+# because an empty first poll short-circuited to ci_green=true).
+
+@test "regression: pr #2009 — failing check-runs arrive after initial empty polls" {
+  # Reproduces the #2009 timeline: at T+3s auto-approve observed zero signals
+  # on the PR head because external CI had not yet registered. The failing
+  # check-runs arrived 114s later. Old code exited green on the first poll;
+  # the settle floor must keep the loop alive long enough for the failure
+  # to be observed.
+  #
+  # Not Netlify-specific — this is the generic 'any CI posts a failure while
+  # we were in our settle window' contract. Name values are illustrative.
+  export WAIT_MIN_ATTEMPTS=5
+  export WAIT_MAX_ATTEMPTS=6
+
+  # Sequence file: one compact JSON response per line. Polls 1-4 observe an
+  # empty head (external CI silent); polls 5-6 observe the failures that
+  # finally landed. Matches #2009's 'bot approved before checks registered'.
+  export GH_MOCK_CHECK_RUNS_SEQ="$MOCK_DIR/cr_seq"
+  {
+    echo '{"check_runs":[]}'
+    echo '{"check_runs":[]}'
+    echo '{"check_runs":[]}'
+    echo '{"check_runs":[]}'
+    echo '{"check_runs":[{"name":"Redirect rules","status":"completed","conclusion":"failure","details_url":"https://external-ci/x/1"},{"name":"Header rules","status":"completed","conclusion":"failure","details_url":"https://external-ci/x/2"},{"name":"Pages changed","status":"completed","conclusion":"failure","details_url":"https://external-ci/x/3"}]}'
+    echo '{"check_runs":[{"name":"Redirect rules","status":"completed","conclusion":"failure","details_url":"https://external-ci/x/1"},{"name":"Header rules","status":"completed","conclusion":"failure","details_url":"https://external-ci/x/2"},{"name":"Pages changed","status":"completed","conclusion":"failure","details_url":"https://external-ci/x/3"}]}'
+  } > "$GH_MOCK_CHECK_RUNS_SEQ"
+
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv ci_green)" = "ci_green=false" ]
+  # Every failing check name must appear in the log so audits can find
+  # which integration blocked the approval.
+  [[ "$output" == *"Redirect rules"* ]]
+  [[ "$output" == *"Header rules"* ]]
+  [[ "$output" == *"Pages changed"* ]]
+}
+
+@test "regression: pr #2009 — commit-status failure arrives during settle window" {
+  # Same race as above, different API surface. Pre-fix code polled only
+  # /check-runs, so any CI that reports exclusively via /status (Netlify,
+  # legacy CI integrations) was completely invisible to the waiter.
+  export WAIT_MIN_ATTEMPTS=4
+  export WAIT_MAX_ATTEMPTS=5
+
+  export GH_MOCK_STATUSES_SEQ="$MOCK_DIR/st_seq"
+  {
+    echo '{"state":"success","statuses":[]}'
+    echo '{"state":"success","statuses":[]}'
+    echo '{"state":"success","statuses":[]}'
+    echo '{"state":"failure","statuses":[{"context":"deploy/netlify","state":"failure","target_url":"https://external-ci/deploys/abc"}]}'
+    echo '{"state":"failure","statuses":[{"context":"deploy/netlify","state":"failure","target_url":"https://external-ci/deploys/abc"}]}'
+  } > "$GH_MOCK_STATUSES_SEQ"
+
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv ci_green)" = "ci_green=false" ]
+  [[ "$output" == *"deploy/netlify"* ]]
+}
+
+@test "regression: empty first poll must not short-circuit to green at default settle" {
+  # The core defect: treating 'nothing visible' as 'all checks passed'.
+  # With the default min_attempts (12) and a tight max_attempts budget, an
+  # initially-empty PR must NOT get instant approval. The pre-fix script
+  # returned ci_green=true on attempt 1 with no external checks visible.
+  unset WAIT_MIN_ATTEMPTS  # exercise the in-script default (12)
+  export WAIT_MAX_ATTEMPTS=3
+  GH_MOCK_CHECK_RUNS_JSON='{"check_runs":[]}' \
+  GH_MOCK_STATUSES_JSON='{"state":"success","statuses":[]}' \
+    run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  # With max(3) < default-min(12) the run must time out, not approve. This
+  # is a direct regression guard: if anyone lowers the default, this test
+  # flips to ci_green=true and the CI job fails.
+  [ "$(kv ci_green)" = "ci_green=false" ]
+}
+
+@test "regression: mixed signal — check-run green + commit status failure blocks" {
+  # Defensive case: all GitHub-native check-runs are clean, but a single
+  # commit-status context is failing. Pre-fix code saw only the check-runs
+  # side and approved. The gate must be a logical AND across both surfaces.
+  GH_MOCK_CHECK_RUNS_JSON='{"check_runs":[
+    {"name":"lint","status":"completed","conclusion":"success","details_url":"https://github.com/o/r/actions/runs/222/job/1"},
+    {"name":"tests","status":"completed","conclusion":"success","details_url":"https://github.com/o/r/actions/runs/333/job/1"}
+  ]}' \
+  GH_MOCK_STATUSES_JSON='{"state":"failure","statuses":[
+    {"context":"deploy/netlify","state":"failure","target_url":"https://app.netlify.com/x/1"}
+  ]}' run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv ci_green)" = "ci_green=false" ]
+  [[ "$output" == *"deploy/netlify"* ]]
+}


### PR DESCRIPTION
## Summary

The shared auto-approve composite action was approving bot PRs even when CI was broken. Concrete case: loft-sh/vcluster-docs#2009 — author `loft-bot`, approved by `vcluster-bot-approver`, four failing checks at approval time (`Header rules`, `Pages changed`, `Redirect rules`, and the `deploy/netlify` commit status in `failure`). `mergeStateStatus` was `UNSTABLE`. If branch protection were misconfigured anywhere the approval would auto-merge broken code.

Two orthogonal gaps combined to make the bot blind:

1. **Commit statuses ignored.** `wait-for-ci.sh` only polled `/commits/:sha/check-runs`. Netlify and other legacy-CI integrations (CircleCI, Travis) report via `/commits/:sha/status`. A failing `deploy/netlify` commit-status context was invisible to the action. Fix: also poll the combined statuses endpoint and treat `failure`/`error` identically to a non-green check-run conclusion.
2. **No settle period before declaring green.** On PR #2009 the first poll at `12:20:30` saw no pending signals at all — Netlify had not yet posted its initial `pending`. The loop exited `ci_green=true` immediately; the failing Netlify check-runs landed 114 s later. Fix: gate the green verdict on `wait-min-attempts` (default `12` polls × `10s` sleep ≈ 110 s settle floor). Slow registrants now get a chance to appear before the action commits to "everything is fine".

Failing check / context names are logged in the `::notice::` line when skipping, so the audit trail is grep-able.

## Blast radius — consumers of this action/workflow

Found via `gh search code --owner loft-sh 'loft-sh/github-actions/.github/workflows/auto-approve-bot-prs.yaml'`:

- `loft-sh/vcluster-docs` (public)
- `loft-sh/vcluster` (public)
- `loft-sh/vcluster-pro` (private)
- `loft-sh/loft-enterprise` (private)
- `loft-sh/loft-prod` (private)
- `loft-sh/hosted-platform` (private)

Change is strictly additive. Callers that pass nothing inherit the new settle floor and the new statuses gate. A caller that wants the pre-fix impatient behaviour can set `wait-min-attempts: 1` on the composite action.

## Test plan

- [x] `make test-auto-approve-bot-prs` — 35/35 green locally (14 pre-existing + 5 new statuses tests + 2 new min-attempts tests + updates to the existing suite to set `WAIT_MIN_ATTEMPTS=1` where instant green is the test subject).
- [x] `shellcheck .github/actions/auto-approve-bot-prs/src/wait-for-ci.sh` — clean.
- [x] `zizmor .github/actions/auto-approve-bot-prs/action.yml` — no findings.
- [x] `make generate-docs` — AUTO-DOC block for the new `wait-min-attempts` input included in README.

How a reviewer can verify the fix against the reporter's PR:

1. In vcluster-docs, open a loft-bot forwardport PR (or use any trusted-author chore/deps PR) after this change ships as `auto-approve-bot-prs/v1`.
2. Watch the `Auto-approve bot PRs` job log. Expected output on the Netlify-failing path:
   ```
   attempt N/90: check_runs(pending=0 failed=0) statuses(pending=0 failed=1)
   ::notice::Other CI checks failed; skipping approval. Failing: deploy/netlify
   ci_green=false
   ```
3. Verify no `hmarr/auto-approve-action` step runs (`ci_green=true` gate). The PR should remain un-approved, mirroring branch-protection intent.
4. Happy path (all green, no Netlify): job logs ≥ 12 poll lines before `ci_green=true`, then the approve step runs.

## Not in this PR

- Migrating the trigger from `pull_request: opened` to `check_suite: completed` (one of the options suggested during triage). The settle-period approach is lower risk — it keeps the existing trigger surface, keeps the audit log consistent with today's runs, and does not require every consumer workflow to rewire its `on:` block. If the settle period proves insufficient in practice, `check_suite.completed` is a straight follow-up.
- `mergeable_state` check in `check-pr-ready.sh`. Considered and rejected for this PR: the state can be transiently `unknown` while GitHub computes metadata, and layering that gate on top of the two fixes here is a second change rather than a reinforcement of the same one. Reasonable follow-up if we still see edge cases.