### PR TITLE
fix(auto-approve): tolerate concurrency-cancelled checks until settle floor

### DIFF
--- a/.github/actions/auto-approve-bot-prs/src/wait-for-ci.sh
+++ b/.github/actions/auto-approve-bot-prs/src/wait-for-ci.sh
@@ -102,12 +102,24 @@ for attempt in $(seq 1 "$max_attempts"); do
     fi
   fi
 
-  cr_pending=0 cr_failed=0 cr_failed_detail="" cr_pending_names=""
+  # `cancelled` is special: GitHub's concurrency-group cancellation marks the
+  # superseded run cancelled and immediately queues a replacement. There's a
+  # short window (observed: 5–10s) where the cancelled attempt is registered
+  # but the replacement is not yet visible. In that window the dedup-by-latest
+  # logic above has nothing to pick — only the cancelled attempt exists — so
+  # treating cancelled as a hard failure here would defeat the dedup fix and
+  # bail before the rerun lands. Split it out: terminal failures bail
+  # immediately; cancelled-only is held until the settle floor so the
+  # replacement has a chance to register and dedup can pick it.
+  cr_pending=0 cr_real_failed=0 cr_real_failed_detail=""
+  cr_cancelled=0 cr_cancelled_detail="" cr_pending_names=""
   if [ "$poll_errored" -eq 0 ]; then
-    cr_pending=$(       jq_or_fail '[.[] | select(.status != "completed")] | length'                                                                                                  "$other" ) || poll_errored=1
-    cr_failed=$(        jq_or_fail '[.[] | select(.conclusion != null and ([.conclusion] | inside(["success","skipped","neutral"]) | not))] | length'                                 "$other" ) || poll_errored=1
-    cr_failed_detail=$( jq_or_fail -r '[.[] | select(.conclusion != null and ([.conclusion] | inside(["success","skipped","neutral"]) | not)) | "\(.name // "unnamed")=\(.conclusion)"] | join(", ")' "$other" ) || poll_errored=1
-    cr_pending_names=$( jq_or_fail -r '[.[] | select(.status != "completed") | .name // "unnamed"] | join(", ")'                                                                      "$other" ) || poll_errored=1
+    cr_pending=$(           jq_or_fail '[.[] | select(.status != "completed")] | length'                                                                                                          "$other" ) || poll_errored=1
+    cr_real_failed=$(       jq_or_fail '[.[] | select(.conclusion != null and ([.conclusion] | inside(["success","skipped","neutral","cancelled"]) | not))] | length'                             "$other" ) || poll_errored=1
+    cr_real_failed_detail=$(jq_or_fail -r '[.[] | select(.conclusion != null and ([.conclusion] | inside(["success","skipped","neutral","cancelled"]) | not)) | "\(.name // "unnamed")=\(.conclusion)"] | join(", ")' "$other" ) || poll_errored=1
+    cr_cancelled=$(         jq_or_fail '[.[] | select(.conclusion == "cancelled")] | length'                                                                                                      "$other" ) || poll_errored=1
+    cr_cancelled_detail=$(  jq_or_fail -r '[.[] | select(.conclusion == "cancelled") | .name // "unnamed"] | join(", ")'                                                                          "$other" ) || poll_errored=1
+    cr_pending_names=$(     jq_or_fail -r '[.[] | select(.status != "completed") | .name // "unnamed"] | join(", ")'                                                                              "$other" ) || poll_errored=1
   fi
 
   # -- Fetch commit statuses ------------------------------------------------
@@ -154,12 +166,23 @@ for attempt in $(seq 1 "$max_attempts"); do
   consecutive_errors=0
 
   pending=$(( cr_pending + st_pending ))
-  failed=$(( cr_failed + st_failed ))
-  echo "attempt ${attempt}/${max_attempts}: check_runs(pending=${cr_pending} failed=${cr_failed}) statuses(pending=${st_pending} failed=${st_failed})"
+  real_failed=$(( cr_real_failed + st_failed ))
+  echo "attempt ${attempt}/${max_attempts}: check_runs(pending=${cr_pending} failed=${cr_real_failed} cancelled=${cr_cancelled}) statuses(pending=${st_pending} failed=${st_failed})"
 
-  if [ "$failed" -gt 0 ]; then
-    details=$(printf '%s\n%s' "$cr_failed_detail" "$st_failed_detail" | awk 'NF' | paste -sd, - | sed 's/,/, /g')
+  # Terminal failures (failure, timed_out, action_required, etc.) bail
+  # immediately — these are not transient and won't be replaced.
+  if [ "$real_failed" -gt 0 ]; then
+    details=$(printf '%s\n%s' "$cr_real_failed_detail" "$st_failed_detail" | awk 'NF' | paste -sd, - | sed 's/,/, /g')
     echo "::notice::Other CI checks failed; skipping approval. Failing: ${details:-unknown}"
+    emit ci_green false
+    exit 0
+  fi
+
+  # Cancelled checks may be in the middle of a concurrency-triggered rerun.
+  # Past the settle floor we stop waiting and treat them as final — the
+  # replacement should have registered by now if it was ever going to.
+  if [ "$cr_cancelled" -gt 0 ] && [ "$attempt" -ge "$min_attempts" ]; then
+    echo "::notice::Cancelled checks did not get replaced within settle period; skipping approval. Cancelled: ${cr_cancelled_detail:-unknown}"
     emit ci_green false
     exit 0
   fi
@@ -170,12 +193,16 @@ for attempt in $(seq 1 "$max_attempts"); do
     waiting=$(printf '%s\n%s' "$cr_pending_names" "$st_pending_names" | awk 'NF' | paste -sd, - | sed 's/,/, /g')
     echo "  pending: ${waiting:-<unnamed>}"
   fi
+  if [ "$cr_cancelled" -gt 0 ]; then
+    echo "  cancelled (waiting for concurrency replacement): ${cr_cancelled_detail}"
+  fi
 
   # Hold the "green" verdict until the settle floor. A first-poll "pending=0"
   # can simply mean external checks have not registered yet (e.g. Netlify
   # webhook still in flight). Waiting min_attempts polls before the first
-  # green verdict gives slow registrants a chance to show up.
-  if [ "$pending" -eq 0 ] && [ "$attempt" -ge "$min_attempts" ]; then
+  # green verdict gives slow registrants a chance to show up. Cancelled
+  # checks also keep us out of green — handled above by the post-settle bail.
+  if [ "$pending" -eq 0 ] && [ "$cr_cancelled" -eq 0 ] && [ "$attempt" -ge "$min_attempts" ]; then
     emit ci_green true
     exit 0
   fi

--- a/.github/actions/auto-approve-bot-prs/test/wait-for-ci.bats
+++ b/.github/actions/auto-approve-bot-prs/test/wait-for-ci.bats
@@ -84,9 +84,12 @@ kv() { grep "^$1=" "$GITHUB_OUTPUT" | tail -n1; }
   [ "$(kv ci_green)" = "ci_green=true" ]
 }
 
-@test "cancelled as latest attempt still blocks (not a stale artifact)" {
+@test "cancelled as latest attempt still blocks once settle period elapses" {
   # Opposite of the superseded case: when cancelled IS the latest attempt,
   # it is a real signal that CI was aborted and approval should not proceed.
+  # The script holds the cancelled state across the settle floor in case a
+  # concurrency-triggered replacement is en route (see #2019/#2020 race);
+  # past the floor (here min=1) it bails.
   GH_MOCK_CHECK_RUNS_JSON='{"check_runs":[
     {"name":"integration-test/chrome","status":"completed","conclusion":"skipped","started_at":"2026-04-17T05:00:00Z","details_url":"https://github.com/o/r/actions/runs/220/job/1"},
     {"name":"integration-test/chrome","status":"completed","conclusion":"cancelled","started_at":"2026-04-17T06:00:00Z","details_url":"https://github.com/o/r/actions/runs/221/job/1"}
@@ -325,6 +328,125 @@ kv() { grep "^$1=" "$GITHUB_OUTPUT" | tail -n1; }
   [ "$(kv ci_green)" = "ci_green=false" ]
   [[ "$output" == *"e2e"* ]]
   [[ "$output" == *"timed_out"* ]]
+}
+
+@test "regression: prs #2019/#2020 — cancelled at attempt 1 must wait for concurrency replacement" {
+  # Reproduces the docs backport storm of 2026-04-27 where 4 sibling
+  # backport PRs were created in 24s. GitHub's concurrency-group cancellation
+  # marked the prior PR's browser-test workflow as `cancelled` and queued a
+  # replacement, but the replacement took 5–10s to register. Pre-fix
+  # wait-for-ci saw the cancelled check on attempt 1, treated it as a
+  # terminal failure, and bailed before the replacement landed. The fix
+  # holds the cancelled state across the settle floor so dedup can pick the
+  # replacement once it shows up.
+  export WAIT_MIN_ATTEMPTS=4
+  export WAIT_MAX_ATTEMPTS=6
+
+  export GH_MOCK_CHECK_RUNS_SEQ="$MOCK_DIR/cr_seq"
+  {
+    # Polls 1-2: only the cancelled attempt is visible (the failure window).
+    echo '{"check_runs":[{"name":"Mobile Safari (iPhone)","id":100,"status":"completed","conclusion":"cancelled","started_at":"2026-04-27T07:40:05Z","details_url":"https://external/runs/220/job/1"}]}'
+    echo '{"check_runs":[{"name":"Mobile Safari (iPhone)","id":100,"status":"completed","conclusion":"cancelled","started_at":"2026-04-27T07:40:05Z","details_url":"https://external/runs/220/job/1"}]}'
+    # Poll 3+: replacement skipped attempt registers; dedup picks the newer id.
+    echo '{"check_runs":[
+      {"name":"Mobile Safari (iPhone)","id":100,"status":"completed","conclusion":"cancelled","started_at":"2026-04-27T07:40:05Z","details_url":"https://external/runs/220/job/1"},
+      {"name":"Mobile Safari (iPhone)","id":200,"status":"completed","conclusion":"skipped","started_at":"2026-04-27T07:40:15Z","details_url":"https://external/runs/221/job/1"}
+    ]}'
+    echo '{"check_runs":[
+      {"name":"Mobile Safari (iPhone)","id":100,"status":"completed","conclusion":"cancelled","started_at":"2026-04-27T07:40:05Z","details_url":"https://external/runs/220/job/1"},
+      {"name":"Mobile Safari (iPhone)","id":200,"status":"completed","conclusion":"skipped","started_at":"2026-04-27T07:40:15Z","details_url":"https://external/runs/221/job/1"}
+    ]}'
+  } > "$GH_MOCK_CHECK_RUNS_SEQ"
+
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv ci_green)" = "ci_green=true" ]
+}
+
+@test "regression: cancelled replacement that arrives as success also unblocks" {
+  # Same shape as the docs backport storm but the replacement attempt lands
+  # on `success` instead of `skipped` (e.g. when the concurrency group fires
+  # but the rerun actually executes the job). Dedup must still pick the
+  # newer id and the verdict must become green.
+  export WAIT_MIN_ATTEMPTS=3
+  export WAIT_MAX_ATTEMPTS=5
+
+  export GH_MOCK_CHECK_RUNS_SEQ="$MOCK_DIR/cr_seq"
+  {
+    echo '{"check_runs":[{"name":"e2e","id":100,"status":"completed","conclusion":"cancelled","started_at":"2026-04-27T07:40:05Z","details_url":"https://external/runs/220/job/1"}]}'
+    echo '{"check_runs":[{"name":"e2e","id":100,"status":"completed","conclusion":"cancelled","started_at":"2026-04-27T07:40:05Z","details_url":"https://external/runs/220/job/1"}]}'
+    echo '{"check_runs":[
+      {"name":"e2e","id":100,"status":"completed","conclusion":"cancelled","started_at":"2026-04-27T07:40:05Z","details_url":"https://external/runs/220/job/1"},
+      {"name":"e2e","id":200,"status":"completed","conclusion":"success","started_at":"2026-04-27T07:40:15Z","details_url":"https://external/runs/221/job/1"}
+    ]}'
+  } > "$GH_MOCK_CHECK_RUNS_SEQ"
+
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv ci_green)" = "ci_green=true" ]
+}
+
+@test "regression: cancelled-only that never gets replaced bails at settle floor (bounded wait)" {
+  # A real user-cancelled check that is never replaced must not block the
+  # auto-approve job indefinitely. Once the settle floor elapses, treat the
+  # cancellation as final and exit non-green. This bounds the wait by
+  # min_attempts*sleep_seconds, not max_attempts*sleep_seconds.
+  export WAIT_MIN_ATTEMPTS=2
+  export WAIT_MAX_ATTEMPTS=10
+  GH_MOCK_CHECK_RUNS_JSON='{"check_runs":[
+    {"name":"e2e","status":"completed","conclusion":"cancelled","details_url":"https://github.com/o/r/actions/runs/222/job/1"}
+  ]}' run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv ci_green)" = "ci_green=false" ]
+  [[ "$output" == *"e2e"* ]]
+  [[ "$output" == *"Cancelled checks did not get replaced"* ]]
+}
+
+@test "regression: terminal failure during settle window still bails immediately" {
+  # The cancelled-tolerance must NOT extend to terminal conclusions.
+  # `failure`/`timed_out`/`action_required` are not replaced by GitHub
+  # machinery; they must continue to bail on first detection regardless of
+  # the settle floor.
+  export WAIT_MIN_ATTEMPTS=20
+  export WAIT_MAX_ATTEMPTS=30
+  export WAIT_SLEEP_SECONDS=1
+  GH_MOCK_CHECK_RUNS_JSON='{"check_runs":[
+    {"name":"e2e","status":"completed","conclusion":"failure","details_url":"https://github.com/o/r/actions/runs/222/job/1"}
+  ]}' run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv ci_green)" = "ci_green=false" ]
+  # Bailed on attempt 1, not after 20+ polls.
+  [[ "$output" != *"attempt 2/"* ]]
+}
+
+@test "regression: cancelled + terminal failure mix still bails immediately on the failure" {
+  # If a cancelled check coexists with a real failure, the real failure wins
+  # and we exit immediately. The cancelled-tolerance does not override
+  # terminal failures.
+  export WAIT_MIN_ATTEMPTS=10
+  export WAIT_MAX_ATTEMPTS=20
+  GH_MOCK_CHECK_RUNS_JSON='{"check_runs":[
+    {"name":"browser-tests","status":"completed","conclusion":"cancelled","details_url":"https://github.com/o/r/actions/runs/220/job/1"},
+    {"name":"e2e","status":"completed","conclusion":"failure","details_url":"https://github.com/o/r/actions/runs/222/job/1"}
+  ]}' run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv ci_green)" = "ci_green=false" ]
+  [[ "$output" == *"e2e"* ]]
+  [[ "$output" == *"failure"* ]]
+  [[ "$output" != *"attempt 2/"* ]]
+}
+
+@test "regression: cancelled does not short-circuit pre-settle empty poll into green" {
+  # Belt-and-braces: even if min_attempts=1 and the only signal is cancelled,
+  # we never declare ci_green=true. The combination of "cancelled present"
+  # and "post-settle" exits non-green, never green.
+  export WAIT_MIN_ATTEMPTS=1
+  export WAIT_MAX_ATTEMPTS=2
+  GH_MOCK_CHECK_RUNS_JSON='{"check_runs":[
+    {"name":"flaky","status":"completed","conclusion":"cancelled","details_url":"https://github.com/o/r/actions/runs/222/job/1"}
+  ]}' run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv ci_green)" = "ci_green=false" ]
 }
 
 @test "regression: mixed signal — check-run green + commit status failure blocks" {


### PR DESCRIPTION
## Why

vcluster-docs backport storm of 2026-04-27 created PRs [#2019][p19], [#2020][p20], [#2021][p21], [#2022][p22] in 24 seconds. GitHub's concurrency-group cancellation marked the prior PR's browser-test workflow `cancelled` and queued a replacement, but the replacement took ~5–10s to register.

PRs #2019/#2020 polled inside that window — only the cancelled attempt was visible, the dedup-by-latest logic ([843b20d][843]) had nothing to pick from, and `wait-for-ci.sh` exited non-green on attempt 1 with `Mobile Safari (iPhone)=cancelled`. PRs #2021/#2022 polled a few seconds later, missed the window, and were approved correctly. **Same workflow, same files, same author — only the millisecond of the first poll decided the outcome.**

This is the same defect class as [#2009][2009] (late-registering external CI), 843b20d (dedup tiebreak), 5ba7a49 (commit-status surface), and 195ad16 (silent API failures): _absence of evidence treated as evidence of absence._ Each prior fix patched a different face of the same cube. This PR patches the remaining face: transient `cancelled` during concurrency replacement.

## What changes

`src/wait-for-ci.sh` — split the failed-conclusions predicate:

- **Terminal failures** (`failure`, `timed_out`, `action_required`, etc.) — bail immediately, unchanged.
- **`cancelled`** — held across the `min_attempts` settle floor so the concurrency-triggered replacement has a chance to register and dedup can pick it. After the floor, an unreplaced cancellation is treated as final.
- Bounded wait: `min_attempts × sleep_seconds` (default 120s) — won't block forever on a real user cancellation. See test #46.

## Tests (32/32 green)

Six new regressions cover the cancellation/replacement matrix:

| # | Scenario | Asserts |
|---|---|---|
| 26 | cancelled @ attempt 1, replacement skipped @ attempt 3 | `ci_green=true` (the bug we just hit) |
| 27 | cancelled replaced by `success` (not skipped) | `ci_green=true` (path-filter-independent) |
| 28 | cancelled, never replaced | `ci_green=false` at settle floor (bounded wait) |
| 29 | terminal `failure` during settle window | `ci_green=false` on attempt 1 (no waiting) |
| 30 | cancelled + terminal `failure` mix | `ci_green=false` on attempt 1, blamed on the failure |
| 31 | min=1, only cancelled visible | never silently approves |

Pre-existing regressions for #2009, default-deny, dedup tiebreak, and statuses-API surface still hold.

## Test plan

- [x] `bats test/wait-for-ci.bats` — 32/32 green
- [x] `bats test/` — full auto-approve suite green
- [ ] After merge: monitor next bot-PR storm in vcluster-docs (renovate batch / multi-version backport) for clean approvals across all sibling PRs

[p19]: https://github.com/loft-sh/vcluster-docs/pull/2019
[p20]: https://github.com/loft-sh/vcluster-docs/pull/2020
[p21]: https://github.com/loft-sh/vcluster-docs/pull/2021
[p22]: https://github.com/loft-sh/vcluster-docs/pull/2022
[2009]: https://github.com/loft-sh/vcluster-docs/pull/2009
[843]: https://github.com/loft-sh/github-actions/commit/843b20d