### PR TITLE
feat(sticky-pr-comment): composite action for upserting sticky pr comments

### DIFF
--- a/.github/actions/sticky-pr-comment/README.md
+++ b/.github/actions/sticky-pr-comment/README.md
@@ -1,0 +1,93 @@
+# Sticky PR Comment
+
+Upserts a sticky comment on a pull request, identified by a stable HTML
+marker. If a comment with the marker already exists it is updated in place,
+otherwise a new comment is created. Domain-agnostic — the caller composes
+the body. Uses the GitHub CLI (`gh`), pre-installed on hosted runners.
+
+## Inputs
+
+<!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
+
+|      INPUT      |  TYPE  | REQUIRED |                   DEFAULT                   |                                                                                                                                                    DESCRIPTION                                                                                                                                                    |
+|-----------------|--------|----------|---------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|      body       | string |   true   |                                             |                                                                                                 Markdown body of the comment. The <br>marker is prepended automatically if it <br>is not already the first line.                                                                                                  |
+| expected-author | string |  false   |           `"github-actions[bot]"`           | Login of the comment author to <br>match. Comments with the marker but <br>a different author are ignored, so <br>users cannot squat on the sticky <br>slot. Defaults to "github-actions[bot]" which is <br>the author when secrets.GITHUB_TOKEN is used; <br>override when posting via a PAT <br>or GitHub App.  |
+|  github-token   | string |   true   |                                             |                                                                                                                  GitHub token. The caller must grant <br>pull-requests: write at the job level.                                                                                                                   |
+|     marker      | string |   true   |                                             |                                                                                       HTML comment uniquely identifying this comment <br>stream (e.g. "<!-- e2e-status -->"). Must be of the <br>form "<!-- some-id -->".                                                                                         |
+|    pr-number    | string |  false   | `"${{ github.event.pull_request.number }}"` |                                                                                                                       Pull request number. Defaults to the <br>current pull_request event.                                                                                                                        |
+|      repo       | string |  false   |        `"${{ github.repository }}"`         |                                                                                                                      Repository in owner/name form. Defaults to <br>the current repository.                                                                                                                       |
+
+<!-- AUTO-DOC-INPUT:END -->
+
+## Outputs
+
+<!-- AUTO-DOC-OUTPUT:START - Do not remove or modify this section -->
+
+|    OUTPUT    |  TYPE  |             DESCRIPTION             |
+|--------------|--------|-------------------------------------|
+| action-taken | string |   Either "created" or "updated".    |
+|  comment-id  | string | Numeric ID of the upserted comment. |
+
+<!-- AUTO-DOC-OUTPUT:END -->
+
+## Usage
+
+```yaml
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Run tests
+        id: tests
+        run: ./run-tests.sh
+
+      - name: Upsert sticky status comment
+        if: always() && github.event_name == 'pull_request'
+        uses: loft-sh/github-actions/.github/actions/sticky-pr-comment@sticky-pr-comment/v1
+        with:
+          marker: '<!-- e2e-status -->'
+          body: |
+            ### E2E Tests
+
+            | Status | Commit | Run |
+            |---|---|---|
+            | ${{ steps.tests.outcome == 'success' && '✅ Passed' || '❌ Failed' }} | `${{ github.event.pull_request.head.sha }}` | [#${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) |
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+The marker must be a self-contained HTML comment (e.g. `<!-- e2e-status -->`).
+It is automatically prepended to `body` when missing, so callers can either
+include it explicitly or omit it.
+
+### Sticky semantics
+
+The action is invoked from inside a job. When the caller's job is **skipped**
+by an `if:` condition, this action never runs and the previous comment stays
+in place — that's exactly the "preserve last real result" behavior most
+callers want. Make sure callers do **not** put the upsert step in a separate
+job that runs unconditionally; otherwise skipped runs will overwrite the
+last real status.
+
+### Permissions
+
+The token passed to `github-token` must have `pull-requests: write`. The
+caller is responsible for granting the permission at job level:
+
+```yaml
+permissions:
+  contents: read
+  pull-requests: write
+```
+
+## Testing
+
+```bash
+make test-sticky-pr-comment
+```
+
+Runs the bats suite in `test/` against `src/upsert-comment.sh` with a stubbed
+`gh` on `PATH`.

--- a/.github/actions/sticky-pr-comment/action.yml
+++ b/.github/actions/sticky-pr-comment/action.yml
@@ -1,0 +1,52 @@
+name: Sticky PR Comment
+description: |
+  Upserts a sticky comment on a pull request, identified by a stable HTML
+  marker. If a comment with the marker already exists it is updated in place,
+  otherwise a new comment is created. Domain-agnostic — the caller composes
+  the body. Uses the GitHub CLI (gh) which is pre-installed on hosted runners.
+inputs:
+  marker:
+    description: 'HTML comment uniquely identifying this comment stream (e.g. "<!-- e2e-status -->"). Must be of the form "<!-- some-id -->".'
+    required: true
+  body:
+    description: 'Markdown body of the comment. The marker is prepended automatically if it is not already the first line.'
+    required: true
+  pr-number:
+    description: 'Pull request number. Defaults to the current pull_request event.'
+    required: false
+    default: ${{ github.event.pull_request.number }}
+  repo:
+    description: 'Repository in owner/name form. Defaults to the current repository.'
+    required: false
+    default: ${{ github.repository }}
+  github-token:
+    description: 'GitHub token. The caller must grant pull-requests: write at the job level.'
+    required: true
+  expected-author:
+    description: 'Login of the comment author to match. Comments with the marker but a different author are ignored, so users cannot squat on the sticky slot. Defaults to "github-actions[bot]" which is the author when secrets.GITHUB_TOKEN is used; override when posting via a PAT or GitHub App.'
+    required: false
+    default: 'github-actions[bot]'
+outputs:
+  comment-id:
+    description: 'Numeric ID of the upserted comment.'
+    value: ${{ steps.upsert.outputs.comment-id }}
+  action-taken:
+    description: 'Either "created" or "updated".'
+    value: ${{ steps.upsert.outputs.action-taken }}
+runs:
+  using: composite
+  steps:
+    - name: Upsert sticky PR comment
+      id: upsert
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        INPUT_MARKER: ${{ inputs.marker }}
+        INPUT_BODY: ${{ inputs.body }}
+        INPUT_PR_NUMBER: ${{ inputs.pr-number }}
+        INPUT_REPO: ${{ inputs.repo }}
+        INPUT_EXPECTED_AUTHOR: ${{ inputs.expected-author }}
+      run: ${{ github.action_path }}/src/upsert-comment.sh
+branding:
+  icon: 'message-square'
+  color: 'blue'

--- a/.github/actions/sticky-pr-comment/src/upsert-comment.sh
+++ b/.github/actions/sticky-pr-comment/src/upsert-comment.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Upsert a sticky PR comment identified by a stable HTML marker.
+#
+# Required env: GH_TOKEN, INPUT_MARKER, INPUT_BODY, INPUT_PR_NUMBER, INPUT_REPO,
+#               INPUT_EXPECTED_AUTHOR
+# Writes: comment-id=<id> and action-taken=created|updated to $GITHUB_OUTPUT.
+set -euo pipefail
+
+: "${GH_TOKEN:?GH_TOKEN required}"
+: "${INPUT_MARKER:?marker required}"
+: "${INPUT_BODY:?body required}"
+: "${INPUT_PR_NUMBER:?pr-number required}"
+: "${INPUT_REPO:?repo required}"
+: "${INPUT_EXPECTED_AUTHOR:?expected-author required}"
+
+# The marker must be a self-contained HTML comment so it can't accidentally
+# match unrelated comments and so callers can't smuggle markdown into it.
+if [[ ! "$INPUT_MARKER" =~ ^\<!--[[:space:]].*[[:space:]]--\>$ ]]; then
+  echo "::error::marker must look like '<!-- some-id -->', got: $INPUT_MARKER"
+  exit 1
+fi
+
+# Ensure the marker is the first line of the body so startswith() matches.
+if [[ "$INPUT_BODY" == "$INPUT_MARKER"* ]]; then
+  BODY="$INPUT_BODY"
+else
+  BODY="${INPUT_MARKER}"$'\n'"${INPUT_BODY}"
+fi
+
+emit() {
+  printf '%s=%s\n' "$1" "$2" >> "$GITHUB_OUTPUT"
+  printf '%s=%s\n' "$1" "$2"
+}
+
+# --paginate concatenates pages into a single JSON array. Filter locally with
+# jq (rather than --jq) so we're not at the mercy of per-page filtering, and
+# so the marker travels as a jq --arg rather than embedded into a quoted
+# filter string.
+COMMENTS_JSON=$(gh api --paginate \
+  "repos/${INPUT_REPO}/issues/${INPUT_PR_NUMBER}/comments")
+# Match by author + marker so a third party can't squat on the sticky slot
+# by pre-creating a comment whose body starts with the marker.
+COMMENT_ID=$(jq -r --arg m "$INPUT_MARKER" --arg u "$INPUT_EXPECTED_AUTHOR" \
+  '[.[] | select(.user.login == $u and (.body | startswith($m)))] | first | .id // empty' \
+  <<<"$COMMENTS_JSON")
+
+if [[ -n "$COMMENT_ID" ]]; then
+  gh api -X PATCH \
+    "repos/${INPUT_REPO}/issues/comments/${COMMENT_ID}" \
+    -f body="$BODY" >/dev/null
+  emit comment-id "$COMMENT_ID"
+  emit action-taken "updated"
+else
+  CREATE_JSON=$(gh api -X POST \
+    "repos/${INPUT_REPO}/issues/${INPUT_PR_NUMBER}/comments" \
+    -f body="$BODY")
+  COMMENT_ID=$(jq -r '.id' <<<"$CREATE_JSON")
+  emit comment-id "$COMMENT_ID"
+  emit action-taken "created"
+fi

--- a/.github/actions/sticky-pr-comment/test/gh_mock.bash
+++ b/.github/actions/sticky-pr-comment/test/gh_mock.bash
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Stub `gh` on PATH for upsert-comment.sh tests. Records every invocation
+# (one line per call: subcommand + flags as space-joined args) into
+# $GH_MOCK_CALLS, and serves canned responses based on env vars.
+#
+# GH_MOCK_LIST_JSON   → JSON array returned for "gh api .../issues/N/comments"
+# GH_MOCK_CREATE_JSON → JSON object returned for "gh api -X POST .../comments"
+# GH_MOCK_PATCH_JSON  → JSON object returned for "gh api -X PATCH .../comments/<id>" (default "{}")
+# GH_MOCK_BODY_LOG    → path; the request body (-f body=...) of every PATCH/POST call is appended
+
+setup_gh_mock() {
+  MOCK_DIR="$(mktemp -d)"
+  export MOCK_DIR
+  PATH="$MOCK_DIR:$PATH"
+  export PATH
+
+  export GH_MOCK_CALLS="$MOCK_DIR/calls.log"
+  export GH_MOCK_BODY_LOG="$MOCK_DIR/bodies.log"
+  : > "$GH_MOCK_CALLS"
+  : > "$GH_MOCK_BODY_LOG"
+
+  cat > "$MOCK_DIR/gh" <<'EOF'
+#!/usr/bin/env bash
+# Mock gh. Only covers `gh api` calls used by upsert-comment.sh.
+
+method="GET"
+path=""
+jq_filter=""
+body=""
+paginate=0
+
+[ "${1:-}" = "api" ] || { echo "unsupported gh invocation: $*" >&2; exit 99; }
+shift
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --jq)        jq_filter="$2"; shift 2 ;;
+    --paginate)  paginate=1; shift ;;
+    -X)          method="$2"; shift 2 ;;
+    -f)
+      case "$2" in
+        body=*) body="${2#body=}" ;;
+      esac
+      shift 2
+      ;;
+    -H|--header) shift 2 ;;
+    -*)          shift ;;
+    *)
+      if [ -z "$path" ]; then path="$1"; fi
+      shift
+      ;;
+  esac
+done
+
+# Record the call (method + path + indicator flags). Body is logged separately.
+{
+  printf '%s %s' "$method" "$path"
+  [ -n "$jq_filter" ] && printf ' --jq=%s' "$jq_filter"
+  [ "$paginate" = "1" ]   && printf ' --paginate'
+  printf '\n'
+} >> "$GH_MOCK_CALLS"
+
+if [ -n "$body" ]; then
+  printf '%s\n---END---\n' "$body" >> "$GH_MOCK_BODY_LOG"
+fi
+
+emit_response() {
+  case "$method:$path" in
+    GET:*"/issues/"*"/comments")
+      printf '%s\n' "${GH_MOCK_LIST_JSON-[]}"
+      ;;
+    POST:*"/issues/"*"/comments")
+      default_create='{"id":0}'
+      printf '%s\n' "${GH_MOCK_CREATE_JSON-$default_create}"
+      ;;
+    PATCH:*"/issues/comments/"*)
+      default_patch='{}'
+      printf '%s\n' "${GH_MOCK_PATCH_JSON-$default_patch}"
+      ;;
+    *)
+      printf '{}\n'
+      ;;
+  esac
+}
+
+if [ -n "$jq_filter" ]; then
+  emit_response | jq -r "$jq_filter"
+else
+  emit_response
+fi
+EOF
+  chmod +x "$MOCK_DIR/gh"
+}
+
+teardown_gh_mock() {
+  rm -rf "$MOCK_DIR"
+}

--- a/.github/actions/sticky-pr-comment/test/upsert-comment.bats
+++ b/.github/actions/sticky-pr-comment/test/upsert-comment.bats
@@ -1,0 +1,167 @@
+#!/usr/bin/env bats
+# Tests for upsert-comment.sh.
+
+SCRIPT="$BATS_TEST_DIRNAME/../src/upsert-comment.sh"
+MARKER='<!-- e2e-status -->'
+AUTHOR='github-actions[bot]'
+
+load gh_mock
+
+setup() {
+  setup_gh_mock
+  export GITHUB_OUTPUT; GITHUB_OUTPUT="$(mktemp)"
+  export GH_TOKEN="fake-token"
+  export INPUT_MARKER="$MARKER"
+  export INPUT_PR_NUMBER="42"
+  export INPUT_REPO="owner/repo"
+  export INPUT_EXPECTED_AUTHOR="$AUTHOR"
+}
+
+teardown() {
+  rm -f "$GITHUB_OUTPUT"
+  teardown_gh_mock
+}
+
+kv() { grep "^$1=" "$GITHUB_OUTPUT" | tail -n1; }
+last_body() { awk 'BEGIN{RS="---END---\n"} END{printf "%s", $0}' "$GH_MOCK_BODY_LOG"; }
+
+@test "no existing comment → creates and emits action-taken=created" {
+  export GH_MOCK_LIST_JSON='[]'
+  export GH_MOCK_CREATE_JSON='{"id": 12345}'
+  export INPUT_BODY="hello world"
+
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv comment-id)" = "comment-id=12345" ]
+  [ "$(kv action-taken)" = "action-taken=created" ]
+
+  # POST was called against the PR comments endpoint
+  grep -q '^POST repos/owner/repo/issues/42/comments$' "$GH_MOCK_CALLS"
+  # No PATCH happened
+  ! grep -q '^PATCH ' "$GH_MOCK_CALLS"
+}
+
+@test "existing comment with marker → updates and emits action-taken=updated" {
+  export GH_MOCK_LIST_JSON='[
+    {"id": 99, "body": "unrelated comment", "user": {"login": "github-actions[bot]"}},
+    {"id": 777, "body": "<!-- e2e-status -->\nold body", "user": {"login": "github-actions[bot]"}}
+  ]'
+  export INPUT_BODY="new body"
+
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv comment-id)" = "comment-id=777" ]
+  [ "$(kv action-taken)" = "action-taken=updated" ]
+
+  grep -q '^PATCH repos/owner/repo/issues/comments/777$' "$GH_MOCK_CALLS"
+  ! grep -q '^POST ' "$GH_MOCK_CALLS"
+}
+
+@test "marker present but wrong author → creates new comment (squat-resistant)" {
+  export GH_MOCK_LIST_JSON='[
+    {"id": 555, "body": "<!-- e2e-status -->\nsquatter body", "user": {"login": "evil-user"}}
+  ]'
+  export GH_MOCK_CREATE_JSON='{"id": 999}'
+  export INPUT_BODY="legit status"
+
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv comment-id)" = "comment-id=999" ]
+  [ "$(kv action-taken)" = "action-taken=created" ]
+
+  grep -q '^POST repos/owner/repo/issues/42/comments$' "$GH_MOCK_CALLS"
+  # Squatter's comment must NOT be patched.
+  ! grep -q '^PATCH repos/owner/repo/issues/comments/555$' "$GH_MOCK_CALLS"
+}
+
+@test "marker matches across mixed authors → picks the one matching expected-author" {
+  export GH_MOCK_LIST_JSON='[
+    {"id": 100, "body": "<!-- e2e-status -->\nsquatter", "user": {"login": "evil-user"}},
+    {"id": 200, "body": "<!-- e2e-status -->\nlegit",    "user": {"login": "github-actions[bot]"}}
+  ]'
+  export INPUT_BODY="updated"
+
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv comment-id)" = "comment-id=200" ]
+  [ "$(kv action-taken)" = "action-taken=updated" ]
+}
+
+@test "custom expected-author (PAT identity) is honored" {
+  export INPUT_EXPECTED_AUTHOR="release-bot"
+  export GH_MOCK_LIST_JSON='[
+    {"id": 11, "body": "<!-- e2e-status -->\nfrom default bot", "user": {"login": "github-actions[bot]"}},
+    {"id": 22, "body": "<!-- e2e-status -->\nfrom release bot", "user": {"login": "release-bot"}}
+  ]'
+  export INPUT_BODY="x"
+
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv comment-id)" = "comment-id=22" ]
+  [ "$(kv action-taken)" = "action-taken=updated" ]
+}
+
+@test "marker auto-prepended when body does not start with it" {
+  export GH_MOCK_LIST_JSON='[]'
+  export GH_MOCK_CREATE_JSON='{"id": 1}'
+  export INPUT_BODY=$'### header\nline two'
+
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+
+  body="$(last_body)"
+  [[ "$body" == "<!-- e2e-status -->"$'\n'"### header"$'\n'"line two" ]] || {
+    printf 'unexpected body: %q\n' "$body"
+    return 1
+  }
+}
+
+@test "marker not duplicated when body already starts with it" {
+  export GH_MOCK_LIST_JSON='[]'
+  export GH_MOCK_CREATE_JSON='{"id": 1}'
+  export INPUT_BODY=$'<!-- e2e-status -->\nbody'
+
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+
+  body="$(last_body)"
+  [[ "$body" == $'<!-- e2e-status -->\nbody' ]] || {
+    printf 'unexpected body: %q\n' "$body"
+    return 1
+  }
+  # No double-marker
+  occurrences="$(grep -o -- '<!-- e2e-status -->' <<<"$body" | wc -l)"
+  [ "$occurrences" -eq 1 ]
+}
+
+@test "first matching comment is chosen when multiple have the marker" {
+  export GH_MOCK_LIST_JSON='[
+    {"id": 100, "body": "<!-- e2e-status -->\nfirst",  "user": {"login": "github-actions[bot]"}},
+    {"id": 200, "body": "<!-- e2e-status -->\nsecond", "user": {"login": "github-actions[bot]"}}
+  ]'
+  export INPUT_BODY="x"
+
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv comment-id)" = "comment-id=100" ]
+}
+
+@test "malformed marker fails fast" {
+  export INPUT_MARKER="not-an-html-comment"
+  export INPUT_BODY="x"
+  run "$SCRIPT"
+  [ "$status" -ne 0 ]
+}
+
+@test "missing required env (INPUT_BODY) fails" {
+  unset INPUT_BODY
+  run "$SCRIPT"
+  [ "$status" -ne 0 ]
+}
+
+@test "missing required env (INPUT_PR_NUMBER) fails" {
+  unset INPUT_PR_NUMBER
+  export INPUT_BODY="x"
+  run "$SCRIPT"
+  [ "$status" -ne 0 ]
+}

--- a/.github/workflows/test-sticky-pr-comment.yaml
+++ b/.github/workflows/test-sticky-pr-comment.yaml
@@ -1,0 +1,83 @@
+name: Test sticky-pr-comment
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/test-sticky-pr-comment.yaml'
+      - '.github/actions/sticky-pr-comment/**'
+
+permissions:
+  contents: read
+
+jobs:
+  bats:
+    name: Run bats tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
+        with:
+          tests: .github/actions/sticky-pr-comment/test
+
+  composite-smoke:
+    name: Composite smoke (create + update)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Initial create
+        id: first
+        uses: ./.github/actions/sticky-pr-comment
+        with:
+          marker: '<!-- sticky-pr-comment-smoke -->'
+          body: |
+            ### sticky-pr-comment smoke
+
+            initial body — run ${{ github.run_id }} attempt 1
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify created
+        env:
+          ACTION_TAKEN: ${{ steps.first.outputs.action-taken }}
+          COMMENT_ID: ${{ steps.first.outputs.comment-id }}
+        run: |
+          echo "first action-taken=$ACTION_TAKEN comment-id=$COMMENT_ID"
+          [[ "$ACTION_TAKEN" == "created" ]]
+          [[ -n "$COMMENT_ID" && "$COMMENT_ID" != "0" ]]
+
+      - name: Re-invoke (should update)
+        id: second
+        uses: ./.github/actions/sticky-pr-comment
+        with:
+          marker: '<!-- sticky-pr-comment-smoke -->'
+          body: |
+            ### sticky-pr-comment smoke
+
+            updated body — run ${{ github.run_id }} attempt 2
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify updated and same id
+        env:
+          FIRST_ID: ${{ steps.first.outputs.comment-id }}
+          SECOND_ID: ${{ steps.second.outputs.comment-id }}
+          SECOND_ACTION: ${{ steps.second.outputs.action-taken }}
+        run: |
+          echo "second action-taken=$SECOND_ACTION comment-id=$SECOND_ID"
+          [[ "$SECOND_ACTION" == "updated" ]]
+          [[ "$FIRST_ID" == "$SECOND_ID" ]]
+
+      - name: Cleanup smoke comment
+        if: always() && steps.first.outputs.comment-id != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          COMMENT_ID: ${{ steps.first.outputs.comment-id }}
+        run: |
+          gh api -X DELETE "repos/${GH_REPO}/issues/comments/${COMMENT_ID}" || true

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-semver-validation test-linear-pr-commenter test-release-notification test-linear-release-sync test-cleanup-head-charts test-ci-test-notify test-auto-approve-bot-prs test-ai-pr-review test-ai-step test-publish-helm-chart test-govulncheck test-go-licenses test-run-ginkgo build-linear-release-sync lint install-auto-doc generate-docs check-docs help
+.PHONY: test test-semver-validation test-linear-pr-commenter test-release-notification test-linear-release-sync test-cleanup-head-charts test-ci-test-notify test-auto-approve-bot-prs test-ai-pr-review test-ai-step test-publish-helm-chart test-govulncheck test-go-licenses test-run-ginkgo test-sticky-pr-comment build-linear-release-sync lint install-auto-doc generate-docs check-docs help
 
 ACTIONS_DIR := .github/actions
 WORKFLOWS_DIR := .github/workflows
@@ -93,7 +93,7 @@ check-docs: generate-docs ## verify docs are up to date (fails if drift detected
 help: ## show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-30s %s\n", $$1, $$2}'
 
-test: test-semver-validation test-linear-pr-commenter test-release-notification test-linear-release-sync test-cleanup-head-charts test-auto-approve-bot-prs test-ai-pr-review test-ai-step test-ci-test-notify test-go-licenses test-publish-helm-chart test-govulncheck test-run-ginkgo ## run all action tests
+test: test-semver-validation test-linear-pr-commenter test-release-notification test-linear-release-sync test-cleanup-head-charts test-auto-approve-bot-prs test-ai-pr-review test-ai-step test-ci-test-notify test-go-licenses test-publish-helm-chart test-govulncheck test-run-ginkgo test-sticky-pr-comment ## run all action tests
 
 test-semver-validation: ## run semver-validation unit tests
 	cd $(ACTIONS_DIR)/semver-validation && npm ci --silent && NODE_OPTIONS=--experimental-vm-modules npx jest --ci --coverage --watchAll=false
@@ -133,6 +133,9 @@ test-go-licenses: ## run go-licenses bats tests
 
 test-run-ginkgo: ## run run-ginkgo bats tests
 	bats $(ACTIONS_DIR)/run-ginkgo/test/*.bats
+
+test-sticky-pr-comment: ## run sticky-pr-comment bats tests
+	bats $(ACTIONS_DIR)/sticky-pr-comment/test/*.bats
 
 build-linear-release-sync: ## build linear-release-sync binary (linux/amd64)
 	cd $(ACTIONS_DIR)/linear-release-sync/src && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-s -w" -o ../linear-release-sync-linux-amd64 .

--- a/README.md
+++ b/README.md
@@ -108,6 +108,61 @@ image setup (vind, Kind, bare Docker).
 
 - `failure-summary`: Markdown-formatted test results summary
 
+### Sticky PR Comment
+
+Upserts a sticky comment on a pull request, identified by a stable HTML
+marker. If a comment with the marker already exists it is updated in place,
+otherwise a new comment is created. Domain-agnostic — the caller composes
+the body. Useful for surfacing the last real run of a CI signal that the
+caller skips on some events (e.g. e2e tests skipped when PR description is
+unchanged), so reviewers always see the most recent meaningful result.
+
+**Location:** `.github/actions/sticky-pr-comment`
+
+**Usage:**
+
+```yaml
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Run tests
+        id: tests
+        run: ./run-tests.sh
+
+      - name: Upsert sticky status comment
+        if: always() && github.event_name == 'pull_request'
+        uses: loft-sh/github-actions/.github/actions/sticky-pr-comment@sticky-pr-comment/v1
+        with:
+          marker: '<!-- e2e-status -->'
+          body: |
+            ### E2E Tests
+            Status: ${{ steps.tests.outcome }}
+            Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+**Inputs:**
+
+- `marker` (required): HTML comment uniquely identifying this comment stream (form `<!-- some-id -->`)
+- `body` (required): markdown body (the marker is auto-prepended when missing)
+- `pr-number` (optional, default: current PR)
+- `repo` (optional, default: current repo)
+- `github-token` (required): token with `pull-requests: write`
+
+**Outputs:**
+
+- `comment-id`: numeric ID of the upserted comment
+- `action-taken`: `created` or `updated`
+
+The action is intended to be invoked from inside the job whose status it
+reports — when that job is skipped via `if:`, the upsert never runs and the
+previous comment stays in place, which is the desired "preserve last real
+result" behavior. See the action README for full details.
+
 ## Available Reusable Workflows
 
 ### Validate Renovate Config
@@ -431,6 +486,7 @@ the action's files change:
 - `test-semver-validation.yaml` - triggers on `.github/actions/semver-validation/**`
 - `test-linear-pr-commenter.yaml` - triggers on `.github/actions/linear-pr-commenter/**`
 - `test-linear-release-sync.yaml` - triggers on `.github/actions/linear-release-sync/**`
+- `test-sticky-pr-comment.yaml` - triggers on `.github/actions/sticky-pr-comment/**`
 - `release-linear-release-sync.yaml` - builds and publishes the binary on tag push or `workflow_dispatch`
 
 Each reusable workflow (`workflow_call`) also has a smoke/integration test


### PR DESCRIPTION
## Summary

- Adds the `sticky-pr-comment` composite action — domain-agnostic upsert of a PR comment identified by a stable HTML marker. Useful for surfacing the last real result of a CI signal that the caller skips on some events.
- Matches comments by **author + marker** so a third party can't squat on the sticky slot by pre-creating a comment that starts with the marker. `expected-author` defaults to `github-actions[bot]` and is overridable for PAT- or App-driven callers.
- Wires up a bats suite (stubbed `gh` on `PATH`), a smoke workflow that does a real create + update against the PR, and the standard Makefile / top-level README integrations.

## Test plan

- [ ] `make test-sticky-pr-comment` is green in CI (bats suite, 11 cases including squat-resistance + custom author)
- [ ] `make lint` is green (actionlint + zizmor)
- [ ] `make check-docs` is green
- [ ] The `composite-smoke` job in `test-sticky-pr-comment.yaml` runs against this PR, posts a sticky comment, updates it on the second invocation, and cleans it up