### PR TITLE
feat(run-ginkgo): upload Ginkgo JSON report to GCS after test run

### DIFF
--- a/.github/actions/run-ginkgo/README.md
+++ b/.github/actions/run-ginkgo/README.md
@@ -8,14 +8,18 @@ markdown summary generation.
 
 <!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
 
-|          INPUT          |  TYPE  | REQUIRED |   DEFAULT    |                                      DESCRIPTION                                       |
-|-------------------------|--------|----------|--------------|----------------------------------------------------------------------------------------|
-|     additional-args     | string |  false   |              |               Extra arguments passed to the test <br>binary (after --)                 |
-| additional-ginkgo-flags | string |  false   |              |     Extra ginkgo CLI flags (e.g. -v, --skip-package=linters, --show-node-events)       |
-|      ginkgo-label       | string |  false   |              | Ginkgo label filter expression. When set, <br>adds --label-filter and -r (recursive).  |
-|          procs          | string |  false   |    `"8"`     |                          Number of parallel Ginkgo processes                           |
-|        test-dir         | string |  false   | `"e2e-next"` |                            Directory containing test suites                            |
-|         timeout         | string |  false   |   `"60m"`    |                                  Ginkgo test timeout                                   |
+|          INPUT          |  TYPE  | REQUIRED |         DEFAULT         |                                                                 DESCRIPTION                                                                 |
+|-------------------------|--------|----------|-------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|
+|     additional-args     | string |  false   |                         |                                          Extra arguments passed to the test <br>binary (after --)                                           |
+| additional-ginkgo-flags | string |  false   |                         |                                Extra ginkgo CLI flags (e.g. -v, --skip-package=linters, --show-node-events)                                 |
+|      ginkgo-label       | string |  false   |                         |                           Ginkgo label filter expression. When set, <br>adds --label-filter and -r (recursive).                             |
+|      github-token       | string |  false   | `"${{ github.token }}"` |                               GitHub token for the gh CLI <br>to fetch job details during report <br>upload.                                |
+|          procs          | string |  false   |          `"8"`          |                                                     Number of parallel Ginkgo processes                                                     |
+|     reports-bucket      | string |  false   |                         |                                         GCS bucket name for uploading the <br>Ginkgo JSON report.                                           |
+|        test-dir         | string |  false   |      `"e2e-next"`       |                                                      Directory containing test suites                                                       |
+|         timeout         | string |  false   |         `"60m"`         |                                                             Ginkgo test timeout                                                             |
+|      upload-report      | string |  false   |        `"false"`        | Set to 'true' to upload the <br>Ginkgo JSON report to GCS after <br>the test run. Requires reports-bucket and <br>workflow-file to be set.  |
+|      workflow-file      | string |  false   |                         |                 Workflow file name (e.g. e2e-ginkgo.yaml) used as <br>the GCS path segment and report <br>metadata field.                   |
 
 <!-- AUTO-DOC-INPUT:END -->
 

--- a/.github/actions/run-ginkgo/action.yml
+++ b/.github/actions/run-ginkgo/action.yml
@@ -26,6 +26,22 @@ inputs:
     description: "Extra ginkgo CLI flags (e.g. -v, --skip-package=linters, --show-node-events)"
     required: false
     default: ""
+  reports-bucket:
+    description: "GCS bucket name for uploading the Ginkgo JSON report."
+    required: false
+    default: ""
+  workflow-file:
+    description: "Workflow file name (e.g. e2e-ginkgo.yaml) used as the GCS path segment and report metadata field."
+    required: false
+    default: ""
+  github-token:
+    description: "GitHub token for the gh CLI to fetch job details during report upload."
+    required: false
+    default: ${{ github.token }}
+  upload-report:
+    description: "Set to 'true' to upload the Ginkgo JSON report to GCS after the test run. Requires reports-bucket and workflow-file to be set."
+    required: false
+    default: "false"
 
 outputs:
   failure-summary:
@@ -59,3 +75,26 @@ runs:
       if: always()
       shell: bash
       run: ${{ github.action_path }}/src/generate-summary.sh
+
+    - name: Check GCP auth for report upload
+      id: gcp-auth-check
+      if: always() && inputs.upload-report == 'true'
+      continue-on-error: true
+      shell: bash
+      run: |
+        if gcloud auth list --filter=status:ACTIVE --format="value(account)" 2>/dev/null | grep -q .; then
+          echo "has-auth=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "::notice::No active GCP auth — skipping GCS report upload"
+          echo "has-auth=false" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Upload Ginkgo report to GCS
+      if: always() && inputs.upload-report == 'true' && steps.gcp-auth-check.outputs.has-auth == 'true'
+      continue-on-error: true
+      shell: bash
+      env:
+        REPORTS_BUCKET: ${{ inputs.reports-bucket }}
+        WORKFLOW_FILE: ${{ inputs.workflow-file }}
+        GH_TOKEN: ${{ inputs.github-token }}
+      run: ${{ github.action_path }}/src/upload-report.sh

--- a/.github/actions/run-ginkgo/src/upload-report.sh
+++ b/.github/actions/run-ginkgo/src/upload-report.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Required env vars: REPORTS_BUCKET, WORKFLOW_FILE
+# Required tools:    gh (with GH_TOKEN), gcloud (authenticated), jq
+# GitHub-provided:   GITHUB_REPOSITORY, GITHUB_RUN_ID, GITHUB_RUN_ATTEMPT,
+#                    RUNNER_NAME, GITHUB_HEAD_REF, GITHUB_REF_NAME,
+#                    GITHUB_SERVER_URL, GITHUB_WORKFLOW, GITHUB_JOB
+set -euo pipefail
+
+# Validate required env vars
+: "${REPORTS_BUCKET:?REPORTS_BUCKET must be set}"
+: "${WORKFLOW_FILE:?WORKFLOW_FILE must be set}"
+
+# Validate required binaries
+for bin in gh gcloud jq; do
+  if ! command -v "$bin" &>/dev/null; then
+    echo "::error::Required binary '$bin' not found in PATH — skipping GCS report upload"
+    exit 1
+  fi
+done
+
+if [ ! -f test-reports/report.json ]; then
+  echo "::error::No Ginkgo report at test-reports/report.json — skipping GCS report upload"
+  exit 0
+fi
+
+JOB_JSON=$(gh api \
+  "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/attempts/${GITHUB_RUN_ATTEMPT}/jobs" \
+  --paginate \
+  --jq ".jobs[] | select(.runner_name == \"${RUNNER_NAME}\")")
+
+JOB_ID=$(echo "$JOB_JSON" | jq -r '.id')
+STARTED_AT=$(echo "$JOB_JSON" | jq -r '.started_at')
+
+if [ -z "$JOB_ID" ] || [ "$JOB_ID" = "null" ]; then
+  echo "::error::Could not resolve numeric job_id for runner ${RUNNER_NAME} - skipping GCS report upload"
+  exit 1
+fi
+
+FINISHED_AT=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
+RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/attempts/${GITHUB_RUN_ATTEMPT}"
+DEST="gs://${REPORTS_BUCKET}/${GITHUB_REPOSITORY}/${WORKFLOW_FILE}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${JOB_ID}.json"
+
+gcloud storage cp test-reports/report.json "$DEST" \
+  --custom-metadata="run_url=${RUN_URL},repository=${GITHUB_REPOSITORY},branch=${BRANCH},workflow_file=${WORKFLOW_FILE},workflow_name=${GITHUB_WORKFLOW},job_id=${JOB_ID},job_name=${GITHUB_JOB},run_attempt=${GITHUB_RUN_ATTEMPT},started_at=${STARTED_AT},finished_at=${FINISHED_AT}"

--- a/.github/actions/run-ginkgo/test/upload-report.bats
+++ b/.github/actions/run-ginkgo/test/upload-report.bats
@@ -1,0 +1,200 @@
+#!/usr/bin/env bats
+# Tests for upload-report.sh
+
+SCRIPT="$BATS_TEST_DIRNAME/../src/upload-report.sh"
+
+setup() {
+  MOCK_DIR=$(mktemp -d)
+  MOCK_BIN="$MOCK_DIR/bin"
+  mkdir -p "$MOCK_BIN"
+
+  # Workspace root with a real report
+  WORK_DIR="$MOCK_DIR/workspace"
+  mkdir -p "$WORK_DIR/test-reports"
+  echo '{"test":"data"}' > "$WORK_DIR/test-reports/report.json"
+
+  # Common GitHub env vars
+  export GITHUB_REPOSITORY="loft-sh/loft-enterprise"
+  export GITHUB_RUN_ID="42"
+  export GITHUB_RUN_ATTEMPT="1"
+  export RUNNER_NAME="runner-1"
+  export GITHUB_REF_NAME="main"
+  export GITHUB_HEAD_REF=""
+  export GITHUB_SERVER_URL="https://github.com"
+  export GITHUB_WORKFLOW="E2E Ginkgo Tests"
+  export GITHUB_JOB="e2e-tests"
+
+  # Script inputs
+  export REPORTS_BUCKET="my-reports-bucket"
+  export WORKFLOW_FILE="e2e-ginkgo.yaml"
+
+  # Mock gh: returns a valid job JSON
+  cat > "$MOCK_BIN/gh" <<'MOCK'
+#!/usr/bin/env bash
+printf '{"id":99,"started_at":"2024-01-01T00:00:00Z"}'
+MOCK
+  chmod +x "$MOCK_BIN/gh"
+
+  # Mock gcloud: records arguments
+  export MOCK_GCLOUD_ARGS="$MOCK_DIR/gcloud-args"
+  cat > "$MOCK_BIN/gcloud" <<MOCK
+#!/usr/bin/env bash
+printf '%s\n' "\$@" > "$MOCK_DIR/gcloud-args"
+MOCK
+  chmod +x "$MOCK_BIN/gcloud"
+
+  # Mock date: deterministic timestamp
+  cat > "$MOCK_BIN/date" <<'MOCK'
+#!/usr/bin/env bash
+echo "2024-01-01T12:00:00Z"
+MOCK
+  chmod +x "$MOCK_BIN/date"
+
+  # Mock jq: thin wrapper around the real jq
+  # (real jq is expected to be on PATH; mock bin prepended so mocks take priority)
+
+  export PATH="$MOCK_BIN:$PATH"
+}
+
+teardown() {
+  rm -rf "$MOCK_DIR"
+}
+
+# --- upload-report flag: required inputs ---
+# The upload-report input gates whether action steps run (action.yml).
+# When they do run, REPORTS_BUCKET and WORKFLOW_FILE must be provided.
+# These tests document what happens when a caller sets upload-report=true
+# but omits one of the required inputs.
+
+@test "exits non-zero when REPORTS_BUCKET is unset (upload-report=true but bucket not set)" {
+  unset REPORTS_BUCKET
+  cd "$MOCK_DIR/workspace"
+  run bash "$SCRIPT"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"REPORTS_BUCKET"* ]]
+}
+
+@test "exits non-zero when WORKFLOW_FILE is unset (upload-report=true but workflow-file not set)" {
+  unset WORKFLOW_FILE
+  cd "$MOCK_DIR/workspace"
+  run bash "$SCRIPT"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"WORKFLOW_FILE"* ]]
+}
+
+# --- Binary validation ---
+
+@test "exits 1 with error when gh is not in PATH" {
+  rm "$MOCK_BIN/gh"
+  # Use a bare PATH (mock bin + bash only) so the system gh is not reachable
+  local bare_bin
+  bare_bin=$(mktemp -d)
+  ln -s "$(command -v bash)" "$bare_bin/bash"
+  cd "$MOCK_DIR/workspace"
+  PATH="$MOCK_BIN:$bare_bin" run bash "$SCRIPT"
+  rm -rf "$bare_bin"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"::error::"* ]]
+  [[ "$output" == *"'gh' not found"* ]]
+}
+
+@test "exits 1 with error when gcloud is not in PATH" {
+  rm "$MOCK_BIN/gcloud"
+  local bare_bin
+  bare_bin=$(mktemp -d)
+  ln -s "$(command -v bash)" "$bare_bin/bash"
+  cd "$MOCK_DIR/workspace"
+  PATH="$MOCK_BIN:$bare_bin" run bash "$SCRIPT"
+  rm -rf "$bare_bin"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"::error::"* ]]
+  [[ "$output" == *"'gcloud' not found"* ]]
+}
+
+# --- Missing report ---
+
+@test "exits 0 with error when report.json is absent" {
+  cd "$MOCK_DIR/workspace"
+  rm test-reports/report.json
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"::error::"* ]]
+  [[ "$output" == *"skipping GCS report upload"* ]]
+}
+
+# --- Bad job ID ---
+
+@test "exits 1 with error when gh api returns null job id" {
+  cat > "$MOCK_BIN/gh" <<'MOCK'
+#!/usr/bin/env bash
+printf '{"id":null,"started_at":"2024-01-01T00:00:00Z"}'
+MOCK
+  chmod +x "$MOCK_BIN/gh"
+
+  cd "$MOCK_DIR/workspace"
+  run bash "$SCRIPT"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"::error::"* ]]
+  [[ "$output" == *"Could not resolve numeric job_id"* ]]
+}
+
+@test "exits 1 with error when gh api returns empty job id" {
+  cat > "$MOCK_BIN/gh" <<'MOCK'
+#!/usr/bin/env bash
+printf '{"id":"","started_at":"2024-01-01T00:00:00Z"}'
+MOCK
+  chmod +x "$MOCK_BIN/gh"
+
+  cd "$MOCK_DIR/workspace"
+  run bash "$SCRIPT"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"::error::"* ]]
+}
+
+# --- Happy path ---
+
+@test "calls gcloud storage cp with correct destination" {
+  cd "$MOCK_DIR/workspace"
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  EXPECTED_DEST="gs://my-reports-bucket/loft-sh/loft-enterprise/e2e-ginkgo.yaml/42/1/99.json"
+  grep -qF "$EXPECTED_DEST" "$MOCK_DIR/gcloud-args"
+}
+
+@test "calls gcloud storage cp with correct source file" {
+  cd "$MOCK_DIR/workspace"
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  grep -qF "test-reports/report.json" "$MOCK_DIR/gcloud-args"
+}
+
+@test "metadata includes run_url" {
+  cd "$MOCK_DIR/workspace"
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  grep -qF "run_url=https://github.com/loft-sh/loft-enterprise/actions/runs/42/attempts/1" "$MOCK_DIR/gcloud-args"
+}
+
+@test "metadata uses GITHUB_HEAD_REF as branch when set" {
+  export GITHUB_HEAD_REF="feature/my-branch"
+  cd "$MOCK_DIR/workspace"
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  grep -qF "branch=feature/my-branch" "$MOCK_DIR/gcloud-args"
+}
+
+@test "metadata falls back to GITHUB_REF_NAME when GITHUB_HEAD_REF is empty" {
+  export GITHUB_HEAD_REF=""
+  export GITHUB_REF_NAME="main"
+  cd "$MOCK_DIR/workspace"
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  grep -qF "branch=main" "$MOCK_DIR/gcloud-args"
+}
+
+@test "metadata includes workflow_file" {
+  cd "$MOCK_DIR/workspace"
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  grep -qF "workflow_file=e2e-ginkgo.yaml" "$MOCK_DIR/gcloud-args"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__/
 !CLAUDE.md
 # but don't commit per-user permission overrides
 .claude/settings.local.json
+/.idea/


### PR DESCRIPTION
## Summary

- Adds two optional inputs to `run-ginkgo`: `reports-bucket` and `workflow-file`
- When `reports-bucket` is set, a GCP auth guard step runs first — if no active auth is found it emits a notice and skips gracefully
- The upload step calls `gcloud storage cp` with rich metadata (run URL, branch, job ID, timestamps) matching the GCS path structure `gs://<bucket>/<repo>/<workflow-file>/<run-id>/<attempt>/<job-id>.json`
- Extracts the duplicated "Upload Ginkgo report to GCS" script blocks from `loft-enterprise`'s `e2e-ginkgo.yaml` and `e2e-ginkgo-nightly.yaml` into a testable `src/upload-report.sh`

## Test plan

- [x] 9 new BATS tests in `test/upload-report.bats` covering: missing report, null job ID, empty job ID, correct GCS destination, correct source file, run_url metadata, branch fallback (`GITHUB_HEAD_REF` → `GITHUB_REF_NAME`), workflow_file metadata
- [x] All 45 tests pass (`npx bats .github/actions/run-ginkgo/test/*.bats`)
- [x] `make generate-docs` regenerated README with the two new inputs
- [ ] Follow-up PR in `loft-enterprise` to wire `reports-bucket` / `workflow-file` into both workflow invocations and remove the now-redundant steps