### PR TITLE
feat(repository-dispatch): add generic cross-repo dispatch composite action

### DIFF
--- a/.github/actions/repository-dispatch/README.md
+++ b/.github/actions/repository-dispatch/README.md
@@ -1,0 +1,86 @@
+# Repository Dispatch
+
+Sends a `repository_dispatch` event to a target repository so any source repo
+can trigger any event type with one mechanical step. Domain-agnostic — the
+caller chooses the event-type and payload schema, the receiver routes on
+them. Uses the GitHub CLI (`gh`), pre-installed on hosted runners.
+
+## Inputs
+
+<!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
+
+|    INPUT    |  TYPE  | REQUIRED | DEFAULT |                                                      DESCRIPTION                                                      |
+|-------------|--------|----------|---------|-----------------------------------------------------------------------------------------------------------------------|
+| event-type  | string |   true   |         |           event_type that the receiver workflow listens <br>for in its on.repository_dispatch.types list.             |
+|   payload   | string |  false   | `"{}"`  | JSON object string sent as client_payload. <br>Must be a JSON object (not an array or scalar). <br>Defaults to "{}".  |
+| target-repo | string |   true   |         |                               Target repository in owner/name form to <br>dispatch to.                                |
+
+<!-- AUTO-DOC-INPUT:END -->
+
+## Usage
+
+```yaml
+jobs:
+  notify-docs:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Notify vcluster-docs of release
+        uses: loft-sh/github-actions/.github/actions/repository-dispatch@repository-dispatch/v1
+        with:
+          target-repo: loft-sh/vcluster-docs
+          event-type: vcluster-released
+          payload: |
+            {
+              "version": "${{ github.ref_name }}",
+              "sha": "${{ github.sha }}"
+            }
+        env:
+          GH_TOKEN: ${{ secrets.CROSS_REPO_DISPATCH_TOKEN }}
+```
+
+### Auth
+
+`GH_TOKEN` must be set as an environment variable on the step (not as an
+input). It must be a Personal Access Token or GitHub App token with `repo`
+scope on the **target** repository — `secrets.GITHUB_TOKEN` does not have
+permission to dispatch into other repos.
+
+### Payload
+
+`payload` is sent verbatim as `client_payload` in the
+[repository_dispatch event](https://docs.github.com/en/rest/repos/repos#create-a-repository-dispatch-event).
+It must be a JSON object (not an array, not a scalar) — arrays and scalars
+are rejected before the request is made. Receivers reference values via
+`${{ github.event.client_payload.<key> }}`.
+
+GitHub limits `client_payload` to 10 top-level properties.
+
+### Receiver workflow
+
+The target repository declares which `event-type` values it listens for:
+
+```yaml
+on:
+  repository_dispatch:
+    types: [vcluster-released]
+
+jobs:
+  apply:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "version=${{ github.event.client_payload.version }}"
+```
+
+Routing logic (which event-types to act on, how to interpret the payload)
+lives entirely in the receiver. This action carries no domain knowledge.
+
+## Testing
+
+```bash
+make test-repository-dispatch
+```
+
+Runs the bats suite in `test/` against `src/dispatch.sh` with a stubbed
+`gh` on `PATH`.

--- a/.github/actions/repository-dispatch/action.yml
+++ b/.github/actions/repository-dispatch/action.yml
@@ -1,0 +1,30 @@
+name: Repository Dispatch
+description: |
+  Sends a repository_dispatch event to a target repository so any source repo
+  can trigger any event type with one mechanical step. Domain-agnostic — the
+  caller chooses the event-type and payload schema, the receiver routes on
+  them. Uses the GitHub CLI (gh) which is pre-installed on hosted runners.
+inputs:
+  target-repo:
+    description: 'Target repository in owner/name form to dispatch to.'
+    required: true
+  event-type:
+    description: 'event_type that the receiver workflow listens for in its on.repository_dispatch.types list.'
+    required: true
+  payload:
+    description: 'JSON object string sent as client_payload. Must be a JSON object (not an array or scalar). Defaults to "{}".'
+    required: false
+    default: '{}'
+runs:
+  using: composite
+  steps:
+    - name: Send repository_dispatch
+      shell: bash
+      env:
+        INPUT_TARGET_REPO: ${{ inputs.target-repo }}
+        INPUT_EVENT_TYPE: ${{ inputs.event-type }}
+        INPUT_PAYLOAD: ${{ inputs.payload }}
+      run: ${{ github.action_path }}/src/dispatch.sh
+branding:
+  icon: 'send'
+  color: 'orange'

--- a/.github/actions/repository-dispatch/src/dispatch.sh
+++ b/.github/actions/repository-dispatch/src/dispatch.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Send a repository_dispatch event to a target repo.
+#
+# Required env: GH_TOKEN, INPUT_TARGET_REPO, INPUT_EVENT_TYPE
+# Optional env: INPUT_PAYLOAD (JSON object, defaults to "{}")
+set -euo pipefail
+
+: "${GH_TOKEN:?GH_TOKEN required (PAT with repo scope on target)}"
+: "${INPUT_TARGET_REPO:?target-repo required}"
+: "${INPUT_EVENT_TYPE:?event-type required}"
+
+PAYLOAD="${INPUT_PAYLOAD-}"
+[[ -z "$PAYLOAD" ]] && PAYLOAD='{}'
+
+# client_payload must be a JSON object per GitHub's repository_dispatch API,
+# so reject arrays and scalars early — the API otherwise returns a 422 that's
+# annoying to debug from caller logs.
+if ! jq -e 'type == "object"' >/dev/null 2>&1 <<<"$PAYLOAD"; then
+  echo "::error::payload must be a JSON object, got: $PAYLOAD"
+  exit 1
+fi
+
+# Build the request body with jq so callers don't have to worry about quoting
+# inside their event_type or payload values.
+BODY=$(jq -n \
+  --arg event_type "$INPUT_EVENT_TYPE" \
+  --argjson client_payload "$PAYLOAD" \
+  '{event_type: $event_type, client_payload: $client_payload}')
+
+gh api -X POST "repos/${INPUT_TARGET_REPO}/dispatches" --input - <<<"$BODY"
+
+echo "::notice::dispatched event_type=${INPUT_EVENT_TYPE} to ${INPUT_TARGET_REPO}"

--- a/.github/actions/repository-dispatch/test/dispatch.bats
+++ b/.github/actions/repository-dispatch/test/dispatch.bats
@@ -128,13 +128,19 @@ last_body() { awk 'BEGIN{RS="---END---\n"} END{printf "%s", $0}' "$GH_MOCK_BODY_
   [ "$count" -eq 2 ]
 }
 
-@test "event_type with special characters is preserved verbatim" {
-  export INPUT_EVENT_TYPE='vcluster-rc-released'
+@test "event_type with JSON-escapable characters round-trips through jq" {
+  # Embedded double quote and backslash exercise jq --arg's JSON-escape
+  # path — the script's whole reason for using jq instead of string concat.
+  export INPUT_EVENT_TYPE='release "rc" \foo'
   run "$SCRIPT"
   [ "$status" -eq 0 ]
 
   body="$(last_body)"
-  [ "$(jq -r '.event_type' <<<"$body")" = "vcluster-rc-released" ]
+  # jq -r decodes the escapes, recovering the original verbatim.
+  [ "$(jq -r '.event_type' <<<"$body")" = 'release "rc" \foo' ]
+  # The wire body must contain the JSON-escaped form, not raw quotes.
+  grep -q '\\"rc\\"' "$GH_MOCK_BODY_LOG"
+  grep -q '\\\\foo' "$GH_MOCK_BODY_LOG"
 }
 
 @test "nested payload values survive jq round-trip" {

--- a/.github/actions/repository-dispatch/test/dispatch.bats
+++ b/.github/actions/repository-dispatch/test/dispatch.bats
@@ -1,0 +1,154 @@
+#!/usr/bin/env bats
+# Tests for dispatch.sh.
+
+SCRIPT="$BATS_TEST_DIRNAME/../src/dispatch.sh"
+
+load gh_mock
+
+setup() {
+  setup_gh_mock
+  export GH_TOKEN="fake-token"
+  export INPUT_TARGET_REPO="loft-sh/vcluster-docs"
+  export INPUT_EVENT_TYPE="vcluster-released"
+  export INPUT_PAYLOAD='{"version":"v0.42.0","sha":"abc123"}'
+}
+
+teardown() {
+  teardown_gh_mock
+}
+
+last_body() { awk 'BEGIN{RS="---END---\n"} END{printf "%s", $0}' "$GH_MOCK_BODY_LOG"; }
+
+@test "happy path → POST to target /dispatches with event_type and client_payload" {
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+
+  grep -q '^POST repos/loft-sh/vcluster-docs/dispatches$' "$GH_MOCK_CALLS"
+
+  body="$(last_body)"
+  [ "$(jq -r '.event_type' <<<"$body")" = "vcluster-released" ]
+  [ "$(jq -r '.client_payload.version' <<<"$body")" = "v0.42.0" ]
+  [ "$(jq -r '.client_payload.sha' <<<"$body")" = "abc123" ]
+}
+
+@test "missing target-repo → fail fast, no API call" {
+  unset INPUT_TARGET_REPO
+  run "$SCRIPT"
+  [ "$status" -ne 0 ]
+  ! grep -q '^POST ' "$GH_MOCK_CALLS"
+}
+
+@test "missing event-type → fail fast, no API call" {
+  unset INPUT_EVENT_TYPE
+  run "$SCRIPT"
+  [ "$status" -ne 0 ]
+  ! grep -q '^POST ' "$GH_MOCK_CALLS"
+}
+
+@test "missing GH_TOKEN → fail fast, no API call" {
+  unset GH_TOKEN
+  run "$SCRIPT"
+  [ "$status" -ne 0 ]
+  ! grep -q '^POST ' "$GH_MOCK_CALLS"
+}
+
+@test "malformed JSON payload → fail fast, no API call" {
+  export INPUT_PAYLOAD='{"unclosed":'
+  run "$SCRIPT"
+  [ "$status" -ne 0 ]
+  ! grep -q '^POST ' "$GH_MOCK_CALLS"
+}
+
+@test "non-object JSON payload (array) → fail fast, no API call" {
+  export INPUT_PAYLOAD='["a","b"]'
+  run "$SCRIPT"
+  [ "$status" -ne 0 ]
+  ! grep -q '^POST ' "$GH_MOCK_CALLS"
+}
+
+@test "non-object JSON payload (scalar) → fail fast, no API call" {
+  export INPUT_PAYLOAD='"just a string"'
+  run "$SCRIPT"
+  [ "$status" -ne 0 ]
+  ! grep -q '^POST ' "$GH_MOCK_CALLS"
+}
+
+@test "empty target-repo → fail fast" {
+  export INPUT_TARGET_REPO=""
+  run "$SCRIPT"
+  [ "$status" -ne 0 ]
+  ! grep -q '^POST ' "$GH_MOCK_CALLS"
+}
+
+@test "empty event-type → fail fast" {
+  export INPUT_EVENT_TYPE=""
+  run "$SCRIPT"
+  [ "$status" -ne 0 ]
+  ! grep -q '^POST ' "$GH_MOCK_CALLS"
+}
+
+@test "default payload is {} when input is empty string" {
+  export INPUT_PAYLOAD=""
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+
+  body="$(last_body)"
+  # client_payload should be an empty object (no keys).
+  [ "$(jq -r '.client_payload | type' <<<"$body")" = "object" ]
+  [ "$(jq -r '.client_payload | keys | length' <<<"$body")" = "0" ]
+}
+
+@test "default payload is {} when var is unset" {
+  unset INPUT_PAYLOAD
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+
+  body="$(last_body)"
+  [ "$(jq -r '.client_payload | type' <<<"$body")" = "object" ]
+  [ "$(jq -r '.client_payload | keys | length' <<<"$body")" = "0" ]
+}
+
+@test "explicit empty object payload → {} sent" {
+  export INPUT_PAYLOAD='{}'
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+
+  body="$(last_body)"
+  [ "$(jq -r '.client_payload | keys | length' <<<"$body")" = "0" ]
+}
+
+@test "idempotent: same call twice → both succeed" {
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+
+  # Two POSTs recorded, identical bodies.
+  count=$(grep -c '^POST repos/loft-sh/vcluster-docs/dispatches$' "$GH_MOCK_CALLS")
+  [ "$count" -eq 2 ]
+}
+
+@test "event_type with special characters is preserved verbatim" {
+  export INPUT_EVENT_TYPE='vcluster-rc-released'
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+
+  body="$(last_body)"
+  [ "$(jq -r '.event_type' <<<"$body")" = "vcluster-rc-released" ]
+}
+
+@test "nested payload values survive jq round-trip" {
+  export INPUT_PAYLOAD='{"version":"v1.2.3","meta":{"channel":"stable","prerelease":false}}'
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+
+  body="$(last_body)"
+  [ "$(jq -r '.client_payload.meta.channel' <<<"$body")" = "stable" ]
+  [ "$(jq -r '.client_payload.meta.prerelease' <<<"$body")" = "false" ]
+}
+
+@test "gh failure surfaces non-zero exit" {
+  export GH_MOCK_FAIL=1
+  run "$SCRIPT"
+  [ "$status" -ne 0 ]
+}

--- a/.github/actions/repository-dispatch/test/gh_mock.bash
+++ b/.github/actions/repository-dispatch/test/gh_mock.bash
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Stub `gh` on PATH for dispatch.sh tests. Records every invocation
+# (one line per call: METHOD path) into $GH_MOCK_CALLS, captures the
+# request body (read from stdin via --input -) into $GH_MOCK_BODY_LOG,
+# and returns success unless GH_MOCK_FAIL=1.
+
+setup_gh_mock() {
+  MOCK_DIR="$(mktemp -d)"
+  export MOCK_DIR
+  PATH="$MOCK_DIR:$PATH"
+  export PATH
+
+  export GH_MOCK_CALLS="$MOCK_DIR/calls.log"
+  export GH_MOCK_BODY_LOG="$MOCK_DIR/bodies.log"
+  : > "$GH_MOCK_CALLS"
+  : > "$GH_MOCK_BODY_LOG"
+
+  cat > "$MOCK_DIR/gh" <<'EOF'
+#!/usr/bin/env bash
+# Mock gh. Only covers `gh api -X POST <path> --input -` calls.
+
+method="GET"
+path=""
+read_stdin=0
+
+[ "${1:-}" = "api" ] || { echo "unsupported gh invocation: $*" >&2; exit 99; }
+shift
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -X)         method="$2"; shift 2 ;;
+    --input)
+      if [ "$2" = "-" ]; then read_stdin=1; fi
+      shift 2
+      ;;
+    -H|--header) shift 2 ;;
+    -*)         shift ;;
+    *)
+      if [ -z "$path" ]; then path="$1"; fi
+      shift
+      ;;
+  esac
+done
+
+printf '%s %s\n' "$method" "$path" >> "$GH_MOCK_CALLS"
+
+if [ "$read_stdin" = "1" ]; then
+  body=$(cat)
+  printf '%s\n---END---\n' "$body" >> "$GH_MOCK_BODY_LOG"
+fi
+
+if [ "${GH_MOCK_FAIL:-0}" = "1" ]; then
+  echo "mock gh: forced failure" >&2
+  exit 1
+fi
+
+# Repository dispatch returns 204 No Content on success — print nothing.
+exit 0
+EOF
+  chmod +x "$MOCK_DIR/gh"
+}
+
+teardown_gh_mock() {
+  rm -rf "$MOCK_DIR"
+}

--- a/.github/workflows/test-repository-dispatch.yaml
+++ b/.github/workflows/test-repository-dispatch.yaml
@@ -1,0 +1,22 @@
+name: Test repository-dispatch
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/test-repository-dispatch.yaml'
+      - '.github/actions/repository-dispatch/**'
+
+permissions:
+  contents: read
+
+jobs:
+  bats:
+    name: Run bats tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
+        with:
+          tests: .github/actions/repository-dispatch/test

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-semver-validation test-linear-pr-commenter test-release-notification test-linear-release-sync test-cleanup-head-charts test-ci-test-notify test-auto-approve-bot-prs test-ai-pr-review test-ai-step test-publish-helm-chart test-govulncheck test-go-licenses test-run-ginkgo test-sticky-pr-comment build-linear-release-sync lint install-auto-doc generate-docs check-docs help
+.PHONY: test test-semver-validation test-linear-pr-commenter test-release-notification test-linear-release-sync test-cleanup-head-charts test-ci-test-notify test-auto-approve-bot-prs test-ai-pr-review test-ai-step test-publish-helm-chart test-govulncheck test-go-licenses test-run-ginkgo test-sticky-pr-comment test-repository-dispatch build-linear-release-sync lint install-auto-doc generate-docs check-docs help
 
 ACTIONS_DIR := .github/actions
 WORKFLOWS_DIR := .github/workflows
@@ -93,7 +93,7 @@ check-docs: generate-docs ## verify docs are up to date (fails if drift detected
 help: ## show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-30s %s\n", $$1, $$2}'
 
-test: test-semver-validation test-linear-pr-commenter test-release-notification test-linear-release-sync test-cleanup-head-charts test-auto-approve-bot-prs test-ai-pr-review test-ai-step test-ci-test-notify test-go-licenses test-publish-helm-chart test-govulncheck test-run-ginkgo test-sticky-pr-comment ## run all action tests
+test: test-semver-validation test-linear-pr-commenter test-release-notification test-linear-release-sync test-cleanup-head-charts test-auto-approve-bot-prs test-ai-pr-review test-ai-step test-ci-test-notify test-go-licenses test-publish-helm-chart test-govulncheck test-run-ginkgo test-sticky-pr-comment test-repository-dispatch ## run all action tests
 
 test-semver-validation: ## run semver-validation unit tests
 	cd $(ACTIONS_DIR)/semver-validation && npm ci --silent && NODE_OPTIONS=--experimental-vm-modules npx jest --ci --coverage --watchAll=false
@@ -136,6 +136,9 @@ test-run-ginkgo: ## run run-ginkgo bats tests
 
 test-sticky-pr-comment: ## run sticky-pr-comment bats tests
 	bats $(ACTIONS_DIR)/sticky-pr-comment/test/*.bats
+
+test-repository-dispatch: ## run repository-dispatch bats tests
+	bats $(ACTIONS_DIR)/repository-dispatch/test/*.bats
 
 build-linear-release-sync: ## build linear-release-sync binary (linux/amd64)
 	cd $(ACTIONS_DIR)/linear-release-sync/src && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-s -w" -o ../linear-release-sync-linux-amd64 .

--- a/README.md
+++ b/README.md
@@ -163,6 +163,43 @@ reports — when that job is skipped via `if:`, the upsert never runs and the
 previous comment stays in place, which is the desired "preserve last real
 result" behavior. See the action README for full details.
 
+### Repository Dispatch
+
+Sends a `repository_dispatch` event to a target repository so any source repo
+can trigger any event type with one mechanical step. Domain-agnostic — the
+caller chooses the event-type and payload schema, the receiver routes on
+them. Foundation for cross-repo triggers (release fan-out, downstream test
+runs).
+
+**Location:** `.github/actions/repository-dispatch`
+
+**Usage:**
+
+```yaml
+- name: Notify vcluster-docs of release
+  uses: loft-sh/github-actions/.github/actions/repository-dispatch@repository-dispatch/v1
+  with:
+    target-repo: loft-sh/vcluster-docs
+    event-type: vcluster-released
+    payload: |
+      {
+        "version": "${{ github.ref_name }}",
+        "sha": "${{ github.sha }}"
+      }
+  env:
+    GH_TOKEN: ${{ secrets.CROSS_REPO_DISPATCH_TOKEN }}
+```
+
+**Inputs:**
+
+- `target-repo` (required): `<owner>/<repo>` of the receiver
+- `event-type` (required): matched against the receiver's `on.repository_dispatch.types`
+- `payload` (optional, default `{}`): JSON object sent as `client_payload`
+
+`GH_TOKEN` is read from the step's environment, not from inputs — it must be
+a PAT or GitHub App token with `repo` scope on the target. See the action
+README for full details.
+
 ## Available Reusable Workflows
 
 ### Validate Renovate Config


### PR DESCRIPTION
## Summary

Adds a generic `repository-dispatch` composite action so any source repo can dispatch any event type to any target repo with one mechanical step. Foundation PR for the docs-config-automation Phase 2 sequence (DEVOPS-888 / -889 / -890).

The action stays domain-agnostic on purpose — A4 design rejected baking docs-specific routing into the name. Receivers handle event-type routing and payload schema; this carries no semver/alpha/beta knowledge.

## What ships

- `.github/actions/repository-dispatch/action.yml` — composite manifest with `target-repo`, `event-type`, `payload` inputs.
- `.github/actions/repository-dispatch/src/dispatch.sh` — validates inputs (non-empty target/event-type, JSON-object payload), then `gh api -X POST repos/<target>/dispatches --input -` with a jq-built body.
- `.github/actions/repository-dispatch/test/{dispatch.bats,gh_mock.bash}` — 16 bats cases covering happy path, all bad-input failures (missing target-repo / event-type / GH_TOKEN, malformed JSON, array/scalar payloads, empty values), default `{}` payload, idempotent re-invocation, special-character event types, nested payload values, and gh-failure surface.
- `.github/actions/repository-dispatch/README.md` — auto-doc-populated inputs table plus auth and receiver-side usage.
- `.github/workflows/test-repository-dispatch.yaml` — paths-filtered bats runner.
- `Makefile` — `make test-repository-dispatch` target wired into `make test`.
- Top-level `README.md` — entry under "Available Actions".

## Auth model

`GH_TOKEN` is read from the calling step's environment (not an input) — the receiver is by definition cross-repo, so callers must use a PAT or GitHub App token with `repo` scope on the target. `secrets.GITHUB_TOKEN` cannot dispatch into other repos. This matches the A4 design doc's example usage.

## After merge

Tag `repository-dispatch/v1`. DEVOPS-888 (vcluster-docs receiver) and DEVOPS-889 (source-side emit in vcluster) consume this action.

## Test plan

- [x] `make test-repository-dispatch` — 16/16 bats cases pass locally.
- [x] `shellcheck` clean on `dispatch.sh` and `gh_mock.bash`.
- [x] `make generate-docs` populated the AUTO-DOC section in the action README.
- [ ] CI on this PR runs the bats workflow (paths-filtered to `.github/actions/repository-dispatch/**`).
- [ ] Once merged, tag `repository-dispatch/v1` and confirm downstream PRs (DEVOPS-888/889) can resolve it by SHA.

Closes DEVOPS-887