### PR TITLE
fix(linear-release-sync): pick previous tag by semver, not creation date

### DIFF
--- a/.github/actions/linear-release-sync/src/changelog/releases/releases.go
+++ b/.github/actions/linear-release-sync/src/changelog/releases/releases.go
@@ -42,6 +42,16 @@ func LastStableReleaseBeforeTag(ctx context.Context, client *githubv4.Client, ow
 	return LatestStableSemverRange(ctx, client, owner, repo, "< "+tagSemver.String())
 }
 
+// LatestStableSemverRange returns the highest-semver stable release whose tag
+// satisfies tagRangeExpr. Releases are paginated via the GitHub API ordered by
+// CREATED_AT (the only meaningful ordering the API supports), but the winner
+// is picked by semver comparison across all matches, not by creation date.
+//
+// Ordering by creation date is wrong for repositories that maintain multiple
+// stable release lines in parallel: a patch on an older minor (e.g. v4.6.3)
+// can be cut moments before a patch on a newer minor (e.g. v4.8.2), and a
+// creation-date-first match would return v4.6.3 as the predecessor of v4.8.2
+// rather than v4.8.1. See DEVOPS-874.
 func LatestStableSemverRange(ctx context.Context, client *githubv4.Client, owner, repo, tagRangeExpr string) (string, error) {
 	tagRange, err := semver.NewConstraint(tagRangeExpr)
 	if err != nil {
@@ -64,9 +74,12 @@ func LatestStableSemverRange(ctx context.Context, client *githubv4.Client, owner
 		} `graphql:"repository(owner: $owner, name: $repo)"`
 	}
 
-	var cursor *githubv4.String
+	var (
+		cursor  *githubv4.String
+		best    *semver.Version
+		bestTag string
+	)
 
-	// Paginate through the Releases
 	for {
 		if err := client.Query(ctx, &query, map[string]interface{}{
 			"owner":    githubv4.String(owner),
@@ -93,8 +106,13 @@ func LatestStableSemverRange(ctx context.Context, client *githubv4.Client, owner
 				continue
 			}
 
-			if tagRange.Check(releaseSemver) {
-				return release.TagName, nil
+			if !tagRange.Check(releaseSemver) {
+				continue
+			}
+
+			if best == nil || releaseSemver.GreaterThan(best) {
+				best = releaseSemver
+				bestTag = release.TagName
 			}
 		}
 
@@ -103,7 +121,7 @@ func LatestStableSemverRange(ctx context.Context, client *githubv4.Client, owner
 		}
 	}
 
-	return "", nil
+	return bestTag, nil
 }
 
 type Release struct {

--- a/.github/actions/linear-release-sync/src/changelog/releases/releases_test.go
+++ b/.github/actions/linear-release-sync/src/changelog/releases/releases_test.go
@@ -104,6 +104,111 @@ func TestLastStableReleaseBeforeTag(t *testing.T) {
 	}
 }
 
+func TestLastStableReleaseBeforeTag_PrefersSemverOverCreationDate(t *testing.T) {
+	// Regression test for DEVOPS-874.
+	//
+	// Releases are paginated by GitHub in CREATED_AT DESC order. With multiple
+	// stable release lines maintained in parallel, the most-recently-cut release
+	// on a different line can come before the true semver predecessor in the
+	// response. The lookup must compare by semver, not by creation date.
+	//
+	// Scenario mirrors loft-sh/loft around 2026-04-28: v4.6.3 was cut two
+	// minutes before v4.8.2, putting it ahead of v4.8.1 in CREATED_AT order.
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]any{
+			"data": map[string]any{
+				"repository": map[string]any{
+					"releases": map[string]any{
+						"pageInfo": map[string]any{
+							"endCursor":   "",
+							"hasNextPage": false,
+						},
+						// Order mirrors a CREATED_AT DESC response with parallel
+						// release lines. v4.6.3 was cut after v4.8.1 in real time
+						// but is a lower semver.
+						"nodes": []any{
+							map[string]any{"tagName": "v4.8.2", "isPrerelease": false},
+							map[string]any{"tagName": "v4.6.3", "isPrerelease": false},
+							map[string]any{"tagName": "v4.8.1", "isPrerelease": false},
+							map[string]any{"tagName": "v4.8.0", "isPrerelease": false},
+						},
+					},
+				},
+			},
+		}
+		json.NewEncoder(w).Encode(resp)
+	})
+
+	client := newTestClient(handler)
+	result, err := LastStableReleaseBeforeTag(context.Background(), client, "owner", "repo", "v4.8.2")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result != "v4.8.1" {
+		t.Errorf("expected v4.8.1 (highest semver < 4.8.2), got %q", result)
+	}
+}
+
+func TestLatestStableSemverRange_HighestSemverAcrossPages(t *testing.T) {
+	// The semver winner can live on a later page than other matches. Verify
+	// pagination continues even after a match is found.
+	callCount := 0
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		var resp map[string]any
+		if callCount == 1 {
+			resp = map[string]any{
+				"data": map[string]any{
+					"repository": map[string]any{
+						"releases": map[string]any{
+							"pageInfo": map[string]any{
+								"endCursor":   "cursor1",
+								"hasNextPage": true,
+							},
+							"nodes": []any{
+								map[string]any{"tagName": "v4.6.3", "isPrerelease": false},
+								map[string]any{"tagName": "v4.7.2", "isPrerelease": false},
+							},
+						},
+					},
+				},
+			}
+		} else {
+			resp = map[string]any{
+				"data": map[string]any{
+					"repository": map[string]any{
+						"releases": map[string]any{
+							"pageInfo": map[string]any{
+								"endCursor":   "",
+								"hasNextPage": false,
+							},
+							"nodes": []any{
+								map[string]any{"tagName": "v4.8.1", "isPrerelease": false},
+								map[string]any{"tagName": "v4.8.0", "isPrerelease": false},
+							},
+						},
+					},
+				},
+			}
+		}
+		json.NewEncoder(w).Encode(resp)
+	})
+
+	client := newTestClient(handler)
+	result, err := LatestStableSemverRange(context.Background(), client, "owner", "repo", "< 4.8.2")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if callCount != 2 {
+		t.Errorf("expected 2 API calls (full pagination), got %d", callCount)
+	}
+	if result != "v4.8.1" {
+		t.Errorf("expected v4.8.1, got %q", result)
+	}
+}
+
 func TestLatestStableSemverRange_Pagination(t *testing.T) {
 	callCount := 0
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
Fixes [DEVOPS-874](https://linear.app/loft/issue/DEVOPS-874/review-comment-posting-action-for-issue-release-updates) — the action posts spurious "Now available in stable release vX.Y.Z" comments on Linear issues that already shipped on an earlier patch of the same release line.

Root cause: `LatestStableSemverRange` paginated GitHub releases in `CREATED_AT DESC` order and returned the *first* release matching the semver constraint. For repos that maintain multiple stable lines in parallel (loft-sh/loft: 4.5.x / 4.6.x / 4.7.x / 4.8.x), a patch on an older minor cut shortly before a patch on a newer minor would win the lookup.

Concrete trigger from the loft release timeline:
- v4.6.3 published 2026-04-28 22:03Z
- v4.8.2 published 2026-04-28 22:05Z

`LastStableReleaseBeforeTag(v4.8.2)` returned **v4.6.3** instead of **v4.8.1**. `FetchAllPRsBetween(v4.6.3, v4.8.2)` then included every commit unique to the 4.8 line — pulling in 4.8.0/4.8.1 PRs. ENGUI-494 (shipped in v4.8.0) was in that set, was already in `Released` state, had no `"Now available in stable release v4.8.2"` comment yet (dedup is per-tag), so the action posted one.

Strict-filtering does not mitigate this — the 4.8.0 PR was merged long before v4.8.2's `PublishedAt`, so it passes the time filter.

## Key Changes
- `LatestStableSemverRange` now collects every release matching the constraint across all pages and returns the highest by semver comparison, instead of returning the first creation-date match.
- Added regression test `TestLastStableReleaseBeforeTag_PrefersSemverOverCreationDate` that pins the loft-sh/loft scenario (v4.6.3 ahead of v4.8.1 in CREATED_AT order, but v4.8.1 is the correct predecessor of v4.8.2).
- Added `TestLatestStableSemverRange_HighestSemverAcrossPages` covering the case where the semver winner is on a later page than a non-winning match.

## Dependencies
None. Existing tests continue to pass (`TestLatestStableSemverRange_Pagination`, `TestLatestStableSemverRange_NoMatch`, etc.).

## TODO
- [ ] Merge
- [ ] Cut a new `linear-release-sync/v1` binary (workflow_dispatch on `release-linear-release-sync.yaml`) so the loft release workflow picks up the fix on the next stable release
- [ ] Decide separately whether to retroactively suppress / amend the wrongly posted comments from the v4.8.2 run (not in scope here)

Closes DEVOPS-874