### PR TITLE
docs(repository-dispatch): use real token name in README example

### DIFF
--- a/.github/actions/repository-dispatch/README.md
+++ b/.github/actions/repository-dispatch/README.md
@@ -37,7 +37,7 @@ jobs:
               "sha": "${{ github.sha }}"
             }
         env:
-          GH_TOKEN: ${{ secrets.CROSS_REPO_DISPATCH_TOKEN }}
+          GH_TOKEN: ${{ secrets.VCLUSTERLABS_DISPATCH_TOKEN }}
 ```
 
 ### Auth


### PR DESCRIPTION
## Summary

The Usage example in `.github/actions/repository-dispatch/README.md` referenced `secrets.CROSS_REPO_DISPATCH_TOKEN`, which isn't a secret that exists in any caller repo. Anyone copying the example would wire up a non-existent secret and silently end up with an empty `GH_TOKEN`, causing `repository_dispatch` to fail authentication on the target repo.

The canonical caller in this repo (`.github/workflows/dispatch-integration-tests.yaml:31`) and `loft-sh/loft-enterprise`'s `release.yaml` both use `VCLUSTERLABS_DISPATCH_TOKEN`. This PR aligns the README example with the real secret name so copy-paste works.

The typo was introduced in #140 (the original PR that added this composite action).

## Scope

- Single line change to the Usage example
- Auto-generated input table (between `AUTO-DOC-INPUT:START/END`) untouched — out of scope

## Follow-up after merge

The `repository-dispatch/v1` floating tag needs to be force-moved to the merge commit so existing consumers pinned at `@repository-dispatch/v1` pick up the fix (same retag pattern used for DEVOPS-855 / v1.3.1). Flagging here so a human with retag permissions can do it.

## Test plan

- [x] `grep -n CROSS_REPO_DISPATCH_TOKEN .github/actions/repository-dispatch/README.md` returns nothing
- [x] Cross-checked with `.github/workflows/dispatch-integration-tests.yaml` (this repo) and `loft-sh/loft-enterprise` `release.yaml` — both use `VCLUSTERLABS_DISPATCH_TOKEN`