### PR TITLE
fix(actionlint): keep checkout credentials for reviewdog git fallback

### DIFF
--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -23,7 +23,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-          persist-credentials: false
 
       - name: Get changed workflow files
         id: changed-files

--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -19,7 +19,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - name: Checkout
+      - name: Checkout # zizmor: ignore[artipacked] -- reviewdog needs git credentials for local diff fallback on large PRs
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0


### PR DESCRIPTION
## Summary

- Remove `persist-credentials: false` from the actionlint workflow's checkout step so reviewdog can access git credentials when it falls back to local git diff on large PRs
- Fixes `fatal: could not read Username for 'https://github.com'` errors
- Safe because the workflow already scopes permissions to `contents: read` / `pull-requests: write` and skips fork PRs

## Test plan

- [ ] Open a large PR in a consuming repo and verify actionlint runs without credential errors
- [ ] Verify reviewdog still posts inline review comments correctly