### PR TITLE
fix(release-notification): pin composite action to v2-compatible sha + smoke status=failure

### DIFF
--- a/.github/workflows/notify-release.yaml
+++ b/.github/workflows/notify-release.yaml
@@ -81,7 +81,7 @@ jobs:
           persist-credentials: false
       - name: Notify #product-releases Slack channel
         if: ${{ !inputs.dry-run }}
-        uses: loft-sh/github-actions/.github/actions/release-notification@4207288daf055fa396f57e248dd3c5657c32c65b # release-notification/v1
+        uses: loft-sh/github-actions/.github/actions/release-notification@b52efbd927586ea78282073f79d2423e552c9f62 # release-notification/v2
         with:
           version: ${{ inputs.release_version }}
           previous_tag: ${{ inputs.previous_tag }}

--- a/.github/workflows/test-notify-release.yaml
+++ b/.github/workflows/test-notify-release.yaml
@@ -4,11 +4,20 @@ on:
   pull_request:
     paths:
       - '.github/workflows/notify-release.yaml'
+      - '.github/actions/release-notification/**'
+      - '.github/workflows/test-notify-release.yaml'
+  schedule:
+    # Weekly canary so contract drift between the wrapper workflow and its
+    # internal composite-action pin is caught even when nobody touches the
+    # files. DEVOPS-923 hid for weeks because the only signal was a
+    # production release failure.
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
 
 permissions: {}
 
 jobs:
-  notify-release:
+  notify-release-success:
     permissions:
       contents: read
     uses: ./.github/workflows/notify-release.yaml
@@ -23,18 +32,36 @@ jobs:
       # never uses it — notify-release.yaml declares it as required.
       SLACK_WEBHOOK_URL_PRODUCT_RELEASES: ${{ secrets.SLACK_WEBHOOK_URL_PRODUCT_RELEASES }}
 
+  notify-release-failure:
+    permissions:
+      contents: read
+    uses: ./.github/workflows/notify-release.yaml
+    with:
+      release_version: 'v0.0.0-smoke-test'
+      target_repo: ${{ github.repository }}
+      product: 'smoke-test'
+      status: 'failure'
+      dry-run: true
+    secrets:
+      SLACK_WEBHOOK_URL_PRODUCT_RELEASES: ${{ secrets.SLACK_WEBHOOK_URL_PRODUCT_RELEASES }}
+
   verify:
-    needs: [notify-release]
+    needs: [notify-release-success, notify-release-failure]
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - name: Check notify-release result
+      - name: Check notify-release results
         env:
-          RESULT: ${{ needs.notify-release.result }}
+          SUCCESS_RESULT: ${{ needs.notify-release-success.result }}
+          FAILURE_RESULT: ${{ needs.notify-release-failure.result }}
         run: |
-          echo "notify-release result=$RESULT"
-          if [ "$RESULT" != "success" ]; then
-            echo "::error::Expected notify-release result=success (dry-run), got '$RESULT'"
-            exit 1
-          fi
-          echo "notify-release workflow completed with result: $RESULT"
+          echo "notify-release-success result=$SUCCESS_RESULT"
+          echo "notify-release-failure result=$FAILURE_RESULT"
+          rc=0
+          for r in "$SUCCESS_RESULT" "$FAILURE_RESULT"; do
+            if [ "$r" != "success" ]; then
+              echo "::error::Expected notify-release dry-run result=success, got '$r'"
+              rc=1
+            fi
+          done
+          exit "$rc"


### PR DESCRIPTION
## Summary

The wrapper workflow `.github/workflows/notify-release.yaml` accepts a `status` input on its `release-notification/v2` public contract (added in #93), but the composite-action pin inside the wrapper was never advanced past `4207288daf...`, whose `action.yml` predates `status`. When a real caller passes `status: failure`, the runner prints `Unexpected input(s) 'status'` and exits 128 — the failure notification it is supposed to fire silently disappears.

The bug is invisible until something fails for real, which is what happened on `loft-sh/vcluster` run [25905886661](https://github.com/loft-sh/vcluster/actions/runs/25905886661/job/76344999681).

## Key Changes

- `.github/workflows/notify-release.yaml`: bump composite-action pin from `4207288daf... # release-notification/v1` → `b52efbd927... # release-notification/v2` (current `main`). One-line change. Trailing version comment fixed.
- `.github/workflows/test-notify-release.yaml`: add a second caller exercising `status: failure`, add a weekly cron schedule, add `workflow_dispatch`, and broaden the path filter so changes to the composite action and to the test workflow itself also trigger it.

## Follow-up after merge (operator action, not in this PR)

- Force-move the `release-notification/v2` tag onto the merge commit so callers pinning the floating tag (`loft-sh/vcluster-pro`, `loft-sh/loft-enterprise`) pick up the fix.

## Dependencies

- `loft-sh/vcluster#3936` (Closes DEVOPS-923) — goreleaser idempotency fix.
- https://github.com/loft-sh/vcluster-pro/pull/1802, https://github.com/loft-sh/loft-enterprise/pull/6855 — same goreleaser one-liner mirrored.

References DEVOPS-923