### PR TITLE
fix(release-notification): render emoji shortcode in failure header

### DIFF
--- a/.github/actions/release-notification/action.yml
+++ b/.github/actions/release-notification/action.yml
@@ -125,7 +125,7 @@ runs:
               text:
                 type: plain_text
                 text: "${{ steps.status_text.outputs.emoji }} Release Pipeline ${{ steps.status_text.outputs.label }}"
-                emoji: false
+                emoji: true
             - type: section
               fields:
                 - type: mrkdwn


### PR DESCRIPTION
## Summary

Flip the failure-path header block from `emoji: false` to `emoji: true` so the `:rotating_light:` / `:warning:` / `:fast_forward:` shortcode emitted by the `Resolve status text` step renders as an actual emoji glyph in Slack instead of being shown as literal text.

## Why

Observed on `loft-enterprise` v4.10.0-alpha.0 release run [#26098387494](https://github.com/loft-sh/loft-enterprise/actions/runs/26098387494). The first real `status=failure` notification fired and arrived in Slack as:

```
:rotating_light: Release Pipeline Failed
```

instead of:

```
🚨 Release Pipeline Failed
```

Slack `plain_text` blocks only convert `:shortcode:` strings to emoji when `emoji: true` is set; `emoji: false` opts out and ships the shortcode verbatim. The success-path header (line 79) keeps `emoji: false` because its text has no shortcode — behavior unchanged there.

This is the smallest possible patch. The success-path header could also be flipped for consistency, but that's a separate cosmetic change.

## Rollout

After merge, the `release-notification/v2` consumer surface needs the now-standard composite-pin dance (mirrors what #145 did yesterday):

1. Bump the wrapper workflow's inner SHA pin: `uses: loft-sh/github-actions/.github/actions/release-notification@<new-sha>` in `.github/workflows/notify-release.yaml`.
2. Force-update the `release-notification/v2` tag to point at the new wrapper SHA.

## Test plan

- [ ] Trigger the existing `test-semver-validation.yaml` smoke-failure path with the v2 tag re-pointed to this fix and confirm the rendered Slack message shows the emoji glyph.
- [ ] Confirm success notifications still render correctly (no behaviour change for `status=success`).