### PR TITLE
fix(release-notification): use @v2 tag for inner composite ref

### DIFF
--- a/.github/workflows/notify-release.yaml
+++ b/.github/workflows/notify-release.yaml
@@ -81,7 +81,7 @@ jobs:
           persist-credentials: false
       - name: Notify #product-releases Slack channel
         if: ${{ !inputs.dry-run }}
-        uses: loft-sh/github-actions/.github/actions/release-notification@b52efbd927586ea78282073f79d2423e552c9f62 # release-notification/v2
+        uses: loft-sh/github-actions/.github/actions/release-notification@release-notification/v2
         with:
           version: ${{ inputs.release_version }}
           previous_tag: ${{ inputs.previous_tag }}

--- a/.github/workflows/notify-release.yaml
+++ b/.github/workflows/notify-release.yaml
@@ -81,7 +81,7 @@ jobs:
           persist-credentials: false
       - name: Notify #product-releases Slack channel
         if: ${{ !inputs.dry-run }}
-        uses: loft-sh/github-actions/.github/actions/release-notification@release-notification/v2
+        uses: loft-sh/github-actions/.github/actions/release-notification@release-notification/v2 # zizmor: ignore[unpinned-uses] -- internal loft-sh/github-actions ref; @v2 is the floating coordination tag that keeps wrapper and composite atomically aligned (see DEVOPS-923 pin-drift class)
         with:
           version: ${{ inputs.release_version }}
           previous_tag: ${{ inputs.previous_tag }}


### PR DESCRIPTION
## Summary

Replace the SHA pin (`@b52efbd9...`) on the inner composite reference in `notify-release.yaml` with the action-specific tag (`@release-notification/v2`). This aligns with the [github-actions-developer convention](https://www.notion.so/loftsh/GitHub-Actions-Developer-Guide-18110940806980abbe16e77d60ed1b9f) — internal `loft-sh/github-actions` references use action-specific tags, SHA pins are reserved for third-party actions only.

## Why

The wrapper-and-composite live in the same repo, but the wrapper pinned the composite by SHA. That created a slow-burn class of pin-drift bugs:

- **DEVOPS-923** (PR #145): composite gained a `status` input on main, wrapper SHA pin still referenced the pre-change composite — runs that passed `status: failure` exited 128 with `Unexpected input(s) 'status'`. Invisible until the smoke tests added in commit `e1e07b8` caught it.
- **#146** (emoji shortcode bug): composite changed on main to set `emoji: true` in the failure header. The wrapper's SHA pin still resolves to the pre-fix composite, so the fix doesn't ship until someone manually bumps this SHA.

Every composite fix would otherwise need a follow-up PR to bump this SHA. By referencing the action via `@release-notification/v2`, the floating v2 tag becomes the single coordination point: retag v2 → both wrapper *and* composite advance atomically. No follow-up PR each time.

## Rollout

After merge:

```bash
cd loft-sh/github-actions
git tag -f release-notification/v2 main
git push origin release-notification/v2 --force
```

Consumers in `vcluster`, `vcluster-pro`, and `loft-enterprise` (all already pinned to `@release-notification/v2`) pick up the emoji fix from #146 *plus* this drift-prevention change on their next workflow run.

## Test plan

- [ ] PR CI is green (actionlint, zizmor)
- [ ] After v2 retag, the weekly smoke test (commit `e1e07b8`) exercises both `status=success` and `status=failure` callers from the floating v2 reference.
- [ ] Watch the next `loft-enterprise` release run for the rendered 🚨 in any failure notification (positive confirmation of #146's fix flowing through this change).