### PR TITLE
fix(prerelease-setup): drop ${{ }} expression from github-token description

### DIFF
--- a/.github/actions/prerelease-setup/action.yml
+++ b/.github/actions/prerelease-setup/action.yml
@@ -6,7 +6,7 @@ inputs:
     description: 'AWS STS role-session-name. Each consumer job passes a distinct value (e.g. prerelease-vcluster-<run-id>, prerelease-aicloud-<run-id>).'
     required: true
   github-token:
-    description: 'GitHub token with contents:read on loft-sh/loft-enterprise. Required because the platform release resolvers call the GitHub API for a private repo; unauthenticated calls return 404. Pass ${{ github.token }} from a job whose permissions grant contents:read.'
+    description: 'GitHub token with contents:read on loft-sh/loft-enterprise. Required because the platform release resolvers call the GitHub API for a private repo; unauthenticated calls return 404. Pass github.token from a job whose permissions grant contents:read.'
     required: true
   standalone-vcluster-version:
     description: 'vCluster version to install for standalone (e.g. 0.34.0). Empty resolves to the latest GitHub release of loft-sh/vcluster.'


### PR DESCRIPTION
## Problem

`prerelease-setup` fails to load with:

```
.github/actions/prerelease-setup/action.yml (Line: 9, Col: 18):
Unrecognized named-value: 'github'. Located at position 1 within expression: github.token
```

The `github-token` input `description` contains a literal `${{ github.token }}`. GitHub evaluates `${{ }}` expressions even inside action input descriptions, and the `github` context is not available there, so the whole action manifest fails template validation at load time ("Prepare all required actions"), before any step runs.

## Impact

Every consumer of `prerelease-setup/v1` is broken. `loft-sh/loft-enterprise` `prerelease-checks.yaml` migrated both jobs to this composite action, and since then its pre-release runs on `main` fail at setup in ~15s:

- run 27331174617 (2026-06-11)
- run 27443560408 (2026-06-12)
- run 27450021571 (2026-06-13)

It went unnoticed because pre-release only runs on tag / dispatch, and the runs that did execute the suite used a branch (`prerel-localact`) that still had the inline setup.

## Fix

Use plain text (`Pass github.token from a job ...`) in the description instead of the `${{ github.token }}` expression.

## Follow-up

After merge, `prerelease-setup/v1` should be re-tagged to the fixed commit so existing consumers recover without changes.

Refs ENGCP-954