### PR TITLE
feat(ci-test-notify): add info status for informational notices

### DIFF
--- a/.github/actions/ci-test-notify/README.md
+++ b/.github/actions/ci-test-notify/README.md
@@ -8,12 +8,12 @@ Replaces the nightly-specific `ci-notify-nightly-tests` action with a generic in
 
 <!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
 
-|    INPUT    |  TYPE  | REQUIRED | DEFAULT |                                                                                         DESCRIPTION                                                                                         |
-|-------------|--------|----------|---------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-|   details   | string |  false   |         |                                               Markdown text appended after the build <br>URL (test results, versions, artifact links, etc.)                                                 |
-|   status    | string |   true   |         |         Run status, typically `needs.<job>.result` or `job.status`. <br>`success` and `failure` notify; `cancelled` and <br>`skipped` are treated as no-ops and <br>send nothing.           |
-|  test-name  | string |   true   |         | Test suite name for the header <br>(e.g. "E2E Ginkgo Nightly Tests"). Keep under ~130 chars — <br>Slack header blocks have a 150-char <br>limit and the status suffix takes <br>~15 chars.  |
-| webhook-url | string |   true   |         |                                                                                 Slack incoming webhook URL                                                                                  |
+|    INPUT    |  TYPE  | REQUIRED | DEFAULT |                                                                                                                                            DESCRIPTION                                                                                                                                             |
+|-------------|--------|----------|---------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|   details   | string |  false   |         |                                                                                                   Markdown text appended after the build <br>URL (test results, versions, artifact links, etc.)                                                                                                    |
+|   status    | string |   true   |         | Run status, typically `needs.<job>.result` or `job.status`. <br>`success` and `failure` notify; `cancelled` and <br>`skipped` are treated as no-ops and <br>send nothing. Use `info` for a <br>standalone informational notice (e.g. a deploy) that always <br>notifies with no pass/fail suffix.  |
+|  test-name  | string |   true   |         |                                                    Test suite name for the header <br>(e.g. "E2E Ginkgo Nightly Tests"). Keep under ~130 chars — <br>Slack header blocks have a 150-char <br>limit and the status suffix takes <br>~15 chars.                                                      |
+| webhook-url | string |   true   |         |                                                                                                                                     Slack incoming webhook URL                                                                                                                                     |
 
 <!-- AUTO-DOC-INPUT:END -->
 
@@ -28,6 +28,9 @@ Build URL: <link to workflow run>
 ─────────────────────────────
 <repo> · Run #<number>
 ```
+
+`status: info` renders a 🚀 header with no `[status]` suffix, for informational
+notices (e.g. a deploy) rather than pass/fail results.
 
 ## Usage
 
@@ -56,6 +59,24 @@ Build URL: <link to workflow run>
 
       Sonobuoy results: ${{ steps.upload.outputs.artifact-url }}
     webhook-url: ${{ secrets.SLACK_WEBHOOK_URL_CI_TESTS_ALERTS }}
+```
+
+### Informational deploy notice
+
+`info` always notifies (no pass/fail suffix) and uses a 🚀 header, for a
+standalone notice such as a release candidate landing in staging:
+
+```yaml
+- uses: loft-sh/github-actions/.github/actions/ci-test-notify@ci-test-notify/v1
+  with:
+    test-name: Release candidate deployed to staging.vcluster.cloud
+    status: info
+    details: |
+      • vcluster-platform: `4.10.0-rc.1`
+
+      QA: spin up an instance on staging, verify it's healthy, then tick the
+      pre-release checklist.
+    webhook-url: ${{ secrets.SLACK_WEBHOOK_URL_QA }}
 ```
 
 ### Failure-only with summary

--- a/.github/actions/ci-test-notify/action.yml
+++ b/.github/actions/ci-test-notify/action.yml
@@ -8,7 +8,7 @@ inputs:
     description: 'Test suite name for the header (e.g. "E2E Ginkgo Nightly Tests"). Keep under ~130 chars — Slack header blocks have a 150-char limit and the status suffix takes ~15 chars.'
     required: true
   status:
-    description: 'Run status, typically `needs.<job>.result` or `job.status`. `success` and `failure` notify; `cancelled` and `skipped` are treated as no-ops and send nothing.'
+    description: 'Run status, typically `needs.<job>.result` or `job.status`. `success` and `failure` notify; `cancelled` and `skipped` are treated as no-ops and send nothing. Use `info` for a standalone informational notice (e.g. a deploy) that always notifies with no pass/fail suffix.'
     required: true
   details:
     description: 'Markdown text appended after the build URL (test results, versions, artifact links, etc.)'

--- a/.github/actions/ci-test-notify/build-payload.sh
+++ b/.github/actions/ci-test-notify/build-payload.sh
@@ -10,10 +10,14 @@ case "$STATUS" in
   failure)    EMOJI="❌"; STATUS_TEXT="Failed" ;;
   cancelled)  EMOJI="⚠️"; STATUS_TEXT="Cancelled" ;;
   skipped)    EMOJI="⏭️"; STATUS_TEXT="Skipped" ;;
+  info)       EMOJI="🚀"; STATUS_TEXT="" ;;
   *)          EMOJI="❓"; STATUS_TEXT="Unknown ($STATUS)" ;;
 esac
 
-HEADER="${EMOJI} ${TEST_NAME} ${STATUS_TEXT}"
+# `info` carries no pass/fail meaning, so it gets no status suffix; every other
+# status appends one (" Success", " Failed", …). Keep the space inside the
+# expansion so an empty suffix leaves no trailing whitespace in the header.
+HEADER="${EMOJI} ${TEST_NAME}${STATUS_TEXT:+ ${STATUS_TEXT}}"
 
 # Slack header blocks reject >150 chars
 if [[ ${#HEADER} -gt 150 ]]; then

--- a/.github/actions/ci-test-notify/should-notify.sh
+++ b/.github/actions/ci-test-notify/should-notify.sh
@@ -10,6 +10,10 @@ set -euo pipefail
 # (or superseded), and a skipped job never executed. Neither warrants a Slack
 # alert, so both are silenced here rather than in every caller.
 #
+# `info` is a status callers set deliberately for a standalone informational
+# notice (e.g. a release candidate landing in staging) rather than a run
+# conclusion; it is not a no-op and always notifies when a webhook is present.
+#
 # An empty webhook (fork PRs, where secrets are unavailable) also suppresses
 # the notification, same as before.
 #

--- a/.github/actions/ci-test-notify/test/build-payload.bats
+++ b/.github/actions/ci-test-notify/test/build-payload.bats
@@ -48,6 +48,13 @@ payload_field() {
   [[ "$(payload_field '.text')" == *"Cancelled"* ]]
 }
 
+@test "info status uses rocket emoji and no status suffix" {
+  STATUS="info" TEST_NAME="Deployed to staging" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  # Exact match asserts there is no trailing status word or whitespace.
+  [ "$(payload_field '.blocks[0].text.text')" = "🚀 Deployed to staging" ]
+}
+
 @test "skipped status produces correct emoji and text" {
   STATUS="skipped" run bash "$SCRIPT"
   [ "$status" -eq 0 ]

--- a/.github/actions/ci-test-notify/test/should-notify.bats
+++ b/.github/actions/ci-test-notify/test/should-notify.bats
@@ -37,6 +37,12 @@ notify_value() {
   [ "$(notify_value)" = "true" ]
 }
 
+@test "info notifies" {
+  STATUS="info" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(notify_value)" = "true" ]
+}
+
 # --- Statuses that must stay silent (the bug this fixes) ---
 
 @test "cancelled does not notify" {


### PR DESCRIPTION
Adds an `info` status to the `ci-test-notify` action for standalone informational Slack pings (a deploy landed, a release candidate reached staging), where `success`/`failure` would force a misleading pass/fail header and suffix.

## What
- `build-payload.sh`: new `info` case, rocket emoji, no status suffix. Header assembly omits the trailing suffix only when empty, so existing `success`/`failure`/`cancelled`/`skipped` headers are byte-for-byte unchanged.
- `should-notify.sh`: `info` always notifies (still suppressed on an empty webhook, e.g. fork PRs). Gating for `cancelled`/`skipped` is untouched.
- `action.yml` + `README.md`: document the status; regenerated the auto-doc input table.
- bats: added `info` coverage to `build-payload.bats` and `should-notify.bats`.

## Why
`hosted-platform` PR [#530](https://github.com/loft-sh/hosted-platform/pull/530) hand-rolls a `jq`+`curl` Slack POST to tell QA an RC deployed to staging. That duplicates the gate/payload/send logic already in this action. This is the smallest additive change that lets that workflow reuse `ci-test-notify` instead. See the reuse-first convention.

## Tests
- `make test-ci-test-notify` — 33/33 pass (2 new).
- `shellcheck` clean on both scripts.
- `make generate-docs` run; no drift outside this action.

References DEVOPS-577.