### PR TITLE
feat(parse-label-filter): add action to skip no-op edited e2e runs

### DIFF
--- a/.github/actions/parse-label-filter/README.md
+++ b/.github/actions/parse-label-filter/README.md
@@ -23,20 +23,28 @@ edit cannot cancel a still-running code run and then skip.
 
 ## Inputs
 
-| Input | Required | Default | Description |
-| --- | --- | --- | --- |
-| `pr-body` | no | `''` | Current PR description. Pass `${{ github.event.pull_request.body }}`. |
-| `previous-pr-body` | no | `''` | PR description before an edit. Pass `${{ github.event.changes.body.from }}`; only populated on edited events. |
-| `event-name` | no | `''` | Triggering event. Pass `${{ github.event_name }}`. |
-| `event-action` | no | `''` | Event action. Pass `${{ github.event.action }}`. |
-| `label-filter-input` | no | `''` | Fallback label filter from a manual dispatch. Pass `${{ inputs.ginkgo-label }}`. Used only when the PR description has no label-filter block. |
+<!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
+
+|       INPUT        |  TYPE  | REQUIRED | DEFAULT |                                                                          DESCRIPTION                                                                          |
+|--------------------|--------|----------|---------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|    event-action    | string |  false   |         |                                                 The event action. Pass the github.event.action <br>context.                                                   |
+|     event-name     | string |  false   |         |                                                The triggering event. Pass the github.event_name <br>context.                                                  |
+| label-filter-input | string |  false   |         | Fallback label filter from a manual <br>dispatch. Pass the ginkgo-label workflow input. <br>Used only when the PR description <br>has no label-filter block.  |
+|      pr-body       | string |  false   |         |                                         Current PR description. Pass the github.event.pull_request.body <br>context.                                          |
+|  previous-pr-body  | string |  false   |         |                           PR description before an edit. Pass <br>github.event.changes.body.from; only populated on edited events.                            |
+
+<!-- AUTO-DOC-INPUT:END -->
 
 ## Outputs
 
-| Output | Description |
-| --- | --- |
-| `label-filter` | Resolved Ginkgo label filter: the parsed PR-description block, else the dispatch input, else `pr`. |
-| `skip-edited` | `"true"` only when this is a `pull_request` `edited` event whose label-filter block did not change; otherwise `"false"`. |
+<!-- AUTO-DOC-OUTPUT:START - Do not remove or modify this section -->
+
+|    OUTPUT    |  TYPE  |                                                             DESCRIPTION                                                              |
+|--------------|--------|--------------------------------------------------------------------------------------------------------------------------------------|
+| label-filter | string |             Resolved Ginkgo label filter: the parsed <br>PR-description block, else the dispatch input, <br>else "pr".               |
+| skip-edited  | string | Either "true" or "false". "true" only <br>when this is a pull_request edited <br>event whose label-filter block did not <br>change.  |
+
+<!-- AUTO-DOC-OUTPUT:END -->
 
 ## Usage
 

--- a/.github/actions/parse-label-filter/README.md
+++ b/.github/actions/parse-label-filter/README.md
@@ -1,0 +1,76 @@
+# Parse label filter
+
+Parses the ` ```label-filter``` ` fenced block from a pull request description,
+resolves the Ginkgo label filter for an E2E run, and decides whether a
+`pull_request` `edited` event can be skipped.
+
+## Why skip-edited exists
+
+E2E workflows commonly trigger on `pull_request: types: [..., edited]` so that
+editing the label-filter block re-targets which suites run without pushing a
+commit. The side effect is that any bot editing the PR description (for example
+`cursor[bot]`) fires `edited` on the same head SHA with no code change, which
+re-runs the whole suite.
+
+This action compares the label-filter block before and after the edit. When it
+is unchanged there is nothing new to test, so `skip-edited` is `"true"` and the
+caller gates its expensive jobs on it. Real triggers (open, reopen, new commits,
+and genuine label-filter edits) are never skipped.
+
+Pair this with a concurrency group that separates edited from code events, e.g.
+`...-${{ github.event.action == 'edited' && 'edited' || 'code' }}`, so a bot
+edit cannot cancel a still-running code run and then skip.
+
+## Inputs
+
+| Input | Required | Default | Description |
+| --- | --- | --- | --- |
+| `pr-body` | no | `''` | Current PR description. Pass `${{ github.event.pull_request.body }}`. |
+| `previous-pr-body` | no | `''` | PR description before an edit. Pass `${{ github.event.changes.body.from }}`; only populated on edited events. |
+| `event-name` | no | `''` | Triggering event. Pass `${{ github.event_name }}`. |
+| `event-action` | no | `''` | Event action. Pass `${{ github.event.action }}`. |
+| `label-filter-input` | no | `''` | Fallback label filter from a manual dispatch. Pass `${{ inputs.ginkgo-label }}`. Used only when the PR description has no label-filter block. |
+
+## Outputs
+
+| Output | Description |
+| --- | --- |
+| `label-filter` | Resolved Ginkgo label filter: the parsed PR-description block, else the dispatch input, else `pr`. |
+| `skip-edited` | `"true"` only when this is a `pull_request` `edited` event whose label-filter block did not change; otherwise `"false"`. |
+
+## Usage
+
+```yaml
+jobs:
+  parse-label-filter:
+    runs-on: ubuntu-22.04
+    outputs:
+      label-filter: ${{ steps.parse.outputs.label-filter }}
+      skip-edited: ${{ steps.parse.outputs.skip-edited }}
+    steps:
+      - name: Parse label filter
+        id: parse
+        uses: loft-sh/github-actions/.github/actions/parse-label-filter@parse-label-filter/v1
+        with:
+          pr-body: ${{ github.event.pull_request.body }}
+          previous-pr-body: ${{ github.event.changes.body.from }}
+          event-name: ${{ github.event_name }}
+          event-action: ${{ github.event.action }}
+          label-filter-input: ${{ inputs.ginkgo-label }}
+
+  e2e-tests:
+    needs: [parse-label-filter]
+    # Skip a no-op description edit; everything else runs.
+    if: needs.parse-label-filter.outputs.skip-edited != 'true'
+    runs-on: large-8_32
+    steps:
+      - run: echo "label filter is ${{ needs.parse-label-filter.outputs.label-filter }}"
+```
+
+The label-filter block in a PR description looks like:
+
+````markdown
+```label-filter
+db-datasource && aws
+```
+````

--- a/.github/actions/parse-label-filter/action.yml
+++ b/.github/actions/parse-label-filter/action.yml
@@ -10,23 +10,23 @@ description: |
   writes outputs.
 inputs:
   pr-body:
-    description: 'Current PR description. Pass ${{ github.event.pull_request.body }}.'
+    description: 'Current PR description. Pass the github.event.pull_request.body context.'
     required: false
     default: ''
   previous-pr-body:
-    description: 'PR description before an edit. Pass ${{ github.event.changes.body.from }}; only populated on edited events.'
+    description: 'PR description before an edit. Pass github.event.changes.body.from; only populated on edited events.'
     required: false
     default: ''
   event-name:
-    description: 'The triggering event. Pass ${{ github.event_name }}.'
+    description: 'The triggering event. Pass the github.event_name context.'
     required: false
     default: ''
   event-action:
-    description: 'The event action. Pass ${{ github.event.action }}.'
+    description: 'The event action. Pass the github.event.action context.'
     required: false
     default: ''
   label-filter-input:
-    description: 'Fallback label filter from a manual dispatch. Pass ${{ inputs.ginkgo-label }}. Used only when the PR description has no label-filter block.'
+    description: 'Fallback label filter from a manual dispatch. Pass the ginkgo-label workflow input. Used only when the PR description has no label-filter block.'
     required: false
     default: ''
 outputs:

--- a/.github/actions/parse-label-filter/action.yml
+++ b/.github/actions/parse-label-filter/action.yml
@@ -1,0 +1,54 @@
+name: Parse label filter
+description: |
+  Parses the ```label-filter``` fenced block from a pull request description and
+  resolves the Ginkgo label filter for an E2E run. Also decides whether a
+  pull_request `edited` event should be skipped: bots (e.g. cursor[bot]) edit the
+  PR description after open, firing `edited` on the same head SHA with no code
+  change. When the label-filter block is unchanged across the edit there is
+  nothing new to test, so `skip-edited` is set to "true" and the caller can skip
+  the suite. Domain-agnostic and side-effect free: it only reads inputs and
+  writes outputs.
+inputs:
+  pr-body:
+    description: 'Current PR description. Pass ${{ github.event.pull_request.body }}.'
+    required: false
+    default: ''
+  previous-pr-body:
+    description: 'PR description before an edit. Pass ${{ github.event.changes.body.from }}; only populated on edited events.'
+    required: false
+    default: ''
+  event-name:
+    description: 'The triggering event. Pass ${{ github.event_name }}.'
+    required: false
+    default: ''
+  event-action:
+    description: 'The event action. Pass ${{ github.event.action }}.'
+    required: false
+    default: ''
+  label-filter-input:
+    description: 'Fallback label filter from a manual dispatch. Pass ${{ inputs.ginkgo-label }}. Used only when the PR description has no label-filter block.'
+    required: false
+    default: ''
+outputs:
+  label-filter:
+    description: 'Resolved Ginkgo label filter: the parsed PR-description block, else the dispatch input, else "pr".'
+    value: ${{ steps.parse.outputs.label-filter }}
+  skip-edited:
+    description: 'Either "true" or "false". "true" only when this is a pull_request edited event whose label-filter block did not change.'
+    value: ${{ steps.parse.outputs.skip-edited }}
+runs:
+  using: composite
+  steps:
+    - name: Parse label filter and check edited
+      id: parse
+      shell: bash
+      env:
+        INPUT_PR_BODY: ${{ inputs.pr-body }}
+        INPUT_PREVIOUS_PR_BODY: ${{ inputs.previous-pr-body }}
+        INPUT_EVENT_NAME: ${{ inputs.event-name }}
+        INPUT_EVENT_ACTION: ${{ inputs.event-action }}
+        INPUT_LABEL_FILTER_INPUT: ${{ inputs.label-filter-input }}
+      run: ${{ github.action_path }}/src/parse-label-filter.sh
+branding:
+  icon: 'filter'
+  color: 'orange'

--- a/.github/actions/parse-label-filter/src/parse-label-filter.sh
+++ b/.github/actions/parse-label-filter/src/parse-label-filter.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Parse the ```label-filter``` block from a PR description and decide whether a
+# pull_request `edited` event should be skipped (label-filter unchanged).
+#
+# Inputs (env, all optional, default empty):
+#   INPUT_PR_BODY             current PR body (github.event.pull_request.body)
+#   INPUT_PREVIOUS_PR_BODY    PR body before an edit (github.event.changes.body.from)
+#   INPUT_EVENT_NAME          github.event_name
+#   INPUT_EVENT_ACTION        github.event.action
+#   INPUT_LABEL_FILTER_INPUT  manual-dispatch label filter (inputs.ginkgo-label)
+#
+# Writes to $GITHUB_OUTPUT:
+#   label-filter=<resolved>   parsed block, else dispatch input, else "pr"
+#   skip-edited=true|false    true only for an edited event with unchanged filter
+set -euo pipefail
+
+pr_body="${INPUT_PR_BODY:-}"
+previous_pr_body="${INPUT_PREVIOUS_PR_BODY:-}"
+event_name="${INPUT_EVENT_NAME:-}"
+event_action="${INPUT_EVENT_ACTION:-}"
+label_filter_input="${INPUT_LABEL_FILTER_INPUT:-}"
+
+# Extract the content of a ```label-filter``` fenced block from the given text.
+# Mirrors the previous regex ('```\s*label-filter\s*\n(.*?)\n```', gms): capture
+# the lines between the opening fence and the next closing fence, then collapse
+# whitespace/newlines the same way the old sanitize step did.
+extract_label_filter() {
+  printf '%s\n' "$1" | tr -d '\r' | awk '
+    /^```[[:space:]]*label-filter[[:space:]]*$/ { capture = 1; next }
+    capture && /^```[[:space:]]*$/             { capture = 0; next }
+    capture                                    { print }
+  ' | awk '{ $1 = $1; print }' | tr -d '\n'
+}
+
+# Trim surrounding whitespace and strip line breaks, matching the old handling
+# of the manual-dispatch input.
+normalize() {
+  printf '%s\n' "$1" | awk '{ $1 = $1; print }' | tr -d '\r\n'
+}
+
+emit() {
+  printf '%s=%s\n' "$1" "$2" >> "${GITHUB_OUTPUT:?GITHUB_OUTPUT required}"
+  printf '%s=%s\n' "$1" "$2"
+}
+
+current_filter="$(extract_label_filter "$pr_body")"
+input_filter="$(normalize "$label_filter_input")"
+
+# Precedence mirrors the previous inline job output: the PR-description block
+# wins, then a manual-dispatch input, then the default "pr" suite.
+if [[ -n "$current_filter" ]]; then
+  label_filter="$current_filter"
+elif [[ -n "$input_filter" ]]; then
+  label_filter="$input_filter"
+else
+  label_filter="pr"
+fi
+emit "label-filter" "$label_filter"
+
+# Only a pull_request `edited` event can be a no-op description edit. Anything
+# else (open, reopen, synchronize, release, dispatch) always runs.
+if [[ "$event_name" != "pull_request" || "$event_action" != "edited" ]]; then
+  emit "skip-edited" "false"
+  exit 0
+fi
+
+previous_filter="$(extract_label_filter "$previous_pr_body")"
+if [[ "$current_filter" == "$previous_filter" ]]; then
+  echo "::notice::Skipping e2e: PR edited but label-filter unchanged (${current_filter:-none})"
+  emit "skip-edited" "true"
+else
+  echo "::notice::Label-filter changed from '${previous_filter:-none}' to '${current_filter:-none}', running e2e"
+  emit "skip-edited" "false"
+fi

--- a/.github/actions/parse-label-filter/test/parse-label-filter.bats
+++ b/.github/actions/parse-label-filter/test/parse-label-filter.bats
@@ -144,3 +144,48 @@ body_with_filter() {
   [ "$status" -eq 0 ]
   [ "$(kv label-filter)" = "label-filter=istio && core" ]
 }
+
+# A label-filter block that spans several physical lines. Each line is trimmed
+# and the newlines between them are stripped (no separator inserted), so the
+# block collapses into a single filter string. This mirrors the original inline
+# `awk '{$1=$1; print}' | tr -d '\r\n'` sanitize step the action replaced.
+@test "multi-line label-filter block is joined into a single filter" {
+  export INPUT_EVENT_NAME="pull_request"
+  export INPUT_EVENT_ACTION="opened"
+  export INPUT_PR_BODY="$(printf '%s\n' \
+    'Intro.' \
+    '' \
+    '```label-filter' \
+    'db-datasource && aws' \
+    '|| istio' \
+    '```' \
+    '' \
+    'Outro.')"
+
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv label-filter)" = "label-filter=db-datasource && aws|| istio" ]
+  [ "$(kv skip-edited)" = "skip-edited=false" ]
+}
+
+@test "edited with unchanged multi-line label-filter -> skip=true" {
+  export INPUT_EVENT_NAME="pull_request"
+  export INPUT_EVENT_ACTION="edited"
+  export INPUT_PR_BODY="$(printf '%s\n' \
+    'A bot appended a summary.' \
+    '```label-filter' \
+    'db-datasource && aws' \
+    '|| istio' \
+    '```')"
+  export INPUT_PREVIOUS_PR_BODY="$(printf '%s\n' \
+    'Original human description.' \
+    '```label-filter' \
+    'db-datasource && aws' \
+    '|| istio' \
+    '```')"
+
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv label-filter)" = "label-filter=db-datasource && aws|| istio" ]
+  [ "$(kv skip-edited)" = "skip-edited=true" ]
+}

--- a/.github/actions/parse-label-filter/test/parse-label-filter.bats
+++ b/.github/actions/parse-label-filter/test/parse-label-filter.bats
@@ -1,0 +1,146 @@
+#!/usr/bin/env bats
+# Tests for parse-label-filter.sh.
+
+SCRIPT="$BATS_TEST_DIRNAME/../src/parse-label-filter.sh"
+
+setup() {
+  export GITHUB_OUTPUT; GITHUB_OUTPUT="$(mktemp)"
+  # Start from a clean slate each test; individual tests set what they need.
+  unset INPUT_PR_BODY INPUT_PREVIOUS_PR_BODY INPUT_EVENT_NAME \
+    INPUT_EVENT_ACTION INPUT_LABEL_FILTER_INPUT
+}
+
+teardown() {
+  rm -f "$GITHUB_OUTPUT"
+}
+
+kv() { grep "^$1=" "$GITHUB_OUTPUT" | tail -n1; }
+
+# A PR body with a label-filter fenced block, indented like a real description.
+body_with_filter() {
+  printf '%s\n' \
+    'Some description text.' \
+    '' \
+    '```label-filter' \
+    "$1" \
+    '```' \
+    '' \
+    'More text.'
+}
+
+@test "no label-filter block, pull_request opened -> defaults to pr, no skip" {
+  export INPUT_EVENT_NAME="pull_request"
+  export INPUT_EVENT_ACTION="opened"
+  export INPUT_PR_BODY="just a description, no block"
+
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv label-filter)" = "label-filter=pr" ]
+  [ "$(kv skip-edited)" = "skip-edited=false" ]
+}
+
+@test "label-filter block is parsed and returned" {
+  export INPUT_EVENT_NAME="pull_request"
+  export INPUT_EVENT_ACTION="opened"
+  export INPUT_PR_BODY="$(body_with_filter 'db-datasource && aws')"
+
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv label-filter)" = "label-filter=db-datasource && aws" ]
+  [ "$(kv skip-edited)" = "skip-edited=false" ]
+}
+
+@test "opening fence with a space after backticks still parses" {
+  export INPUT_EVENT_NAME="pull_request"
+  export INPUT_EVENT_ACTION="synchronize"
+  export INPUT_PR_BODY="$(printf '%s\n' '``` label-filter' 'istio' '```')"
+
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv label-filter)" = "label-filter=istio" ]
+}
+
+@test "dispatch input used when no block present" {
+  export INPUT_EVENT_NAME="workflow_dispatch"
+  export INPUT_LABEL_FILTER_INPUT="conformance"
+
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv label-filter)" = "label-filter=conformance" ]
+  [ "$(kv skip-edited)" = "skip-edited=false" ]
+}
+
+@test "PR block wins over dispatch input" {
+  export INPUT_EVENT_NAME="pull_request"
+  export INPUT_EVENT_ACTION="opened"
+  export INPUT_PR_BODY="$(body_with_filter 'from-body')"
+  export INPUT_LABEL_FILTER_INPUT="from-input"
+
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv label-filter)" = "label-filter=from-body" ]
+}
+
+@test "edited with unchanged label-filter -> skip=true" {
+  export INPUT_EVENT_NAME="pull_request"
+  export INPUT_EVENT_ACTION="edited"
+  export INPUT_PR_BODY="$(body_with_filter 'pr')"
+  export INPUT_PREVIOUS_PR_BODY="$(printf '%s\n' 'Different prose entirely.' '```label-filter' 'pr' '```')"
+
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv skip-edited)" = "skip-edited=true" ]
+}
+
+@test "edited with no block before or after (bot description edit) -> skip=true" {
+  export INPUT_EVENT_NAME="pull_request"
+  export INPUT_EVENT_ACTION="edited"
+  export INPUT_PR_BODY="A cursor[bot] summary was appended."
+  export INPUT_PREVIOUS_PR_BODY="Original human description."
+
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv skip-edited)" = "skip-edited=true" ]
+}
+
+@test "edited with changed label-filter -> skip=false" {
+  export INPUT_EVENT_NAME="pull_request"
+  export INPUT_EVENT_ACTION="edited"
+  export INPUT_PR_BODY="$(body_with_filter 'db-datasource')"
+  export INPUT_PREVIOUS_PR_BODY="$(body_with_filter 'pr')"
+
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv skip-edited)" = "skip-edited=false" ]
+}
+
+@test "edited that adds a label-filter block where there was none -> skip=false" {
+  export INPUT_EVENT_NAME="pull_request"
+  export INPUT_EVENT_ACTION="edited"
+  export INPUT_PR_BODY="$(body_with_filter 'istio')"
+  export INPUT_PREVIOUS_PR_BODY="No block here."
+
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv skip-edited)" = "skip-edited=false" ]
+}
+
+@test "release event never skips" {
+  export INPUT_EVENT_NAME="release"
+  export INPUT_EVENT_ACTION="published"
+
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv skip-edited)" = "skip-edited=false" ]
+  [ "$(kv label-filter)" = "label-filter=pr" ]
+}
+
+@test "label filter with surrounding whitespace is trimmed" {
+  export INPUT_EVENT_NAME="pull_request"
+  export INPUT_EVENT_ACTION="opened"
+  export INPUT_PR_BODY="$(printf '%s\n' '```label-filter' '   istio && core   ' '```')"
+
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv label-filter)" = "label-filter=istio && core" ]
+}

--- a/.github/workflows/test-parse-label-filter.yaml
+++ b/.github/workflows/test-parse-label-filter.yaml
@@ -1,0 +1,100 @@
+name: Test parse-label-filter
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/test-parse-label-filter.yaml'
+      - '.github/actions/parse-label-filter/**'
+
+permissions:
+  contents: read
+
+jobs:
+  bats:
+    name: Run bats tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
+        with:
+          tests: .github/actions/parse-label-filter/test
+
+  composite-smoke:
+    name: Composite smoke (parse + skip decision)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Parse a label-filter block
+        id: parse
+        uses: ./.github/actions/parse-label-filter
+        with:
+          event-name: pull_request
+          event-action: opened
+          pr-body: |
+            Some description.
+
+            ```label-filter
+            db-datasource && aws
+            ```
+
+      - name: Verify parsed filter, no skip
+        env:
+          LABEL_FILTER: ${{ steps.parse.outputs.label-filter }}
+          SKIP_EDITED: ${{ steps.parse.outputs.skip-edited }}
+        run: |
+          echo "label-filter=$LABEL_FILTER skip-edited=$SKIP_EDITED"
+          [[ "$LABEL_FILTER" == "db-datasource && aws" ]]
+          [[ "$SKIP_EDITED" == "false" ]]
+
+      - name: Edited event with unchanged filter
+        id: edited-unchanged
+        uses: ./.github/actions/parse-label-filter
+        with:
+          event-name: pull_request
+          event-action: edited
+          pr-body: |
+            Human text. A bot appended a summary.
+
+            ```label-filter
+            pr
+            ```
+          previous-pr-body: |
+            Human text.
+
+            ```label-filter
+            pr
+            ```
+
+      - name: Verify skip-edited=true
+        env:
+          SKIP_EDITED: ${{ steps.edited-unchanged.outputs.skip-edited }}
+        run: |
+          echo "skip-edited=$SKIP_EDITED"
+          [[ "$SKIP_EDITED" == "true" ]]
+
+      - name: Edited event with changed filter
+        id: edited-changed
+        uses: ./.github/actions/parse-label-filter
+        with:
+          event-name: pull_request
+          event-action: edited
+          pr-body: |
+            ```label-filter
+            db-datasource
+            ```
+          previous-pr-body: |
+            ```label-filter
+            pr
+            ```
+
+      - name: Verify skip-edited=false
+        env:
+          SKIP_EDITED: ${{ steps.edited-changed.outputs.skip-edited }}
+        run: |
+          echo "skip-edited=$SKIP_EDITED"
+          [[ "$SKIP_EDITED" == "false" ]]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-semver-validation test-linear-pr-commenter test-release-notification test-linear-release-sync test-aws-test-infra test-cleanup-head-charts test-ci-test-notify test-auto-approve-bot-prs test-ai-pr-review test-ai-step test-publish-helm-chart test-govulncheck test-go-licenses test-run-ginkgo test-sticky-pr-comment test-repository-dispatch build-linear-release-sync lint install-auto-doc generate-docs check-docs help
+.PHONY: test test-semver-validation test-linear-pr-commenter test-release-notification test-linear-release-sync test-aws-test-infra test-cleanup-head-charts test-ci-test-notify test-auto-approve-bot-prs test-ai-pr-review test-ai-step test-publish-helm-chart test-govulncheck test-go-licenses test-run-ginkgo test-sticky-pr-comment test-repository-dispatch test-parse-label-filter build-linear-release-sync lint install-auto-doc generate-docs check-docs help
 
 ACTIONS_DIR := .github/actions
 WORKFLOWS_DIR := .github/workflows
@@ -93,7 +93,7 @@ check-docs: generate-docs ## verify docs are up to date (fails if drift detected
 help: ## show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-30s %s\n", $$1, $$2}'
 
-test: test-semver-validation test-linear-pr-commenter test-release-notification test-linear-release-sync test-aws-test-infra test-cleanup-head-charts test-auto-approve-bot-prs test-ai-pr-review test-ai-step test-ci-test-notify test-go-licenses test-publish-helm-chart test-govulncheck test-run-ginkgo test-sticky-pr-comment test-repository-dispatch ## run all action tests
+test: test-semver-validation test-linear-pr-commenter test-release-notification test-linear-release-sync test-aws-test-infra test-cleanup-head-charts test-auto-approve-bot-prs test-ai-pr-review test-ai-step test-ci-test-notify test-go-licenses test-publish-helm-chart test-govulncheck test-run-ginkgo test-sticky-pr-comment test-repository-dispatch test-parse-label-filter ## run all action tests
 
 test-semver-validation: ## run semver-validation unit tests
 	cd $(ACTIONS_DIR)/semver-validation && npm ci --silent && NODE_OPTIONS=--experimental-vm-modules npx jest --ci --coverage --watchAll=false
@@ -142,6 +142,9 @@ test-sticky-pr-comment: ## run sticky-pr-comment bats tests
 
 test-repository-dispatch: ## run repository-dispatch bats tests
 	bats $(ACTIONS_DIR)/repository-dispatch/test/*.bats
+
+test-parse-label-filter: ## run parse-label-filter bats tests
+	bats $(ACTIONS_DIR)/parse-label-filter/test
 
 build-linear-release-sync: ## build linear-release-sync binary (linux/amd64)
 	cd $(ACTIONS_DIR)/linear-release-sync/src && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-s -w" -o ../linear-release-sync-linux-amd64 .

--- a/README.md
+++ b/README.md
@@ -163,6 +163,64 @@ reports — when that job is skipped via `if:`, the upsert never runs and the
 previous comment stays in place, which is the desired "preserve last real
 result" behavior. See the action README for full details.
 
+### Parse label filter
+
+Parses the ` ```label-filter``` ` fenced block from a PR description, resolves
+the Ginkgo label filter, and decides whether a `pull_request` `edited` event
+can be skipped. E2E workflows trigger on `edited` so editing the label-filter
+re-targets suites without a new commit, but that also re-runs the suite when a
+bot (e.g. `cursor[bot]`) edits the PR description. The action returns
+`skip-edited=true` when the label-filter block is unchanged across an edit, so
+the caller can skip the suite. Side-effect free.
+
+**Location:** `.github/actions/parse-label-filter`
+
+**Usage:**
+
+```yaml
+jobs:
+  parse-label-filter:
+    runs-on: ubuntu-22.04
+    outputs:
+      label-filter: ${{ steps.parse.outputs.label-filter }}
+      skip-edited: ${{ steps.parse.outputs.skip-edited }}
+    steps:
+      - name: Parse label filter
+        id: parse
+        uses: loft-sh/github-actions/.github/actions/parse-label-filter@parse-label-filter/v1
+        with:
+          pr-body: ${{ github.event.pull_request.body }}
+          previous-pr-body: ${{ github.event.changes.body.from }}
+          event-name: ${{ github.event_name }}
+          event-action: ${{ github.event.action }}
+          label-filter-input: ${{ inputs.ginkgo-label }}
+
+  e2e-tests:
+    needs: [parse-label-filter]
+    if: needs.parse-label-filter.outputs.skip-edited != 'true'
+    runs-on: large-8_32
+    steps:
+      - run: echo "filter ${{ needs.parse-label-filter.outputs.label-filter }}"
+```
+
+**Inputs:**
+
+- `pr-body` (optional): current PR description (`${{ github.event.pull_request.body }}`)
+- `previous-pr-body` (optional): PR description before an edit (`${{ github.event.changes.body.from }}`)
+- `event-name` (optional): `${{ github.event_name }}`
+- `event-action` (optional): `${{ github.event.action }}`
+- `label-filter-input` (optional): manual-dispatch fallback (`${{ inputs.ginkgo-label }}`)
+
+**Outputs:**
+
+- `label-filter`: resolved filter (parsed block, else dispatch input, else `pr`)
+- `skip-edited`: `true` only for an `edited` event whose label-filter is unchanged
+
+Pair with a concurrency group that splits edited from code events
+(`...-${{ github.event.action == 'edited' && 'edited' || 'code' }}`) so a bot
+edit cannot cancel a still-running code run and then skip. See the action
+README for full details.
+
 ### Repository Dispatch
 
 Sends a `repository_dispatch` event to a target repository so any source repo


### PR DESCRIPTION
## Summary

Extract the E2E "parse label-filter + skip no-op edited runs" logic into one tested composite action, `parse-label-filter`.

E2E workflows in loft-enterprise (`e2e-ginkgo.yaml`), vcluster (`e2e-oss-ginkgo.yaml`), and vcluster-pro (`e2e.yaml`) all trigger on `pull_request: edited` so editing the ` ```label-filter``` ` block re-targets which suites run without a new commit. The side effect: a bot editing the PR description (e.g. `cursor[bot]`) fires `edited` on the same head SHA with no code change, re-running the whole suite. Each repo solved this by inlining the same ~20-line parse-and-compare shell block into its workflow: duplicated, untested logic in YAML.

## Key Changes

- New `.github/actions/parse-label-filter` composite action:
  - Parses the ` ```label-filter``` ` block from the PR body in pure bash (drops the third-party `actions-ecosystem/action-regex-match` dependency).
  - Resolves `label-filter` (PR block, else manual-dispatch input, else `pr`).
  - Returns `skip-edited=true` only for a `pull_request` `edited` event whose label-filter block is unchanged.
- Logic lives in `src/parse-label-filter.sh` (no logic in YAML), covered by `test/parse-label-filter.bats` (11 cases) and a side-effect-free composite smoke job in `test-parse-label-filter.yaml`.
- README inventory entry added.

## Verification

- `bats` 11/11 pass locally; `shellcheck` clean; `actionlint` clean; `zizmor` no findings on the new files.

## Rollout

- First caller: vcluster-pro `e2e.yaml` (loft-sh/vcluster-pro#1973, DEVOPS-1057), which drops its inline block and calls this action.
- After merge: tag `parse-label-filter/v1` and repin the vcluster-pro caller from the branch ref to the tag.
- Follow-ups: migrate loft-enterprise and vcluster callers to this action (one PR per repo).

References DEVOPS-1057
