### PR TITLE
feat(vcluster-release): add single release dispatcher action

### DIFF
--- a/.github/actions/vcluster-release/README.md
+++ b/.github/actions/vcluster-release/README.md
@@ -15,11 +15,11 @@ monorepo-created OSS release cannot re-trigger the OSS builder.
 
 <!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
 
-|    INPUT     |  TYPE  | REQUIRED | DEFAULT  |                                                           DESCRIPTION                                                            |
-|--------------|--------|----------|----------|----------------------------------------------------------------------------------------------------------------------------------|
-|   dry-run    | string |  false   | `"true"` | When true (default), run the read-only <br>routing checks and print the exact <br>tag + dispatch calls without firing <br>them.  |
-| github-token | string |   true   |          | Token with repo + workflow scope <br>on both loft-sh/vcluster and loft-sh/vcluster-pro (cross-repo tag creation and dispatch).   |
-|   version    | string |   true   |          |                                      Release version to cut, e.g. v0.35.4 <br>or v0.36.2.                                        |
+|    INPUT     |  TYPE  | REQUIRED | DEFAULT  |                                                                                                       DESCRIPTION                                                                                                        |
+|--------------|--------|----------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|   dry-run    | string |  false   | `"true"` | Fail-closed: only an explicit "false" cuts <br>for real. Any other value (the default, a typo, wrong case) <br>runs the read-only routing checks and <br>prints the exact tag + dispatch <br>calls without firing them.  |
+| github-token | string |   true   |          |                                             Token with repo + workflow scope <br>on both loft-sh/vcluster and loft-sh/vcluster-pro (cross-repo tag creation and dispatch).                                               |
+|   version    | string |   true   |          |                                                                                  Release version to cut, e.g. v0.35.4 <br>or v0.36.2.                                                                                    |
 
 <!-- AUTO-DOC-INPUT:END -->
 
@@ -44,6 +44,9 @@ in the monorepo era.
   silent fallback), distinguishing a real 404 from a transient API error.
 - **Dry-run** still performs the read-only checks, so a bad routing decision
   (missing branch, already-released) is caught before anything is dispatched.
+  Dry-run is **fail-closed**: only an explicit `false` cuts for real; any other
+  `dry-run` value (a typo, wrong case, empty) stays in dry-run and warns, so a
+  misconfigured caller cannot accidentally fire a real cross-repo release.
 
 ## Partial-failure recovery
 

--- a/.github/actions/vcluster-release/README.md
+++ b/.github/actions/vcluster-release/README.md
@@ -45,6 +45,23 @@ in the monorepo era.
 - **Dry-run** still performs the read-only checks, so a bad routing decision
   (missing branch, already-released) is caught before anything is dispatched.
 
+## Partial-failure recovery
+
+The legacy path (tag OSS → tag pro → dispatch OSS → dispatch pro) is **not
+atomic**. If a run dies partway, read the log to see how far it got before
+recovering, so an interrupted cut is not mistaken for a genuine double-cut:
+
+- **Failed during tagging** (one repo tagged, the other not, nothing dispatched):
+  delete the orphaned tag and re-run the action. Nothing has been built yet.
+- **Failed after the OSS dispatch** (the log shows the `::notice::` that
+  `loft-sh/vcluster` was dispatched, but the pro dispatch did not run): the OSS
+  build is already in flight. **Do not** delete the tags and re-run this action
+  wholesale (that would dispatch OSS a second time). Instead, dispatch pro only:
+
+  ```bash
+  gh workflow run release.yaml --repo loft-sh/vcluster-pro --ref <version>
+  ```
+
 ## Usage
 
 Consumed by a `workflow_dispatch` workflow on the caller's default branch (the

--- a/.github/actions/vcluster-release/README.md
+++ b/.github/actions/vcluster-release/README.md
@@ -1,0 +1,101 @@
+# Cut vCluster release
+
+Single entry point for cutting a vCluster release on any supported line. The
+version string decides the routing, so nobody has to remember which release
+procedure a given version needs.
+
+The GitHub Release is treated as a pipeline **output**, not a trigger. This
+action only creates the tag(s) and dispatches each line's own `release.yaml` via
+`workflow_dispatch` (`gh workflow run --ref <tag>`, which runs the tagged
+commit's version of the workflow). The dispatched builder creates the release at
+the end of a green build. Because no builder triggers on `release:created`, a
+monorepo-created OSS release cannot re-trigger the OSS builder.
+
+## Inputs
+
+<!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
+
+|    INPUT     |  TYPE  | REQUIRED | DEFAULT  |                                                           DESCRIPTION                                                            |
+|--------------|--------|----------|----------|----------------------------------------------------------------------------------------------------------------------------------|
+|   dry-run    | string |  false   | `"true"` | When true (default), run the read-only <br>routing checks and print the exact <br>tag + dispatch calls without firing <br>them.  |
+| github-token | string |   true   |          | Token with repo + workflow scope <br>on both loft-sh/vcluster and loft-sh/vcluster-pro (cross-repo tag creation and dispatch).   |
+|   version    | string |   true   |          |                                      Release version to cut, e.g. v0.35.4 <br>or v0.36.2.                                        |
+
+<!-- AUTO-DOC-INPUT:END -->
+
+## Routing
+
+Era is decided by a numeric `(major, minor)` compare against the `CUTOVER`
+constant (`v0.36`):
+
+| Era | Versions | Fan-out |
+|-----|----------|---------|
+| legacy | `< v0.36` | Verify the `vX.Y` branch in **both** repos, tag both, dispatch `loft-sh/vcluster` **first**, then `loft-sh/vcluster-pro`. |
+| monorepo | `>= v0.36` | Resolve target (`vX.Y` line branch if it exists, else `main`), dispatch `loft-sh/vcluster-pro` only. |
+
+Numeric compare matters: `v0.9` sorts *below* `v0.36` (legacy), and `v1.0` lands
+in the monorepo era.
+
+## Guards
+
+- **Double-cut:** fails if the tag or a release for `version` already exists in a
+  target repo.
+- **Unprepared line:** fails loudly if a required `vX.Y` branch is absent (no
+  silent fallback), distinguishing a real 404 from a transient API error.
+- **Dry-run** still performs the read-only checks, so a bad routing decision
+  (missing branch, already-released) is caught before anything is dispatched.
+
+## Usage
+
+Consumed by a `workflow_dispatch` workflow on the caller's default branch (the
+single canonical release button):
+
+```yaml
+name: Cut release
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version to cut (e.g. v0.35.4 or v0.36.2)"
+        type: string
+        required: true
+      dry_run:
+        description: "Print the routing decision and exact calls without firing them"
+        type: boolean
+        required: true
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  vcluster-release:
+    if: ${{ github.repository_owner == 'loft-sh' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: loft-sh/github-actions/.github/actions/vcluster-release@vcluster-release/v1
+        with:
+          version: ${{ inputs.version }}
+          dry-run: ${{ inputs.dry_run }}
+          github-token: ${{ secrets.GH_ACCESS_TOKEN }}
+```
+
+### Auth
+
+`github-token` must be a Personal Access Token or GitHub App token with `repo` +
+`workflow` scope on **both** `loft-sh/vcluster` and `loft-sh/vcluster-pro`
+(cross-repo tag creation and dispatch). `secrets.GITHUB_TOKEN` cannot dispatch
+into other repos.
+
+## Testing
+
+```bash
+make test-vcluster-release
+```
+
+Runs the bats suite in `test/` against `src/vcluster-release.sh` with a configurable
+`gh` stub on `PATH` (no real API calls). The stub mirrors real `gh` behaviour,
+including exiting non-zero on a 404.

--- a/.github/actions/vcluster-release/README.md
+++ b/.github/actions/vcluster-release/README.md
@@ -39,7 +39,9 @@ in the monorepo era.
 ## Guards
 
 - **Double-cut:** fails if the tag or a release for `version` already exists in a
-  target repo.
+  target repo. The tag lookup is an exact match (a prerelease like `v0.35.4-rc.1`
+  does not block the final `v0.35.4`), and like the branch check it distinguishes
+  a real 404 from a transient API error rather than silently skipping the guard.
 - **Unprepared line:** fails loudly if a required `vX.Y` branch is absent (no
   silent fallback), distinguishing a real 404 from a transient API error.
 - **Dry-run** still performs the read-only checks, so a bad routing decision

--- a/.github/actions/vcluster-release/action.yml
+++ b/.github/actions/vcluster-release/action.yml
@@ -14,7 +14,7 @@ inputs:
     description: 'Release version to cut, e.g. v0.35.4 or v0.36.2.'
     required: true
   dry-run:
-    description: 'When true (default), run the read-only routing checks and print the exact tag + dispatch calls without firing them.'
+    description: 'Fail-closed: only an explicit "false" cuts for real. Any other value (the default, a typo, wrong case) runs the read-only routing checks and prints the exact tag + dispatch calls without firing them.'
     required: false
     default: 'true'
   github-token:

--- a/.github/actions/vcluster-release/action.yml
+++ b/.github/actions/vcluster-release/action.yml
@@ -1,0 +1,39 @@
+name: Cut vCluster release
+description: |
+  Single entry point for cutting a vCluster release on any supported line. The
+  version string decides the routing, so nobody has to remember which release
+  procedure a given version needs. Classifies the era by numeric compare against
+  the cutover (v0.36), then creates the tag(s) and dispatches each line's own
+  release.yaml via workflow_dispatch (gh workflow run --ref <tag>, which runs the
+  tagged commit's version of the workflow). Legacy lines (< v0.36) fan out to
+  both loft-sh/vcluster and loft-sh/vcluster-pro (OSS first); monorepo lines
+  (>= v0.36) dispatch loft-sh/vcluster-pro only. The GitHub Release is a pipeline
+  output, so nothing here triggers a downstream release:created build.
+inputs:
+  version:
+    description: 'Release version to cut, e.g. v0.35.4 or v0.36.2.'
+    required: true
+  dry-run:
+    description: 'When true (default), run the read-only routing checks and print the exact tag + dispatch calls without firing them.'
+    required: false
+    default: 'true'
+  github-token:
+    description: 'Token with repo + workflow scope on both loft-sh/vcluster and loft-sh/vcluster-pro (cross-repo tag creation and dispatch).'
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Validate version
+      uses: loft-sh/github-actions/.github/actions/semver-validation@6b5890feaccd82f7c0999ccf10a425cd0844dee0 # semver-validation/v1
+      with:
+        version: ${{ inputs.version }}
+    - name: Cut release
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        INPUT_VERSION: ${{ inputs.version }}
+        INPUT_DRY_RUN: ${{ inputs.dry-run }}
+      run: ${{ github.action_path }}/src/vcluster-release.sh
+branding:
+  icon: 'tag'
+  color: 'orange'

--- a/.github/actions/vcluster-release/src/vcluster-release.sh
+++ b/.github/actions/vcluster-release/src/vcluster-release.sh
@@ -200,8 +200,21 @@ cut_monorepo() {
 }
 
 main() {
-  local version="${INPUT_VERSION:?INPUT_VERSION is required}" era line
-  export DRY_RUN="${INPUT_DRY_RUN:-true}"
+  local version="${INPUT_VERSION:?INPUT_VERSION is required}" era line raw_dry_run
+  # Fail closed: only an explicit, unambiguous "false" cuts for real. Any other
+  # value (empty, typo, "yes", "1", wrong case, stray whitespace) stays in
+  # dry-run, so a misconfigured caller can never accidentally fire a real
+  # cross-repo release.
+  raw_dry_run="${INPUT_DRY_RUN:-true}"
+  case "${raw_dry_run,,}" in
+    false) DRY_RUN="false" ;;
+    true)  DRY_RUN="true" ;;
+    *)
+      echo "::warning::unrecognized dry-run value '${raw_dry_run}'; defaulting to dry-run (no mutations). Pass exactly 'false' to cut for real." >&2
+      DRY_RUN="true"
+      ;;
+  esac
+  export DRY_RUN
   echo "vcluster-release: version=${version} dry_run=${DRY_RUN} cutover=${CUTOVER}"
 
   era="$(classify_era "$version")"

--- a/.github/actions/vcluster-release/src/vcluster-release.sh
+++ b/.github/actions/vcluster-release/src/vcluster-release.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# Single release dispatcher (DEVOPS-1050).
+#
+# One entry point for cutting a release on any supported line. The version
+# string decides the routing; nobody has to remember which era a version is in.
+#
+# The GitHub Release is treated as a pipeline *output*, not a trigger: this
+# script only creates the tag(s) and dispatches each line's own release.yaml via
+# `gh workflow run --ref <tag>` (verified to run the tag's version of the
+# workflow). The dispatched builder creates the release at the end of a green
+# build. Nothing triggers on `release:created`, so a monorepo-created OSS release
+# cannot re-trigger the OSS builder.
+#
+# Routing by numeric (major, minor) compare against CUTOVER (v0.36):
+#   legacy   (< v0.36) -> verify the vX.Y branch in BOTH repos, tag both, then
+#                         dispatch loft-sh/vcluster FIRST, then loft-sh/vcluster-pro.
+#   monorepo (>= v0.36) -> resolve target (line branch vX.Y if it exists, else
+#                         main), tag it, dispatch loft-sh/vcluster-pro only.
+#
+# dry_run (default true) performs the read-only checks (branch existence,
+# double-cut guard) so the printed routing decision is validated, but prints the
+# mutating tag/dispatch calls instead of firing them.
+set -euo pipefail
+
+CUTOVER="${CUTOVER:-v0.36}"
+OSS_REPO="${OSS_REPO:-loft-sh/vcluster}"
+PRO_REPO="${PRO_REPO:-loft-sh/vcluster-pro}"
+WORKFLOW="${WORKFLOW:-release.yaml}"
+
+# ---------------------------------------------------------------------------
+# Pure helpers (no network) - the routing brain, exhaustively unit-tested.
+# ---------------------------------------------------------------------------
+
+# parse_major_minor <version> -> "MAJOR MINOR"
+# Accepts v-prefixed or bare, with or without patch/prerelease:
+#   v0.35.4-rc.1 -> "0 35", v1.0 -> "1 0". Fails loudly on garbage.
+parse_major_minor() {
+  local v="${1#v}" major minor rest
+  major="${v%%.*}"
+  rest="${v#*.}"
+  minor="${rest%%.*}"
+  # Trim any non-numeric suffix on the minor (e.g. "36-rc.1" -> "36").
+  minor="${minor%%[!0-9]*}"
+  if [[ ! "$major" =~ ^[0-9]+$ || ! "$minor" =~ ^[0-9]+$ ]]; then
+    echo "::error::cannot parse major.minor from version '$1'" >&2
+    return 1
+  fi
+  printf '%s %s\n' "$major" "$minor"
+}
+
+# derive_line <version> -> vX.Y
+derive_line() {
+  local mm major minor
+  mm="$(parse_major_minor "$1")" || return 1
+  read -r major minor <<<"$mm"
+  printf 'v%s.%s\n' "$major" "$minor"
+}
+
+# classify_era <version> [cutover] -> "legacy" | "monorepo"
+# (major, minor) >= (cutover major, minor) is monorepo; anything below is legacy.
+classify_era() {
+  local version="$1" cutover="${2:-$CUTOVER}" vmm cmm vmaj vmin cmaj cmin
+  vmm="$(parse_major_minor "$version")" || return 1
+  cmm="$(parse_major_minor "$cutover")" || return 1
+  read -r vmaj vmin <<<"$vmm"
+  read -r cmaj cmin <<<"$cmm"
+  if (( vmaj > cmaj || (vmaj == cmaj && vmin >= cmin) )); then
+    printf 'monorepo\n'
+  else
+    printf 'legacy\n'
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Network helpers. Read-only ones always run (they validate the routing, even
+# in dry-run). Mutating ones honour DRY_RUN.
+# ---------------------------------------------------------------------------
+
+# branch_exists <repo> <branch> -> 0 if 200, 1 if 404, exits 1 on transient error.
+# Read only the HTTP status line. On a 404 `gh` exits non-zero, so we must
+# capture its output with `|| true` BEFORE parsing - piping gh directly into the
+# status-substitution would let pipefail propagate the non-zero exit and clobber
+# the code to empty, misreading a real 404 as a transient failure. gh writes the
+# "HTTP/2.0 404" status line to stdout even with --silent (only the body is
+# suppressed); a genuine transient error (DNS/auth/rate-limit) yields no status
+# line, so an empty code correctly means "could not reach the API".
+branch_exists() {
+  local repo="$1" branch="$2" headers http_code
+  headers="$(gh api "repos/${repo}/branches/${branch}" --silent -i 2>/dev/null || true)"
+  http_code="$(printf '%s\n' "$headers" | head -1 | awk '{print $2}')"
+  case "$http_code" in
+    200) return 0 ;;
+    404) return 1 ;;
+    "")
+      echo "::error::failed to reach ${repo} branches API for '${branch}' (no HTTP status - DNS, rate-limit, or auth). Not treating as missing." >&2
+      exit 1
+      ;;
+    *)
+      echo "::error::unexpected status ${http_code} from ${repo} branches API for '${branch}'." >&2
+      exit 1
+      ;;
+  esac
+}
+
+# require_branch <repo> <branch> - hard error if the branch is absent.
+require_branch() {
+  local repo="$1" branch="$2"
+  if ! branch_exists "$repo" "$branch"; then
+    echo "::error::release branch '${branch}' not found in ${repo}. Create it (and its workflow_dispatch-enabled release.yaml) before cutting this line - refusing to guess." >&2
+    exit 1
+  fi
+}
+
+# guard_not_released <repo> <tag> - double-cut guard. A pre-existing tag or
+# release for this version is a hard error: releases are cut once.
+guard_not_released() {
+  local repo="$1" tag="$2"
+  if gh release view "$tag" --repo "$repo" >/dev/null 2>&1; then
+    echo "::error::release ${tag} already exists in ${repo}. Refusing to re-cut (double-cut guard)." >&2
+    exit 1
+  fi
+  if gh api "repos/${repo}/git/refs/tags/${tag}" >/dev/null 2>&1; then
+    echo "::error::tag ${tag} already exists in ${repo}. Delete it to re-cut, or bump the version." >&2
+    exit 1
+  fi
+}
+
+# create_tag <repo> <branch> <tag> - tag the branch head. Inert w.r.t. release
+# workflows (they trigger on workflow_dispatch, not tag push).
+create_tag() {
+  local repo="$1" branch="$2" tag="$3" sha
+  if [[ "${DRY_RUN:-true}" == "true" ]]; then
+    echo "[dry-run] gh api -X POST repos/${repo}/git/refs -f ref=refs/tags/${tag} -f sha=<${branch} head>"
+    return 0
+  fi
+  sha="$(gh api "repos/${repo}/git/refs/heads/${branch}" --jq '.object.sha')"
+  gh api -X POST "repos/${repo}/git/refs" -f ref="refs/tags/${tag}" -f sha="${sha}" >/dev/null
+  echo "created tag ${tag} in ${repo} at ${branch} (${sha})"
+}
+
+# dispatch <repo> <tag> - run that ref's release.yaml. --ref <tag> executes the
+# tagged commit's version of the workflow (verified in sandbox).
+dispatch() {
+  local repo="$1" tag="$2"
+  if [[ "${DRY_RUN:-true}" == "true" ]]; then
+    echo "[dry-run] gh workflow run ${WORKFLOW} --repo ${repo} --ref ${tag}"
+    return 0
+  fi
+  gh workflow run "${WORKFLOW}" --repo "${repo}" --ref "${tag}"
+  echo "dispatched ${WORKFLOW} in ${repo} at ${tag}"
+}
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+
+cut_legacy() {
+  local version="$1" line="$2"
+  echo "Routing ${version} -> legacy (line ${line}); dispatch order: ${OSS_REPO} then ${PRO_REPO}"
+  # Both repos must be ready before we mutate anything.
+  require_branch "$OSS_REPO" "$line"
+  require_branch "$PRO_REPO" "$line"
+  guard_not_released "$OSS_REPO" "$version"
+  guard_not_released "$PRO_REPO" "$version"
+  # Tag both, then dispatch OSS first so the OSS release exists for pro's
+  # standalone upload (pro's builder still waits/retries for it).
+  create_tag "$OSS_REPO" "$line" "$version"
+  create_tag "$PRO_REPO" "$line" "$version"
+  dispatch "$OSS_REPO" "$version"
+  dispatch "$PRO_REPO" "$version"
+}
+
+cut_monorepo() {
+  local version="$1" line="$2" target
+  if branch_exists "$PRO_REPO" "$line"; then
+    target="$line"
+  else
+    target="main"
+  fi
+  echo "Routing ${version} -> monorepo (line ${line}, target ${target}); dispatch: ${PRO_REPO} only"
+  guard_not_released "$PRO_REPO" "$version"
+  create_tag "$PRO_REPO" "$target" "$version"
+  dispatch "$PRO_REPO" "$version"
+}
+
+main() {
+  local version="${INPUT_VERSION:?INPUT_VERSION is required}" era line
+  export DRY_RUN="${INPUT_DRY_RUN:-true}"
+  echo "vcluster-release: version=${version} dry_run=${DRY_RUN} cutover=${CUTOVER}"
+
+  era="$(classify_era "$version")"
+  line="$(derive_line "$version")"
+
+  case "$era" in
+    legacy)   cut_legacy "$version" "$line" ;;
+    monorepo) cut_monorepo "$version" "$line" ;;
+    *)        echo "::error::unknown era '${era}'" >&2; exit 1 ;;
+  esac
+}
+
+# Only auto-run when executed directly; sourcing (e.g. from bats) must not.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/.github/actions/vcluster-release/src/vcluster-release.sh
+++ b/.github/actions/vcluster-release/src/vcluster-release.sh
@@ -133,7 +133,15 @@ create_tag() {
     echo "[dry-run] gh api -X POST repos/${repo}/git/refs -f ref=refs/tags/${tag} -f sha=<${branch} head>"
     return 0
   fi
-  sha="$(gh api "repos/${repo}/git/refs/heads/${branch}" --jq '.object.sha')"
+  # `.object.sha // empty` guards the jq null-string hazard: on an unexpected
+  # ref-response shape jq would otherwise print the literal "null" and exit 0
+  # (set -e does not catch it), producing a GitHub 422 "Invalid SHA" instead of
+  # a meaningful diagnostic.
+  sha="$(gh api "repos/${repo}/git/refs/heads/${branch}" --jq '.object.sha // empty')"
+  if [[ -z "$sha" ]]; then
+    echo "::error::could not resolve HEAD sha for branch '${branch}' in ${repo}" >&2
+    exit 1
+  fi
   gh api -X POST "repos/${repo}/git/refs" -f ref="refs/tags/${tag}" -f sha="${sha}" >/dev/null
   echo "created tag ${tag} in ${repo} at ${branch} (${sha})"
 }
@@ -167,6 +175,14 @@ cut_legacy() {
   create_tag "$OSS_REPO" "$line" "$version"
   create_tag "$PRO_REPO" "$line" "$version"
   dispatch "$OSS_REPO" "$version"
+  # OSS is now building. This sequence is non-atomic: if the pro dispatch below
+  # fails, the correct recovery is to dispatch pro ONLY. Deleting the tags and
+  # re-running this action would re-dispatch (and rebuild) OSS. Emit the true
+  # progress state so a partial failure is diagnosable from the run log rather
+  # than misread as a plain double-cut. See README > Partial-failure recovery.
+  if [[ "${DRY_RUN:-true}" != "true" ]]; then
+    echo "::notice::${OSS_REPO} dispatched for ${version}. If the ${PRO_REPO} dispatch below fails, recover by dispatching ${PRO_REPO} only - do NOT delete tags and re-run this action (that re-dispatches OSS)."
+  fi
   dispatch "$PRO_REPO" "$version"
 }
 

--- a/.github/actions/vcluster-release/src/vcluster-release.sh
+++ b/.github/actions/vcluster-release/src/vcluster-release.sh
@@ -76,30 +76,38 @@ classify_era() {
 # in dry-run). Mutating ones honour DRY_RUN.
 # ---------------------------------------------------------------------------
 
-# branch_exists <repo> <branch> -> 0 if 200, 1 if 404, exits 1 on transient error.
-# Read only the HTTP status line. On a 404 `gh` exits non-zero, so we must
-# capture its output with `|| true` BEFORE parsing - piping gh directly into the
-# status-substitution would let pipefail propagate the non-zero exit and clobber
-# the code to empty, misreading a real 404 as a transient failure. gh writes the
-# "HTTP/2.0 404" status line to stdout even with --silent (only the body is
-# suppressed); a genuine transient error (DNS/auth/rate-limit) yields no status
-# line, so an empty code correctly means "could not reach the API".
-branch_exists() {
-  local repo="$1" branch="$2" headers http_code
-  headers="$(gh api "repos/${repo}/branches/${branch}" --silent -i 2>/dev/null || true)"
+# api_exists <path> <what> -> 0 if 200, 1 if 404, exits 1 on transient/unexpected.
+# Shared read-only existence probe. Read only the HTTP status line. On a 404 `gh`
+# exits non-zero, so we must capture its output with `|| true` BEFORE parsing -
+# piping gh directly into the status-substitution would let pipefail propagate the
+# non-zero exit and clobber the code to empty, misreading a real 404 as a transient
+# failure. gh writes the "HTTP/2.0 404" status line to stdout even with --silent
+# (only the body is suppressed); a genuine transient error (DNS/auth/rate-limit)
+# yields no status line, so an empty code correctly means "could not reach the API".
+# Distinguishing the two matters to every caller: an unreachable API must never be
+# silently read as "absent" (a missed double-cut guard) or "missing" (a wrong branch).
+api_exists() {
+  local path="$1" what="$2" headers http_code
+  headers="$(gh api "$path" --silent -i 2>/dev/null || true)"
   http_code="$(printf '%s\n' "$headers" | head -1 | awk '{print $2}')"
   case "$http_code" in
     200) return 0 ;;
     404) return 1 ;;
     "")
-      echo "::error::failed to reach ${repo} branches API for '${branch}' (no HTTP status - DNS, rate-limit, or auth). Not treating as missing." >&2
+      echo "::error::failed to reach GitHub API for ${what} (no HTTP status - DNS, rate-limit, or auth). Not treating as absent." >&2
       exit 1
       ;;
     *)
-      echo "::error::unexpected status ${http_code} from ${repo} branches API for '${branch}'." >&2
+      echo "::error::unexpected status ${http_code} from GitHub API for ${what}." >&2
       exit 1
       ;;
   esac
+}
+
+# branch_exists <repo> <branch> -> 0 if 200, 1 if 404, exits 1 on transient error.
+branch_exists() {
+  local repo="$1" branch="$2"
+  api_exists "repos/${repo}/branches/${branch}" "branch '${branch}' in ${repo}"
 }
 
 # require_branch <repo> <branch> - hard error if the branch is absent.
@@ -115,11 +123,17 @@ require_branch() {
 # release for this version is a hard error: releases are cut once.
 guard_not_released() {
   local repo="$1" tag="$2"
-  if gh release view "$tag" --repo "$repo" >/dev/null 2>&1; then
+  # Both probes go through api_exists, so a transient API failure (rate-limit /
+  # auth / DNS) aborts loudly instead of being misread as "not released" - which
+  # would silently skip the double-cut guard.
+  if api_exists "repos/${repo}/releases/tags/${tag}" "release ${tag} in ${repo}"; then
     echo "::error::release ${tag} already exists in ${repo}. Refusing to re-cut (double-cut guard)." >&2
     exit 1
   fi
-  if gh api "repos/${repo}/git/refs/tags/${tag}" >/dev/null 2>&1; then
+  # Singular `git/ref/tags/` requires an exact match (404s otherwise). The plural
+  # `git/refs/tags/` prefix-matches, so it would report `v0.35.4` as existing when
+  # only `v0.35.4-rc.1` had been tagged - a false double-cut on the final release.
+  if api_exists "repos/${repo}/git/ref/tags/${tag}" "tag ${tag} in ${repo}"; then
     echo "::error::tag ${tag} already exists in ${repo}. Delete it to re-cut, or bump the version." >&2
     exit 1
   fi

--- a/.github/actions/vcluster-release/test/vcluster-release.bats
+++ b/.github/actions/vcluster-release/test/vcluster-release.bats
@@ -24,7 +24,10 @@ teardown() {
 #   GH_STUB_RELEASES="loft-sh/vcluster:v0.35.4"
 #   GH_STUB_TAGS="loft-sh/vcluster-pro:v0.35.4"
 # Anything not listed 404s / is absent. POST refs, refs/heads sha lookups and
-# `workflow run` succeed (only reached in non-dry-run tests).
+# `workflow run` succeed (only reached in non-dry-run tests). GH_STUB_TRANSIENT /
+# GH_STUB_UNEXPECTED simulate API failures on every probe; GH_STUB_TRANSIENT_TAGS
+# scopes a transient failure to the double-cut probes only (branch check still
+# passes), to exercise guard_not_released's transient handling in isolation.
 install_gh_stub() {
   cat >"${STUB_DIR}/gh" <<'EOF'
 #!/usr/bin/env bash
@@ -35,31 +38,45 @@ contains() { case " $1 " in *" $2 "*) return 0 ;; *) return 1 ;; esac; }
 
 if [[ "$sub" == "api" ]]; then
   path="$1"
+  # emit_status <present:0|1> <scope> - print an HTTP status line and exit like
+  # real gh. Real gh prints the status line to stdout for 200 AND 404, but exits
+  # non-zero on 404. GH_STUB_TRANSIENT=1 simulates a network/auth failure (no
+  # status line, non-zero exit) on every probe. GH_STUB_TRANSIENT_TAGS=1 scopes
+  # that same failure to the double-cut probes only (scope=tags), so a test can
+  # let the branch check pass and still exercise the guard's transient handling.
+  # GH_STUB_UNEXPECTED=1 simulates an unexpected status (403/500) that is neither
+  # 200 nor 404 - it must abort, not fall back.
+  emit_status() {
+    if [[ "${GH_STUB_TRANSIENT:-}" == "1" ]]; then exit 1; fi
+    if [[ "$2" == "tags" && "${GH_STUB_TRANSIENT_TAGS:-}" == "1" ]]; then exit 1; fi
+    if [[ "${GH_STUB_UNEXPECTED:-}" == "1" ]]; then echo "HTTP/2.0 403 Forbidden"; exit 1; fi
+    if [[ "$1" == "0" ]]; then echo "HTTP/2.0 200 OK"; exit 0; else echo "HTTP/2.0 404 Not Found"; exit 1; fi
+  }
   case "$path" in
     repos/*/branches/*)
       rest="${path#repos/}"; repo="${rest%%/branches/*}"; branch="${rest##*/branches/}"
-      # Real gh: prints the status line to stdout for both, but exits non-zero on
-      # 404. GH_STUB_TRANSIENT=1 simulates a network/auth failure (no status line,
-      # non-zero exit). GH_STUB_UNEXPECTED=1 simulates an unexpected HTTP status
-      # (e.g. 403/500) that is neither 200 nor 404 - it must abort, not fall back.
-      if [[ "${GH_STUB_TRANSIENT:-}" == "1" ]]; then exit 1; fi
-      if [[ "${GH_STUB_UNEXPECTED:-}" == "1" ]]; then echo "HTTP/2.0 403 Forbidden"; exit 1; fi
-      if contains "${GH_STUB_BRANCHES:-}" "${repo}:${branch}"; then echo "HTTP/2.0 200 OK"; exit 0; else echo "HTTP/2.0 404 Not Found"; exit 1; fi ;;
+      contains "${GH_STUB_BRANCHES:-}" "${repo}:${branch}" && emit_status 0 branches || emit_status 1 branches ;;
+    repos/*/releases/tags/*)
+      rest="${path#repos/}"; repo="${rest%%/releases/tags/*}"; tag="${rest##*/releases/tags/}"
+      contains "${GH_STUB_RELEASES:-}" "${repo}:${tag}" && emit_status 0 tags || emit_status 1 tags ;;
+    repos/*/git/ref/tags/*)
+      # Singular endpoint: exact match, 404 otherwise (mirrors the real API).
+      rest="${path#repos/}"; repo="${rest%%/git/ref/tags/*}"; tag="${rest##*/git/ref/tags/}"
+      contains "${GH_STUB_TAGS:-}" "${repo}:${tag}" && emit_status 0 tags || emit_status 1 tags ;;
     repos/*/git/refs/tags/*)
+      # Plural endpoint: prefix match (mirrors the real API). Kept so a regression
+      # from the singular exact-match endpoint trips the false-double-cut test.
       rest="${path#repos/}"; repo="${rest%%/git/refs/tags/*}"; tag="${rest##*/git/refs/tags/}"
-      contains "${GH_STUB_TAGS:-}" "${repo}:${tag}" && exit 0 || exit 1 ;;
+      for entry in ${GH_STUB_TAGS:-}; do
+        [[ "${entry%%:*}" == "$repo" && "${entry#*:}" == "${tag}"* ]] && emit_status 0 tags
+      done
+      emit_status 1 tags ;;
     repos/*/git/refs/heads/*)
       echo "deadbeefcafe"; exit 0 ;;
     *)
       # POST repos/<repo>/git/refs and anything else: succeed.
       exit 0 ;;
   esac
-fi
-
-if [[ "$sub" == "release" && "${1:-}" == "view" ]]; then
-  tag="$2"; repo=""
-  while [[ $# -gt 0 ]]; do [[ "$1" == "--repo" ]] && repo="$2"; shift; done
-  contains "${GH_STUB_RELEASES:-}" "${repo}:${tag}" && exit 0 || exit 1
 fi
 
 if [[ "$sub" == "workflow" && "${1:-}" == "run" ]]; then exit 0; fi
@@ -206,6 +223,27 @@ EOF
   INPUT_VERSION="v0.35.4" INPUT_DRY_RUN="true" run main
   [ "$status" -ne 0 ]
   [[ "$output" == *"tag v0.35.4 already exists"* ]]
+}
+
+@test "guard: a transient failure on the double-cut probe aborts loudly (not read as not-released)" {
+  # The branch check passes; only the guard's release/tag probe transient-fails.
+  # guard_not_released must abort, not silently treat the API error as "absent".
+  export GH_STUB_BRANCHES="loft-sh/vcluster-pro:v0.36"
+  export GH_STUB_TRANSIENT_TAGS="1"
+  INPUT_VERSION="v0.36.2" INPUT_DRY_RUN="true" run main
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"failed to reach"* ]]
+}
+
+@test "legacy: a prerelease tag does not trip the final release's double-cut guard" {
+  # v0.35.4-rc.1 is tagged; cutting the final v0.35.4 must NOT be seen as an
+  # existing tag. The singular git/ref/tags/ endpoint exact-matches; a regression
+  # to the plural prefix-matching endpoint would falsely trip the guard here.
+  export GH_STUB_BRANCHES="loft-sh/vcluster:v0.35 loft-sh/vcluster-pro:v0.35"
+  export GH_STUB_TAGS="loft-sh/vcluster:v0.35.4-rc.1 loft-sh/vcluster-pro:v0.35.4-rc.1"
+  INPUT_VERSION="v0.35.4" INPUT_DRY_RUN="true" run main
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"already exists"* ]]
 }
 
 # ---- main: monorepo flow (dry-run) ----

--- a/.github/actions/vcluster-release/test/vcluster-release.bats
+++ b/.github/actions/vcluster-release/test/vcluster-release.bats
@@ -281,6 +281,26 @@ EOF
   [[ "$output" != *"in loft-sh/vcluster "* ]]
 }
 
+@test "dry-run fail-closed: an unrecognized value stays dry (no mutation), warns" {
+  # 'yes' is neither 'true' nor 'false' - must NOT be read as "cut for real".
+  export GH_STUB_BRANCHES="loft-sh/vcluster:v0.35 loft-sh/vcluster-pro:v0.35"
+  INPUT_VERSION="v0.35.4" INPUT_DRY_RUN="yes" run main
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"unrecognized dry-run value"* ]]
+  [[ "$output" == *"dry_run=true"* ]]
+  [[ "$output" == *"[dry-run]"* ]]
+  [[ "$output" != *"dispatched release.yaml"* ]]
+}
+
+@test "dry-run fail-closed: only an explicit false cuts for real (case-insensitive)" {
+  export GH_STUB_BRANCHES="loft-sh/vcluster:v0.35 loft-sh/vcluster-pro:v0.35"
+  INPUT_VERSION="v0.35.4" INPUT_DRY_RUN="False" run main
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"dry_run=false"* ]]
+  [[ "$output" == *"dispatched release.yaml"* ]]
+  [[ "$output" != *"[dry-run]"* ]]
+}
+
 @test "monorepo: an unexpected HTTP status (403/500) aborts loudly (not read as missing)" {
   # The *) arm of branch_exists: neither 200 nor 404 must hard-fail, never fall
   # back to main.

--- a/.github/actions/vcluster-release/test/vcluster-release.bats
+++ b/.github/actions/vcluster-release/test/vcluster-release.bats
@@ -40,8 +40,10 @@ if [[ "$sub" == "api" ]]; then
       rest="${path#repos/}"; repo="${rest%%/branches/*}"; branch="${rest##*/branches/}"
       # Real gh: prints the status line to stdout for both, but exits non-zero on
       # 404. GH_STUB_TRANSIENT=1 simulates a network/auth failure (no status line,
-      # non-zero exit).
+      # non-zero exit). GH_STUB_UNEXPECTED=1 simulates an unexpected HTTP status
+      # (e.g. 403/500) that is neither 200 nor 404 - it must abort, not fall back.
       if [[ "${GH_STUB_TRANSIENT:-}" == "1" ]]; then exit 1; fi
+      if [[ "${GH_STUB_UNEXPECTED:-}" == "1" ]]; then echo "HTTP/2.0 403 Forbidden"; exit 1; fi
       if contains "${GH_STUB_BRANCHES:-}" "${repo}:${branch}"; then echo "HTTP/2.0 200 OK"; exit 0; else echo "HTTP/2.0 404 Not Found"; exit 1; fi ;;
     repos/*/git/refs/tags/*)
       rest="${path#repos/}"; repo="${rest%%/git/refs/tags/*}"; tag="${rest##*/git/refs/tags/}"
@@ -171,6 +173,13 @@ EOF
   oss_line=$(printf '%s\n' "$output" | grep -n 'gh workflow run release.yaml --repo loft-sh/vcluster ' | head -1 | cut -d: -f1)
   pro_line=$(printf '%s\n' "$output" | grep -n 'gh workflow run release.yaml --repo loft-sh/vcluster-pro ' | head -1 | cut -d: -f1)
   [ -n "$oss_line" ] && [ -n "$pro_line" ] && [ "$oss_line" -lt "$pro_line" ]
+  # Both repos are tagged, and the tag-before-dispatch invariant holds: each
+  # tag POST must precede the first dispatch line.
+  oss_tag=$(printf '%s\n' "$output" | grep -n 'POST repos/loft-sh/vcluster/git/refs ' | head -1 | cut -d: -f1)
+  pro_tag=$(printf '%s\n' "$output" | grep -n 'POST repos/loft-sh/vcluster-pro/git/refs ' | head -1 | cut -d: -f1)
+  [ -n "$oss_tag" ] && [ -n "$pro_tag" ]
+  [ "$oss_tag" -lt "$oss_line" ]
+  [ "$pro_tag" -lt "$oss_line" ]
   # Dry-run only: never actually dispatched.
   [[ "$output" != *"dispatched release.yaml"* ]]
 }
@@ -243,4 +252,40 @@ EOF
   run main
   [ "$status" -ne 0 ]
   [[ "$output" == *"INPUT_VERSION is required"* ]]
+}
+
+# ---- main: live (non-dry-run) path ----
+
+@test "legacy non-dry-run: reaches the mutating path (real tag + dispatch), emits recovery notice" {
+  export GH_STUB_BRANCHES="loft-sh/vcluster:v0.35 loft-sh/vcluster-pro:v0.35"
+  INPUT_VERSION="v0.35.4" INPUT_DRY_RUN="false" run main
+  [ "$status" -eq 0 ]
+  # The mutating branches ran, not the dry-run prints.
+  [[ "$output" == *"created tag v0.35.4 in loft-sh/vcluster "* ]]
+  [[ "$output" == *"created tag v0.35.4 in loft-sh/vcluster-pro "* ]]
+  [[ "$output" == *"dispatched release.yaml in loft-sh/vcluster "* ]]
+  [[ "$output" == *"dispatched release.yaml in loft-sh/vcluster-pro "* ]]
+  [[ "$output" != *"[dry-run]"* ]]
+  # Partial-failure recovery hint fires only on the live path.
+  [[ "$output" == *"do NOT delete tags and re-run this action"* ]]
+}
+
+@test "monorepo non-dry-run: reaches the mutating pro-only path" {
+  export GH_STUB_BRANCHES="loft-sh/vcluster-pro:v0.36"
+  INPUT_VERSION="v0.36.2" INPUT_DRY_RUN="false" run main
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"created tag v0.36.2 in loft-sh/vcluster-pro "* ]]
+  [[ "$output" == *"dispatched release.yaml in loft-sh/vcluster-pro "* ]]
+  [[ "$output" != *"[dry-run]"* ]]
+  # No OSS mutation on the monorepo path.
+  [[ "$output" != *"in loft-sh/vcluster "* ]]
+}
+
+@test "monorepo: an unexpected HTTP status (403/500) aborts loudly (not read as missing)" {
+  # The *) arm of branch_exists: neither 200 nor 404 must hard-fail, never fall
+  # back to main.
+  export GH_STUB_UNEXPECTED="1"
+  INPUT_VERSION="v0.36.0" INPUT_DRY_RUN="true" run main
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"unexpected status"* ]]
 }

--- a/.github/actions/vcluster-release/test/vcluster-release.bats
+++ b/.github/actions/vcluster-release/test/vcluster-release.bats
@@ -1,0 +1,246 @@
+#!/usr/bin/env bats
+# Tests for vcluster-release.sh
+#
+# The routing helpers (parse_major_minor / derive_line / classify_era) are pure
+# and network-free. branch_exists / guard / create_tag / dispatch and main are
+# exercised with a configurable `gh` stub on PATH, so no real API call is made.
+
+setup() {
+  SCRIPT="${BATS_TEST_DIRNAME}/../src/vcluster-release.sh"
+  source "$SCRIPT"
+
+  STUB_DIR="$(mktemp -d)"
+  PATH="${STUB_DIR}:${PATH}"
+  install_gh_stub
+}
+
+teardown() {
+  rm -rf "$STUB_DIR"
+}
+
+# A single configurable `gh` stub. It reads which branches/releases/tags "exist"
+# from env set per-test:
+#   GH_STUB_BRANCHES="loft-sh/vcluster:v0.35 loft-sh/vcluster-pro:v0.35"
+#   GH_STUB_RELEASES="loft-sh/vcluster:v0.35.4"
+#   GH_STUB_TAGS="loft-sh/vcluster-pro:v0.35.4"
+# Anything not listed 404s / is absent. POST refs, refs/heads sha lookups and
+# `workflow run` succeed (only reached in non-dry-run tests).
+install_gh_stub() {
+  cat >"${STUB_DIR}/gh" <<'EOF'
+#!/usr/bin/env bash
+set -u
+sub="$1"; shift || true
+
+contains() { case " $1 " in *" $2 "*) return 0 ;; *) return 1 ;; esac; }
+
+if [[ "$sub" == "api" ]]; then
+  path="$1"
+  case "$path" in
+    repos/*/branches/*)
+      rest="${path#repos/}"; repo="${rest%%/branches/*}"; branch="${rest##*/branches/}"
+      # Real gh: prints the status line to stdout for both, but exits non-zero on
+      # 404. GH_STUB_TRANSIENT=1 simulates a network/auth failure (no status line,
+      # non-zero exit).
+      if [[ "${GH_STUB_TRANSIENT:-}" == "1" ]]; then exit 1; fi
+      if contains "${GH_STUB_BRANCHES:-}" "${repo}:${branch}"; then echo "HTTP/2.0 200 OK"; exit 0; else echo "HTTP/2.0 404 Not Found"; exit 1; fi ;;
+    repos/*/git/refs/tags/*)
+      rest="${path#repos/}"; repo="${rest%%/git/refs/tags/*}"; tag="${rest##*/git/refs/tags/}"
+      contains "${GH_STUB_TAGS:-}" "${repo}:${tag}" && exit 0 || exit 1 ;;
+    repos/*/git/refs/heads/*)
+      echo "deadbeefcafe"; exit 0 ;;
+    *)
+      # POST repos/<repo>/git/refs and anything else: succeed.
+      exit 0 ;;
+  esac
+fi
+
+if [[ "$sub" == "release" && "${1:-}" == "view" ]]; then
+  tag="$2"; repo=""
+  while [[ $# -gt 0 ]]; do [[ "$1" == "--repo" ]] && repo="$2"; shift; done
+  contains "${GH_STUB_RELEASES:-}" "${repo}:${tag}" && exit 0 || exit 1
+fi
+
+if [[ "$sub" == "workflow" && "${1:-}" == "run" ]]; then exit 0; fi
+
+exit 0
+EOF
+  chmod +x "${STUB_DIR}/gh"
+}
+
+# ---- parse_major_minor (pure) ----
+
+@test "parse_major_minor: v-prefixed patch+prerelease -> major minor" {
+  run parse_major_minor "v0.35.4-rc.1"
+  [ "$status" -eq 0 ]
+  [ "$output" = "0 35" ]
+}
+
+@test "parse_major_minor: bare major.minor" {
+  run parse_major_minor "1.0"
+  [ "$output" = "1 0" ]
+}
+
+@test "parse_major_minor: prerelease directly on minor -> strips suffix" {
+  run parse_major_minor "v0.36-rc.1"
+  [ "$output" = "0 36" ]
+}
+
+@test "parse_major_minor: double-digit minor" {
+  run parse_major_minor "v0.123.4"
+  [ "$output" = "0 123" ]
+}
+
+@test "parse_major_minor: garbage fails loudly" {
+  run parse_major_minor "not-a-version"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"cannot parse major.minor"* ]]
+}
+
+# ---- derive_line (pure) ----
+
+@test "derive_line: v0.35.4-rc.1 -> v0.35" {
+  run derive_line "v0.35.4-rc.1"
+  [ "$output" = "v0.35" ]
+}
+
+@test "derive_line: v0.36.0-rc.1 -> v0.36" {
+  run derive_line "v0.36.0-rc.1"
+  [ "$output" = "v0.36" ]
+}
+
+@test "derive_line: v1.2.3 -> v1.2" {
+  run derive_line "v1.2.3"
+  [ "$output" = "v1.2" ]
+}
+
+# ---- classify_era (pure) ----
+
+@test "classify_era: v0.9 is legacy (numeric, not string, compare)" {
+  run classify_era "v0.9.0"
+  [ "$output" = "legacy" ]
+}
+
+@test "classify_era: v0.31 is legacy" {
+  run classify_era "v0.31.7"
+  [ "$output" = "legacy" ]
+}
+
+@test "classify_era: v0.35.4 is legacy" {
+  run classify_era "v0.35.4"
+  [ "$output" = "legacy" ]
+}
+
+@test "classify_era: v0.35.9-rc.1 is legacy" {
+  run classify_era "v0.35.9-rc.1"
+  [ "$output" = "legacy" ]
+}
+
+@test "classify_era: v0.36 (cutover boundary) is monorepo" {
+  run classify_era "v0.36.0"
+  [ "$output" = "monorepo" ]
+}
+
+@test "classify_era: v0.36.0-rc.1 is monorepo" {
+  run classify_era "v0.36.0-rc.1"
+  [ "$output" = "monorepo" ]
+}
+
+@test "classify_era: v0.37 is monorepo" {
+  run classify_era "v0.37.2"
+  [ "$output" = "monorepo" ]
+}
+
+@test "classify_era: v1.0.0 lands in monorepo era" {
+  run classify_era "v1.0.0"
+  [ "$output" = "monorepo" ]
+}
+
+@test "classify_era: honours a custom cutover" {
+  run classify_era "v0.34.0" "v0.34"
+  [ "$output" = "monorepo" ]
+}
+
+# ---- main: legacy flow (dry-run) ----
+
+@test "legacy dry-run: dispatches OSS before pro, tags both, fires nothing" {
+  export GH_STUB_BRANCHES="loft-sh/vcluster:v0.35 loft-sh/vcluster-pro:v0.35"
+  INPUT_VERSION="v0.35.4" INPUT_DRY_RUN="true" run main
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"-> legacy"* ]]
+  # OSS dispatch line appears before the pro dispatch line.
+  oss_line=$(printf '%s\n' "$output" | grep -n 'gh workflow run release.yaml --repo loft-sh/vcluster ' | head -1 | cut -d: -f1)
+  pro_line=$(printf '%s\n' "$output" | grep -n 'gh workflow run release.yaml --repo loft-sh/vcluster-pro ' | head -1 | cut -d: -f1)
+  [ -n "$oss_line" ] && [ -n "$pro_line" ] && [ "$oss_line" -lt "$pro_line" ]
+  # Dry-run only: never actually dispatched.
+  [[ "$output" != *"dispatched release.yaml"* ]]
+}
+
+@test "legacy: missing branch in a repo is a hard error" {
+  # OSS has the branch, pro does not.
+  export GH_STUB_BRANCHES="loft-sh/vcluster:v0.35"
+  INPUT_VERSION="v0.35.4" INPUT_DRY_RUN="true" run main
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not found in loft-sh/vcluster-pro"* ]]
+}
+
+@test "legacy: existing release is a double-cut hard error" {
+  export GH_STUB_BRANCHES="loft-sh/vcluster:v0.35 loft-sh/vcluster-pro:v0.35"
+  export GH_STUB_RELEASES="loft-sh/vcluster:v0.35.4"
+  INPUT_VERSION="v0.35.4" INPUT_DRY_RUN="true" run main
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"already exists"* ]]
+}
+
+@test "legacy: existing tag is a double-cut hard error" {
+  export GH_STUB_BRANCHES="loft-sh/vcluster:v0.35 loft-sh/vcluster-pro:v0.35"
+  export GH_STUB_TAGS="loft-sh/vcluster:v0.35.4"
+  INPUT_VERSION="v0.35.4" INPUT_DRY_RUN="true" run main
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"tag v0.35.4 already exists"* ]]
+}
+
+# ---- main: monorepo flow (dry-run) ----
+
+@test "monorepo dry-run: pro-only dispatch, target line branch when it exists" {
+  export GH_STUB_BRANCHES="loft-sh/vcluster-pro:v0.36"
+  INPUT_VERSION="v0.36.2" INPUT_DRY_RUN="true" run main
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"-> monorepo"* ]]
+  [[ "$output" == *"target v0.36"* ]]
+  [[ "$output" == *"gh workflow run release.yaml --repo loft-sh/vcluster-pro --ref v0.36.2"* ]]
+  # No OSS dispatch on the monorepo path.
+  [[ "$output" != *"--repo loft-sh/vcluster "* ]]
+}
+
+@test "monorepo dry-run: falls back to main when the line branch is absent (404 exits non-zero)" {
+  # Regression: a real 404 makes gh exit non-zero. branch_exists must read that
+  # as "missing" (-> main), not as a transient error that aborts the cut.
+  export GH_STUB_BRANCHES=""
+  INPUT_VERSION="v0.36.0" INPUT_DRY_RUN="true" run main
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"target main"* ]]
+  [[ "$output" != *"failed to reach"* ]]
+}
+
+@test "monorepo: a genuine transient API failure aborts loudly (not read as missing)" {
+  export GH_STUB_TRANSIENT="1"
+  INPUT_VERSION="v0.36.0" INPUT_DRY_RUN="true" run main
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"failed to reach"* ]]
+}
+
+@test "monorepo: existing release is a double-cut hard error" {
+  export GH_STUB_BRANCHES="loft-sh/vcluster-pro:v0.36"
+  export GH_STUB_RELEASES="loft-sh/vcluster-pro:v0.36.2"
+  INPUT_VERSION="v0.36.2" INPUT_DRY_RUN="true" run main
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"already exists"* ]]
+}
+
+# ---- main: guards ----
+
+@test "main requires INPUT_VERSION" {
+  run main
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"INPUT_VERSION is required"* ]]
+}

--- a/.github/workflows/test-vcluster-release.yaml
+++ b/.github/workflows/test-vcluster-release.yaml
@@ -1,0 +1,22 @@
+name: Test vcluster-release
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/test-vcluster-release.yaml'
+      - '.github/actions/vcluster-release/**'
+
+permissions:
+  contents: read
+
+jobs:
+  bats:
+    name: Run bats tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
+        with:
+          tests: .github/actions/vcluster-release/test

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-semver-validation test-linear-pr-commenter test-link-backport-prs test-release-notification test-linear-release-sync test-aws-test-infra test-cleanup-head-charts test-ci-test-notify test-auto-approve-bot-prs test-ai-pr-review test-ai-step test-publish-helm-chart test-govulncheck test-go-licenses test-run-ginkgo test-sticky-pr-comment test-repository-dispatch test-parse-label-filter test-release-branch-freeze build-linear-release-sync lint install-auto-doc generate-docs check-docs help
+.PHONY: test test-semver-validation test-linear-pr-commenter test-link-backport-prs test-release-notification test-linear-release-sync test-aws-test-infra test-cleanup-head-charts test-ci-test-notify test-auto-approve-bot-prs test-ai-pr-review test-ai-step test-publish-helm-chart test-govulncheck test-go-licenses test-run-ginkgo test-sticky-pr-comment test-repository-dispatch test-parse-label-filter test-release-branch-freeze test-vcluster-release build-linear-release-sync lint install-auto-doc generate-docs check-docs help
 
 ACTIONS_DIR := .github/actions
 WORKFLOWS_DIR := .github/workflows
@@ -93,7 +93,7 @@ check-docs: generate-docs ## verify docs are up to date (fails if drift detected
 help: ## show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-30s %s\n", $$1, $$2}'
 
-test: test-semver-validation test-linear-pr-commenter test-link-backport-prs test-release-notification test-linear-release-sync test-aws-test-infra test-cleanup-head-charts test-auto-approve-bot-prs test-ai-pr-review test-ai-step test-ci-test-notify test-go-licenses test-publish-helm-chart test-govulncheck test-run-ginkgo test-sticky-pr-comment test-repository-dispatch test-parse-label-filter test-release-branch-freeze ## run all action tests
+test: test-semver-validation test-linear-pr-commenter test-link-backport-prs test-release-notification test-linear-release-sync test-aws-test-infra test-cleanup-head-charts test-auto-approve-bot-prs test-ai-pr-review test-ai-step test-ci-test-notify test-go-licenses test-publish-helm-chart test-govulncheck test-run-ginkgo test-sticky-pr-comment test-repository-dispatch test-parse-label-filter test-release-branch-freeze test-vcluster-release ## run all action tests
 
 test-semver-validation: ## run semver-validation unit tests
 	cd $(ACTIONS_DIR)/semver-validation && npm ci --silent && NODE_OPTIONS=--experimental-vm-modules npx jest --ci --coverage --watchAll=false
@@ -151,6 +151,9 @@ test-parse-label-filter: ## run parse-label-filter bats tests
 
 test-release-branch-freeze: ## run release-branch-freeze bats tests
 	bats $(ACTIONS_DIR)/release-branch-freeze/test
+
+test-vcluster-release: ## run vcluster-release bats tests
+	bats $(ACTIONS_DIR)/vcluster-release/test/*.bats
 
 build-linear-release-sync: ## build linear-release-sync binary (linux/amd64)
 	cd $(ACTIONS_DIR)/linear-release-sync/src && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-s -w" -o ../linear-release-sync-linux-amd64 .

--- a/README.md
+++ b/README.md
@@ -314,6 +314,34 @@ re-pointed at the branch being released, so only that branch is frozen.
 PAT or GitHub App token with Administration read and write on the target repo.
 See the action README for full details.
 
+### Cut vCluster release
+
+Single entry point for cutting a vCluster release on any supported line. The
+version string decides the routing (legacy `< v0.36` fans out to both
+`loft-sh/vcluster` and `loft-sh/vcluster-pro`; monorepo `>= v0.36` dispatches
+`loft-sh/vcluster-pro` only). Creates the tag(s) and dispatches each line's own
+`release.yaml`; the GitHub Release is a pipeline output, not a trigger.
+
+**Location:** `.github/actions/vcluster-release`
+
+**Usage:**
+
+```yaml
+- uses: loft-sh/github-actions/.github/actions/vcluster-release@vcluster-release/v1
+  with:
+    version: ${{ inputs.version }}
+    dry-run: ${{ inputs.dry_run }}
+    github-token: ${{ secrets.GH_ACCESS_TOKEN }}
+```
+
+**Inputs:**
+
+- `version` (required): release version, e.g. `v0.35.4` or `v0.36.2`
+- `dry-run` (optional, default `true`): run read-only routing checks and print the tag + dispatch calls without firing them
+- `github-token` (required): PAT/App token with `repo` + `workflow` scope on both `loft-sh/vcluster` and `loft-sh/vcluster-pro`
+
+See the [action README](./.github/actions/vcluster-release/README.md) for routing and guard details.
+
 ## Available Reusable Workflows
 
 ### Validate Renovate Config


### PR DESCRIPTION
## Summary

- Adds a `vcluster-release` composite action: one entry point for cutting a vCluster release on any supported line, so nobody has to remember which release procedure a version needs.
- Named per-product (`vcluster-release`, not `cut-release`) since this shared repo releases multiple products and the action is vcluster-specific (hardcodes `loft-sh/vcluster` + `loft-sh/vcluster-pro` and the `v0.36` cutover). Leaves room for e.g. `platform-release` later.
- Routes by numeric `(major, minor)` compare against the `v0.36` cutover: **legacy (`< v0.36`)** fans out to both `loft-sh/vcluster` and `loft-sh/vcluster-pro` (OSS first); **monorepo (`>= v0.36`)** dispatches `loft-sh/vcluster-pro` only.
- Creates the tag(s) and dispatches each line's own `release.yaml` via `workflow_dispatch` (`gh workflow run --ref <tag>`, which runs the tagged commit's version). The GitHub Release is a pipeline **output**, not a trigger — so a monorepo-created OSS release can't re-trigger the OSS builder.
- Guards: double-cut (existing tag/release), unprepared/missing branch (distinguishing a real 404 from a transient API error), and a `dry-run` default that still runs the read-only routing checks.

## Test plan

- `make test-vcluster-release` — 26 bats cases: pure routing (`parse_major_minor`/`derive_line`/`classify_era` incl. numeric `v0.9 < v0.36` and `v1.0` boundary), legacy dispatch order (OSS before pro), double-cut guards, monorepo `main` fallback, and the 404-vs-transient distinction (stub mirrors real `gh` exiting non-zero on 404).
- `make lint` (actionlint + zizmor, whole repo) clean; `make check-docs` up to date.
- Verified end-to-end in dry-run against the real repos: legacy `v0.35.99` routes OSS→pro; monorepo `v0.36.99` falls back to `main`; the double-cut guard correctly refused a real existing release.

## Notes

- The `unpinned-uses` zizmor finding on the sibling `semver-validation` reference is expected (internal action pinned by SHA + tag comment per this repo's convention).
- Consumed by a `workflow_dispatch` button in `loft-sh/vcluster-pro` (separate PR, held until this merges and `vcluster-release/v1` is tagged).

References DEVOPS-1050