### PR TITLE
fix(vcluster-release): move era cutover from v0.36 to v0.37

### DIFF
--- a/.github/actions/vcluster-release/README.md
+++ b/.github/actions/vcluster-release/README.md
@@ -19,22 +19,23 @@ monorepo-created OSS release cannot re-trigger the OSS builder.
 |--------------|--------|----------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 |   dry-run    | string |  false   | `"true"` | Fail-closed: only an explicit "false" cuts <br>for real. Any other value (the default, a typo, wrong case) <br>runs the read-only routing checks and <br>prints the exact tag + dispatch <br>calls without firing them.  |
 | github-token | string |   true   |          |                                             Token with repo + workflow scope <br>on both loft-sh/vcluster and loft-sh/vcluster-pro (cross-repo tag creation and dispatch).                                               |
-|   version    | string |   true   |          |                                                                                  Release version to cut, e.g. v0.35.4 <br>or v0.36.2.                                                                                    |
+|   version    | string |   true   |          |                                                                                  Release version to cut, e.g. v0.35.4 <br>or v0.37.2.                                                                                    |
 
 <!-- AUTO-DOC-INPUT:END -->
 
 ## Routing
 
 Era is decided by a numeric `(major, minor)` compare against the `CUTOVER`
-constant (`v0.36`):
+constant (`v0.37`):
 
 | Era | Versions | Fan-out |
 |-----|----------|---------|
-| legacy | `< v0.36` | Verify the `vX.Y` branch in **both** repos, tag both, dispatch `loft-sh/vcluster` **first**, then `loft-sh/vcluster-pro`. |
-| monorepo | `>= v0.36` | Resolve target (`vX.Y` line branch if it exists, else `main`), dispatch `loft-sh/vcluster-pro` only. |
+| legacy | `< v0.37` | Verify the `vX.Y` branch in **both** repos, tag both, dispatch `loft-sh/vcluster` **first**, then `loft-sh/vcluster-pro`. |
+| monorepo | `>= v0.37` | Resolve target (`vX.Y` line branch if it exists, else `main`), dispatch `loft-sh/vcluster-pro` only. |
 
-Numeric compare matters: `v0.9` sorts *below* `v0.36` (legacy), and `v1.0` lands
-in the monorepo era.
+`v0.36` is the last legacy line (two-repo dance); `v0.37` is the first
+merged/monorepo line. Numeric compare matters: `v0.9` sorts *below* `v0.37`
+(legacy), and `v1.0` lands in the monorepo era.
 
 ## Guards
 
@@ -78,7 +79,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Release version to cut (e.g. v0.35.4 or v0.36.2)"
+        description: "Release version to cut (e.g. v0.35.4 or v0.37.2)"
         type: string
         required: true
       dry_run:

--- a/.github/actions/vcluster-release/action.yml
+++ b/.github/actions/vcluster-release/action.yml
@@ -3,15 +3,15 @@ description: |
   Single entry point for cutting a vCluster release on any supported line. The
   version string decides the routing, so nobody has to remember which release
   procedure a given version needs. Classifies the era by numeric compare against
-  the cutover (v0.36), then creates the tag(s) and dispatches each line's own
+  the cutover (v0.37), then creates the tag(s) and dispatches each line's own
   release.yaml via workflow_dispatch (gh workflow run --ref <tag>, which runs the
-  tagged commit's version of the workflow). Legacy lines (< v0.36) fan out to
+  tagged commit's version of the workflow). Legacy lines (< v0.37) fan out to
   both loft-sh/vcluster and loft-sh/vcluster-pro (OSS first); monorepo lines
-  (>= v0.36) dispatch loft-sh/vcluster-pro only. The GitHub Release is a pipeline
+  (>= v0.37) dispatch loft-sh/vcluster-pro only. The GitHub Release is a pipeline
   output, so nothing here triggers a downstream release:created build.
 inputs:
   version:
-    description: 'Release version to cut, e.g. v0.35.4 or v0.36.2.'
+    description: 'Release version to cut, e.g. v0.35.4 or v0.37.2.'
     required: true
   dry-run:
     description: 'Fail-closed: only an explicit "false" cuts for real. Any other value (the default, a typo, wrong case) runs the read-only routing checks and prints the exact tag + dispatch calls without firing them.'

--- a/.github/actions/vcluster-release/src/vcluster-release.sh
+++ b/.github/actions/vcluster-release/src/vcluster-release.sh
@@ -11,18 +11,19 @@
 # build. Nothing triggers on `release:created`, so a monorepo-created OSS release
 # cannot re-trigger the OSS builder.
 #
-# Routing by numeric (major, minor) compare against CUTOVER (v0.36):
-#   legacy   (< v0.36) -> verify the vX.Y branch in BOTH repos, tag both, then
+# Routing by numeric (major, minor) compare against CUTOVER (v0.37):
+#   legacy   (< v0.37) -> verify the vX.Y branch in BOTH repos, tag both, then
 #                         dispatch loft-sh/vcluster FIRST, then loft-sh/vcluster-pro.
-#   monorepo (>= v0.36) -> resolve target (line branch vX.Y if it exists, else
+#   monorepo (>= v0.37) -> resolve target (line branch vX.Y if it exists, else
 #                         main), tag it, dispatch loft-sh/vcluster-pro only.
+# v0.36 is a legacy line (two-repo dance); v0.37 is the first merged/monorepo line.
 #
 # dry_run (default true) performs the read-only checks (branch existence,
 # double-cut guard) so the printed routing decision is validated, but prints the
 # mutating tag/dispatch calls instead of firing them.
 set -euo pipefail
 
-CUTOVER="${CUTOVER:-v0.36}"
+CUTOVER="${CUTOVER:-v0.37}"
 OSS_REPO="${OSS_REPO:-loft-sh/vcluster}"
 PRO_REPO="${PRO_REPO:-loft-sh/vcluster-pro}"
 WORKFLOW="${WORKFLOW:-release.yaml}"

--- a/.github/actions/vcluster-release/test/vcluster-release.bats
+++ b/.github/actions/vcluster-release/test/vcluster-release.bats
@@ -154,18 +154,23 @@ EOF
   [ "$output" = "legacy" ]
 }
 
-@test "classify_era: v0.36 (cutover boundary) is monorepo" {
+@test "classify_era: v0.36 is legacy (last legacy line, below the v0.37 cutover)" {
   run classify_era "v0.36.0"
-  [ "$output" = "monorepo" ]
+  [ "$output" = "legacy" ]
 }
 
-@test "classify_era: v0.36.0-rc.1 is monorepo" {
+@test "classify_era: v0.36.0-rc.1 is legacy" {
   run classify_era "v0.36.0-rc.1"
+  [ "$output" = "legacy" ]
+}
+
+@test "classify_era: v0.37 (cutover boundary) is monorepo" {
+  run classify_era "v0.37.0"
   [ "$output" = "monorepo" ]
 }
 
-@test "classify_era: v0.37 is monorepo" {
-  run classify_era "v0.37.2"
+@test "classify_era: v0.37.0-rc.1 is monorepo" {
+  run classify_era "v0.37.0-rc.1"
   [ "$output" = "monorepo" ]
 }
 
@@ -228,9 +233,9 @@ EOF
 @test "guard: a transient failure on the double-cut probe aborts loudly (not read as not-released)" {
   # The branch check passes; only the guard's release/tag probe transient-fails.
   # guard_not_released must abort, not silently treat the API error as "absent".
-  export GH_STUB_BRANCHES="loft-sh/vcluster-pro:v0.36"
+  export GH_STUB_BRANCHES="loft-sh/vcluster-pro:v0.37"
   export GH_STUB_TRANSIENT_TAGS="1"
-  INPUT_VERSION="v0.36.2" INPUT_DRY_RUN="true" run main
+  INPUT_VERSION="v0.37.2" INPUT_DRY_RUN="true" run main
   [ "$status" -ne 0 ]
   [[ "$output" == *"failed to reach"* ]]
 }
@@ -249,12 +254,12 @@ EOF
 # ---- main: monorepo flow (dry-run) ----
 
 @test "monorepo dry-run: pro-only dispatch, target line branch when it exists" {
-  export GH_STUB_BRANCHES="loft-sh/vcluster-pro:v0.36"
-  INPUT_VERSION="v0.36.2" INPUT_DRY_RUN="true" run main
+  export GH_STUB_BRANCHES="loft-sh/vcluster-pro:v0.37"
+  INPUT_VERSION="v0.37.2" INPUT_DRY_RUN="true" run main
   [ "$status" -eq 0 ]
   [[ "$output" == *"-> monorepo"* ]]
-  [[ "$output" == *"target v0.36"* ]]
-  [[ "$output" == *"gh workflow run release.yaml --repo loft-sh/vcluster-pro --ref v0.36.2"* ]]
+  [[ "$output" == *"target v0.37"* ]]
+  [[ "$output" == *"gh workflow run release.yaml --repo loft-sh/vcluster-pro --ref v0.37.2"* ]]
   # No OSS dispatch on the monorepo path.
   [[ "$output" != *"--repo loft-sh/vcluster "* ]]
 }
@@ -263,7 +268,7 @@ EOF
   # Regression: a real 404 makes gh exit non-zero. branch_exists must read that
   # as "missing" (-> main), not as a transient error that aborts the cut.
   export GH_STUB_BRANCHES=""
-  INPUT_VERSION="v0.36.0" INPUT_DRY_RUN="true" run main
+  INPUT_VERSION="v0.37.0" INPUT_DRY_RUN="true" run main
   [ "$status" -eq 0 ]
   [[ "$output" == *"target main"* ]]
   [[ "$output" != *"failed to reach"* ]]
@@ -271,15 +276,15 @@ EOF
 
 @test "monorepo: a genuine transient API failure aborts loudly (not read as missing)" {
   export GH_STUB_TRANSIENT="1"
-  INPUT_VERSION="v0.36.0" INPUT_DRY_RUN="true" run main
+  INPUT_VERSION="v0.37.0" INPUT_DRY_RUN="true" run main
   [ "$status" -ne 0 ]
   [[ "$output" == *"failed to reach"* ]]
 }
 
 @test "monorepo: existing release is a double-cut hard error" {
-  export GH_STUB_BRANCHES="loft-sh/vcluster-pro:v0.36"
-  export GH_STUB_RELEASES="loft-sh/vcluster-pro:v0.36.2"
-  INPUT_VERSION="v0.36.2" INPUT_DRY_RUN="true" run main
+  export GH_STUB_BRANCHES="loft-sh/vcluster-pro:v0.37"
+  export GH_STUB_RELEASES="loft-sh/vcluster-pro:v0.37.2"
+  INPUT_VERSION="v0.37.2" INPUT_DRY_RUN="true" run main
   [ "$status" -ne 0 ]
   [[ "$output" == *"already exists"* ]]
 }
@@ -309,10 +314,10 @@ EOF
 }
 
 @test "monorepo non-dry-run: reaches the mutating pro-only path" {
-  export GH_STUB_BRANCHES="loft-sh/vcluster-pro:v0.36"
-  INPUT_VERSION="v0.36.2" INPUT_DRY_RUN="false" run main
+  export GH_STUB_BRANCHES="loft-sh/vcluster-pro:v0.37"
+  INPUT_VERSION="v0.37.2" INPUT_DRY_RUN="false" run main
   [ "$status" -eq 0 ]
-  [[ "$output" == *"created tag v0.36.2 in loft-sh/vcluster-pro "* ]]
+  [[ "$output" == *"created tag v0.37.2 in loft-sh/vcluster-pro "* ]]
   [[ "$output" == *"dispatched release.yaml in loft-sh/vcluster-pro "* ]]
   [[ "$output" != *"[dry-run]"* ]]
   # No OSS mutation on the monorepo path.
@@ -343,7 +348,7 @@ EOF
   # The *) arm of branch_exists: neither 200 nor 404 must hard-fail, never fall
   # back to main.
   export GH_STUB_UNEXPECTED="1"
-  INPUT_VERSION="v0.36.0" INPUT_DRY_RUN="true" run main
+  INPUT_VERSION="v0.37.0" INPUT_DRY_RUN="true" run main
   [ "$status" -ne 0 ]
   [[ "$output" == *"unexpected status"* ]]
 }


### PR DESCRIPTION
## What

Moves the `vcluster-release` action's era cutover from `v0.36` to `v0.37`.

- `v0.36` is now a **legacy** line (two-repo dance: OSS-first tag + dispatch, pro waits for the OSS release before the standalone upload).
- `v0.37` is the **first merged/monorepo** line (single pro pipeline, builds OSS from `staging/` and creates the OSS release itself).

`v0.36` is not released yet, so this is a clean boundary move: `v0.36` simply gets the legacy path like `v0.31`–`v0.35`, with no line migration.

## Changes

- `src/vcluster-release.sh`: `CUTOVER` constant `v0.36` → `v0.37` + header comment.
- `test/vcluster-release.bats`: `classify_era` boundary cases (`v0.36` → legacy, `v0.37` → monorepo boundary); monorepo-flow tests re-anchored on `v0.37`. Pure `parse_major_minor` / `derive_line` cases keep `v0.36` (era-independent).
- `action.yml` + `README.md`: routing docs and examples.

## Verification

- `make test-vcluster-release`: 34/34 pass.
- `shellcheck` clean.

Related to DEVOPS-1050. Pairs with the cut-release button (loft-sh/vcluster-pro#1990); merge before the stage-4 builder fan-out so the shared routing reflects the correct boundary.