### PR TITLE
feat(vcluster-release): route releases by suffix->source-branch matrix

### DIFF
--- a/.github/actions/vcluster-release/README.md
+++ b/.github/actions/vcluster-release/README.md
@@ -15,12 +15,12 @@ monorepo-created OSS release cannot re-trigger the OSS builder.
 
 <!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
 
-|    INPUT     |  TYPE  | REQUIRED | DEFAULT  |                                                                                                       DESCRIPTION                                                                                                        |
-|--------------|--------|----------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-|   dry-run    | string |  false   | `"true"` | Fail-closed: only an explicit "false" cuts <br>for real. Any other value (the default, a typo, wrong case) <br>runs the read-only routing checks and <br>prints the exact tag + dispatch <br>calls without firing them.  |
-| github-token | string |   true   |          |                                             Token with repo + workflow scope <br>on both loft-sh/vcluster and loft-sh/vcluster-pro (cross-repo tag creation and dispatch).                                               |
-| source-branch | string |  false   | `""` |                              Branch to cut from. Required for `-next`/`-next.internal` <br>(the feature branch). Optional for `-rc` (main or `vX.Y`, defaults main). <br>Must be main for `-alpha`/`-beta`, `vX.Y` for stable; empty takes the matrix default.                               |
-|   version    | string |   true   |          |                                                                                  Release version to cut, e.g. v0.35.4 <br>or v0.37.2.                                                                                    |
+|     INPUT     |  TYPE  | REQUIRED | DEFAULT  |                                                                                                                                 DESCRIPTION                                                                                                                                  |
+|---------------|--------|----------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|    dry-run    | string |  false   | `"true"` |                           Fail-closed: only an explicit "false" cuts <br>for real. Any other value (the default, a typo, wrong case) <br>runs the read-only routing checks and <br>prints the exact tag + dispatch <br>calls without firing them.                            |
+| github-token  | string |   true   |          |                                                                       Token with repo + workflow scope <br>on both loft-sh/vcluster and loft-sh/vcluster-pro (cross-repo tag creation and dispatch).                                                                         |
+| source-branch | string |  false   |          | Branch to cut from. Required for <br>-next/-next.internal (the short-lived feature branch). Optional for -rc (main or the vX.Y branch; defaults to main). <br>Must be main for -alpha/-beta and <br>the vX.Y branch for stable; leave <br>empty to take the matrix default.  |
+|    version    | string |   true   |          |                                                                                                            Release version to cut, e.g. v0.35.4 <br>or v0.37.2.                                                                                                              |
 
 <!-- AUTO-DOC-INPUT:END -->
 

--- a/.github/actions/vcluster-release/README.md
+++ b/.github/actions/vcluster-release/README.md
@@ -19,19 +19,38 @@ monorepo-created OSS release cannot re-trigger the OSS builder.
 |--------------|--------|----------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 |   dry-run    | string |  false   | `"true"` | Fail-closed: only an explicit "false" cuts <br>for real. Any other value (the default, a typo, wrong case) <br>runs the read-only routing checks and <br>prints the exact tag + dispatch <br>calls without firing them.  |
 | github-token | string |   true   |          |                                             Token with repo + workflow scope <br>on both loft-sh/vcluster and loft-sh/vcluster-pro (cross-repo tag creation and dispatch).                                               |
+| source-branch | string |  false   | `""` |                              Branch to cut from. Required for `-next`/`-next.internal` <br>(the feature branch). Optional for `-rc` (main or `vX.Y`, defaults main). <br>Must be main for `-alpha`/`-beta`, `vX.Y` for stable; empty takes the matrix default.                               |
 |   version    | string |   true   |          |                                                                                  Release version to cut, e.g. v0.35.4 <br>or v0.37.2.                                                                                    |
 
 <!-- AUTO-DOC-INPUT:END -->
 
 ## Routing
 
+Two independent decisions: the **prerelease suffix** fixes which branch a version
+may be cut from (the `source-branch` input), and the **era** fixes the fan-out.
+
+### Suffix -> source branch (fail-closed)
+
+An unroutable suffix (e.g. `-devpod.alpha`) is rejected, never guessed.
+
+| Suffix | Allowed source branch | Notes |
+|--------|-----------------------|-------|
+| `-alpha` / `-beta` | `main` only | |
+| `-rc` | `main` or the `vX.Y` release branch | empty `source-branch` defaults to `main` |
+| stable (`vX.Y.Z`) | the `vX.Y` release branch only | no fallback to `main` |
+| `-next` / `-next.internal` | a short-lived feature branch (`source-branch` **required**) | not `main`, not `vX.Y`; **always builds `loft-sh/vcluster-pro` only** |
+
+`-next`/`-next.internal` short-circuit the era routing below.
+
+### Era -> fan-out
+
 Era is decided by a numeric `(major, minor)` compare against the `CUTOVER`
 constant (`v0.37`):
 
 | Era | Versions | Fan-out |
 |-----|----------|---------|
-| legacy | `< v0.37` | Verify the `vX.Y` branch in **both** repos, tag both, dispatch `loft-sh/vcluster` **first**, then `loft-sh/vcluster-pro`. |
-| monorepo | `>= v0.37` | Resolve target (`vX.Y` line branch if it exists, else `main`), dispatch `loft-sh/vcluster-pro` only. |
+| legacy | `< v0.37` | `-rc`/stable only, from the `vX.Y` branch in **both** repos; tag both, dispatch `loft-sh/vcluster` **first**, then `loft-sh/vcluster-pro`. |
+| monorepo | `>= v0.37` | Tag the suffix-resolved branch in `loft-sh/vcluster-pro`, dispatch `loft-sh/vcluster-pro` only. |
 
 `v0.36` is the last legacy line (two-repo dance); `v0.37` is the first
 merged/monorepo line. Numeric compare matters: `v0.9` sorts *below* `v0.37`

--- a/.github/actions/vcluster-release/action.yml
+++ b/.github/actions/vcluster-release/action.yml
@@ -1,11 +1,14 @@
 name: Cut vCluster release
 description: |
   Single entry point for cutting a vCluster release on any supported line. The
-  version string decides the routing, so nobody has to remember which release
-  procedure a given version needs. Classifies the era by numeric compare against
-  the cutover (v0.37), then creates the tag(s) and dispatches each line's own
-  release.yaml via workflow_dispatch (gh workflow run --ref <tag>, which runs the
-  tagged commit's version of the workflow). Legacy lines (< v0.37) fan out to
+  version string plus its prerelease suffix decide the routing, so nobody has to
+  remember which release procedure a given version needs. The suffix fixes which
+  branch a version may be cut from (-alpha/-beta from main, -rc from main or the
+  release branch, stable from the release branch, -next/-next.internal from a
+  short-lived feature branch); the era (numeric compare against the cutover
+  v0.37) fixes the fan-out. It then creates the tag(s) and dispatches each line's
+  own release.yaml via workflow_dispatch (gh workflow run --ref <tag>, which runs
+  the tagged commit's version of the workflow). Legacy lines (< v0.37) fan out to
   both loft-sh/vcluster and loft-sh/vcluster-pro (OSS first); monorepo lines
   (>= v0.37) dispatch loft-sh/vcluster-pro only. The GitHub Release is a pipeline
   output, so nothing here triggers a downstream release:created build.
@@ -13,6 +16,10 @@ inputs:
   version:
     description: 'Release version to cut, e.g. v0.35.4 or v0.37.2.'
     required: true
+  source-branch:
+    description: 'Branch to cut from. Required for -next/-next.internal (the short-lived feature branch). Optional for -rc (main or the vX.Y branch; defaults to main). Must be main for -alpha/-beta and the vX.Y branch for stable; leave empty to take the matrix default.'
+    required: false
+    default: ''
   dry-run:
     description: 'Fail-closed: only an explicit "false" cuts for real. Any other value (the default, a typo, wrong case) runs the read-only routing checks and prints the exact tag + dispatch calls without firing them.'
     required: false
@@ -32,6 +39,7 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.github-token }}
         INPUT_VERSION: ${{ inputs.version }}
+        INPUT_SOURCE_BRANCH: ${{ inputs.source-branch }}
         INPUT_DRY_RUN: ${{ inputs.dry-run }}
       run: ${{ github.action_path }}/src/vcluster-release.sh
 branding:

--- a/.github/actions/vcluster-release/src/vcluster-release.sh
+++ b/.github/actions/vcluster-release/src/vcluster-release.sh
@@ -11,11 +11,20 @@
 # build. Nothing triggers on `release:created`, so a monorepo-created OSS release
 # cannot re-trigger the OSS builder.
 #
-# Routing by numeric (major, minor) compare against CUTOVER (v0.37):
-#   legacy   (< v0.37) -> verify the vX.Y branch in BOTH repos, tag both, then
-#                         dispatch loft-sh/vcluster FIRST, then loft-sh/vcluster-pro.
-#   monorepo (>= v0.37) -> resolve target (line branch vX.Y if it exists, else
-#                         main), tag it, dispatch loft-sh/vcluster-pro only.
+# The prerelease suffix decides which branch a version may be cut from
+# (fail-closed - an unroutable suffix like -devpod.alpha is rejected, never
+# guessed):
+#   -alpha / -beta      -> main only
+#   -rc                 -> main or the vX.Y release branch (default main)
+#   stable (vX.Y.Z)     -> the vX.Y release branch only
+#   -next / -next.internal -> a short-lived feature branch (source-branch input
+#                         required); always builds pro only.
+# The feature-branch prereleases short-circuit the era routing below; everything
+# else routes by numeric (major, minor) compare against CUTOVER (v0.37):
+#   legacy   (< v0.37) -> rc/stable only, from the vX.Y branch in BOTH repos;
+#                         tag both, dispatch loft-sh/vcluster FIRST, then -pro.
+#   monorepo (>= v0.37) -> tag the resolved branch in loft-sh/vcluster-pro,
+#                         dispatch loft-sh/vcluster-pro only.
 # v0.36 is a legacy line (two-repo dance); v0.37 is the first merged/monorepo line.
 #
 # dry_run (default true) performs the read-only checks (branch existence,
@@ -70,6 +79,72 @@ classify_era() {
   else
     printf 'legacy\n'
   fi
+}
+
+# classify_suffix <version> -> alpha | beta | rc | next | next-internal | stable
+# Fail-closed: only the prerelease suffixes the dispatcher knows how to route are
+# accepted. Anything else - including a legal-but-unrouted tag such as
+# -devpod.alpha - is rejected so an unhandled release type can never be silently
+# misrouted onto the wrong branch. Order matters: -next.internal is a sub-flavor
+# of -next and must be matched first.
+classify_suffix() {
+  local v="$1"
+  case "$v" in
+    *-next.internal.*) printf 'next-internal\n' ;;
+    *-next.*)          printf 'next\n' ;;
+    *-alpha.*)         printf 'alpha\n' ;;
+    *-beta.*)          printf 'beta\n' ;;
+    *-rc.*)            printf 'rc\n' ;;
+    *-*)
+      echo "::error::version '$v' has an unsupported prerelease suffix; the dispatcher cuts only -alpha/-beta/-rc/-next/-next.internal or a stable vX.Y.Z" >&2
+      return 1 ;;
+    *) printf 'stable\n' ;;
+  esac
+}
+
+# is_feature_branch <branch> -> 0 for a short-lived feature branch, 1 otherwise.
+# A feature branch is anything that is neither main nor a vX.Y release branch.
+is_feature_branch() {
+  local b="$1"
+  [[ "$b" == "main" ]] && return 1
+  [[ "$b" =~ ^v[0-9]+\.[0-9]+$ ]] && return 1
+  return 0
+}
+
+# resolve_target <suffix> <source-branch> <line> -> the branch to tag, or a hard
+# error if <source-branch> violates the matrix. Handles the non-feature suffixes
+# only (alpha/beta/rc/stable); next/next.internal are routed by cut_feature_prerelease.
+#   alpha|beta -> main only
+#   rc         -> main or the line branch vX.Y (empty source-branch defaults to main)
+#   stable     -> the line branch vX.Y only
+resolve_target() {
+  local suffix="$1" src="$2" line="$3"
+  case "$suffix" in
+    alpha|beta)
+      if [[ -n "$src" && "$src" != "main" ]]; then
+        echo "::error::${suffix} releases are cut from main only, not '${src}'" >&2
+        return 1
+      fi
+      printf 'main\n' ;;
+    rc)
+      if [[ -z "$src" || "$src" == "main" ]]; then
+        printf 'main\n'
+      elif [[ "$src" == "$line" ]]; then
+        printf '%s\n' "$line"
+      else
+        echo "::error::rc releases are cut from main or the ${line} release branch, not '${src}'" >&2
+        return 1
+      fi ;;
+    stable)
+      if [[ -n "$src" && "$src" != "$line" ]]; then
+        echo "::error::stable releases are cut from the ${line} release branch only, not '${src}'" >&2
+        return 1
+      fi
+      printf '%s\n' "$line" ;;
+    *)
+      echo "::error::resolve_target: unexpected suffix '${suffix}'" >&2
+      return 1 ;;
+  esac
 }
 
 # ---------------------------------------------------------------------------
@@ -202,15 +277,26 @@ cut_legacy() {
 }
 
 cut_monorepo() {
-  local version="$1" line="$2" target
-  if branch_exists "$PRO_REPO" "$line"; then
-    target="$line"
-  else
-    target="main"
-  fi
-  echo "Routing ${version} -> monorepo (line ${line}, target ${target}); dispatch: ${PRO_REPO} only"
+  local version="$1" target="$2"
+  echo "Routing ${version} -> monorepo (target ${target}); dispatch: ${PRO_REPO} only"
+  # The target is resolved from the suffix matrix, so it must already exist:
+  # stable/rc name a vX.Y branch that has to be cut first, alpha/beta name main.
+  # Refusing to guess is the point - never fall back to a different branch.
+  require_branch "$PRO_REPO" "$target"
   guard_not_released "$PRO_REPO" "$version"
   create_tag "$PRO_REPO" "$target" "$version"
+  dispatch "$PRO_REPO" "$version"
+}
+
+# cut_feature_prerelease <version> <feature-branch> - -next / -next.internal are
+# cut from a short-lived feature branch and only ever build pro (they are
+# prereleases of a future, monorepo-era line). Bypasses the era fan-out.
+cut_feature_prerelease() {
+  local version="$1" feature="$2"
+  echo "Routing ${version} -> feature-branch prerelease (source ${feature}); dispatch: ${PRO_REPO} only"
+  require_branch "$PRO_REPO" "$feature"
+  guard_not_released "$PRO_REPO" "$version"
+  create_tag "$PRO_REPO" "$feature" "$version"
   dispatch "$PRO_REPO" "$version"
 }
 
@@ -230,15 +316,49 @@ main() {
       ;;
   esac
   export DRY_RUN
-  echo "vcluster-release: version=${version} dry_run=${DRY_RUN} cutover=${CUTOVER}"
+
+  local suffix source_branch target
+  suffix="$(classify_suffix "$version")" || exit 1
+  source_branch="${INPUT_SOURCE_BRANCH:-}"
+  line="$(derive_line "$version")"
+  echo "vcluster-release: version=${version} suffix=${suffix} source-branch=${source_branch:-<none>} dry_run=${DRY_RUN} cutover=${CUTOVER}"
+
+  # Feature-branch prereleases (-next/-next.internal) short-circuit the era
+  # routing: they are cut from a short-lived feature branch and always build pro.
+  if [[ "$suffix" == "next" || "$suffix" == "next-internal" ]]; then
+    if [[ -z "$source_branch" ]]; then
+      echo "::error::${suffix} releases require the source-branch input (the short-lived feature branch to cut from)." >&2
+      exit 1
+    fi
+    if ! is_feature_branch "$source_branch"; then
+      echo "::error::${suffix} releases are cut from a short-lived feature branch, not '${source_branch}' (main and vX.Y release branches are not allowed)." >&2
+      exit 1
+    fi
+    cut_feature_prerelease "$version" "$source_branch"
+    return
+  fi
 
   era="$(classify_era "$version")"
-  line="$(derive_line "$version")"
 
   case "$era" in
-    legacy)   cut_legacy "$version" "$line" ;;
-    monorepo) cut_monorepo "$version" "$line" ;;
-    *)        echo "::error::unknown era '${era}'" >&2; exit 1 ;;
+    monorepo)
+      target="$(resolve_target "$suffix" "$source_branch" "$line")" || exit 1
+      cut_monorepo "$version" "$target" ;;
+    legacy)
+      # Legacy lines are historical two-repo lines: only rc/stable are cut, from
+      # the vX.Y branch. main-sourced (alpha/beta) and feature-sourced (next)
+      # prereleases are go-forward concepts that do not apply here.
+      case "$suffix" in
+        rc|stable) ;;
+        *) echo "::error::${suffix} releases are not supported on the legacy line ${line}; legacy lines cut only rc or stable from the ${line} branch." >&2; exit 1 ;;
+      esac
+      if [[ -n "$source_branch" && "$source_branch" != "$line" ]]; then
+        echo "::error::legacy ${line} releases are cut from the ${line} branch, not '${source_branch}'." >&2
+        exit 1
+      fi
+      cut_legacy "$version" "$line" ;;
+    *)
+      echo "::error::unknown era '${era}'" >&2; exit 1 ;;
   esac
 }
 

--- a/.github/actions/vcluster-release/test/vcluster-release.bats
+++ b/.github/actions/vcluster-release/test/vcluster-release.bats
@@ -264,14 +264,47 @@ EOF
   [[ "$output" != *"--repo loft-sh/vcluster "* ]]
 }
 
-@test "monorepo dry-run: falls back to main when the line branch is absent (404 exits non-zero)" {
-  # Regression: a real 404 makes gh exit non-zero. branch_exists must read that
-  # as "missing" (-> main), not as a transient error that aborts the cut.
+@test "monorepo: stable with no vX.Y branch is a hard error (no fallback to main)" {
+  # Matrix rule: stable is cut from the vX.Y release branch only. A missing v0.37
+  # branch (real 404, gh exits non-zero) must fail loudly, never silently retarget
+  # main. branch_exists still distinguishes 404 from a transient failure.
   export GH_STUB_BRANCHES=""
   INPUT_VERSION="v0.37.0" INPUT_DRY_RUN="true" run main
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"release branch 'v0.37' not found"* ]]
+  [[ "$output" != *"failed to reach"* ]]
+}
+
+@test "monorepo rc: an omitted source-branch defaults to main" {
+  export GH_STUB_BRANCHES="loft-sh/vcluster-pro:main"
+  INPUT_VERSION="v0.40.0-rc.1" INPUT_DRY_RUN="true" run main
   [ "$status" -eq 0 ]
   [[ "$output" == *"target main"* ]]
-  [[ "$output" != *"failed to reach"* ]]
+  [[ "$output" == *"[dry-run] gh workflow run release.yaml --repo loft-sh/vcluster-pro --ref v0.40.0-rc.1"* ]]
+}
+
+@test "monorepo rc: an explicit vX.Y source-branch targets the release branch" {
+  export GH_STUB_BRANCHES="loft-sh/vcluster-pro:v0.40"
+  INPUT_VERSION="v0.40.0-rc.1" INPUT_SOURCE_BRANCH="v0.40" INPUT_DRY_RUN="true" run main
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"target v0.40"* ]]
+}
+
+@test "monorepo rc: a foreign source-branch is rejected" {
+  INPUT_VERSION="v0.40.0-rc.1" INPUT_SOURCE_BRANCH="my-feature" INPUT_DRY_RUN="true" run main
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"rc releases are cut from main or the v0.40 release branch"* ]]
+}
+
+@test "monorepo alpha: defaults to main; a non-main source-branch is rejected" {
+  export GH_STUB_BRANCHES="loft-sh/vcluster-pro:main"
+  INPUT_VERSION="v0.40.0-alpha.1" INPUT_DRY_RUN="true" run main
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"target main"* ]]
+
+  INPUT_VERSION="v0.40.0-alpha.1" INPUT_SOURCE_BRANCH="v0.40" INPUT_DRY_RUN="true" run main
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"alpha releases are cut from main only"* ]]
 }
 
 @test "monorepo: a genuine transient API failure aborts loudly (not read as missing)" {
@@ -351,4 +384,87 @@ EOF
   INPUT_VERSION="v0.37.0" INPUT_DRY_RUN="true" run main
   [ "$status" -ne 0 ]
   [[ "$output" == *"unexpected status"* ]]
+}
+
+# ---- classify_suffix (pure) ----
+
+@test "classify_suffix: stable / alpha / beta / rc" {
+  run classify_suffix "v0.40.0";        [ "$output" = "stable" ]
+  run classify_suffix "v0.40.0-alpha.1"; [ "$output" = "alpha" ]
+  run classify_suffix "v0.40.0-beta.2";  [ "$output" = "beta" ]
+  run classify_suffix "v0.40.0-rc.3";    [ "$output" = "rc" ]
+}
+
+@test "classify_suffix: -next.internal is matched before -next" {
+  run classify_suffix "v0.40.0-next.internal.1"
+  [ "$output" = "next-internal" ]
+  run classify_suffix "v0.40.0-next.5"
+  [ "$output" = "next" ]
+}
+
+@test "classify_suffix: an unrouted legal suffix (-devpod.alpha) is fail-closed" {
+  run classify_suffix "v0.40.0-devpod.alpha.1"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"unsupported prerelease suffix"* ]]
+}
+
+# ---- is_feature_branch (pure) ----
+
+@test "is_feature_branch: main and vX.Y are not feature branches; anything else is" {
+  run is_feature_branch "my-feature"; [ "$status" -eq 0 ]
+  run is_feature_branch "dmytrosydorov/foo"; [ "$status" -eq 0 ]
+  run is_feature_branch "main"; [ "$status" -ne 0 ]
+  run is_feature_branch "v0.40"; [ "$status" -ne 0 ]
+}
+
+# ---- resolve_target (pure) ----
+
+@test "resolve_target: stable requires the line branch; a foreign source is rejected" {
+  run resolve_target "stable" "" "v0.40";        [ "$output" = "v0.40" ]
+  run resolve_target "stable" "v0.40" "v0.40";   [ "$output" = "v0.40" ]
+  run resolve_target "stable" "main" "v0.40";    [ "$status" -ne 0 ]
+}
+
+# ---- main: feature-branch prereleases (-next / -next.internal) ----
+
+@test "next: cut from a feature branch, pro-only, tags the feature head" {
+  export GH_STUB_BRANCHES="loft-sh/vcluster-pro:my-feature"
+  INPUT_VERSION="v0.40.0-next.1" INPUT_SOURCE_BRANCH="my-feature" INPUT_DRY_RUN="true" run main
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"feature-branch prerelease (source my-feature)"* ]]
+  [[ "$output" == *"[dry-run] gh workflow run release.yaml --repo loft-sh/vcluster-pro --ref v0.40.0-next.1"* ]]
+  # feature head is tagged, and OSS is never touched.
+  [[ "$output" == *"repos/loft-sh/vcluster-pro/git/refs -f ref=refs/tags/v0.40.0-next.1 -f sha=<my-feature head>"* ]]
+  [[ "$output" != *"loft-sh/vcluster/"* ]]
+}
+
+@test "next.internal: also cut from a feature branch, pro-only" {
+  export GH_STUB_BRANCHES="loft-sh/vcluster-pro:my-feature"
+  INPUT_VERSION="v0.40.0-next.internal.2" INPUT_SOURCE_BRANCH="my-feature" INPUT_DRY_RUN="true" run main
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"feature-branch prerelease (source my-feature)"* ]]
+}
+
+@test "next: a missing source-branch is a hard error" {
+  INPUT_VERSION="v0.40.0-next.1" INPUT_DRY_RUN="true" run main
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"require the source-branch input"* ]]
+}
+
+@test "next: main and vX.Y sources are rejected (feature branch only)" {
+  INPUT_VERSION="v0.40.0-next.1" INPUT_SOURCE_BRANCH="main" INPUT_DRY_RUN="true" run main
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"short-lived feature branch"* ]]
+
+  INPUT_VERSION="v0.40.0-next.1" INPUT_SOURCE_BRANCH="v0.40" INPUT_DRY_RUN="true" run main
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"short-lived feature branch"* ]]
+}
+
+# ---- main: legacy line only accepts rc/stable ----
+
+@test "legacy: alpha/beta/next are rejected on a legacy line" {
+  INPUT_VERSION="v0.35.0-alpha.1" INPUT_DRY_RUN="true" run main
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not supported on the legacy line v0.35"* ]]
 }

--- a/.github/actions/vcluster-release/test/vcluster-release.bats
+++ b/.github/actions/vcluster-release/test/vcluster-release.bats
@@ -425,6 +425,27 @@ EOF
   run resolve_target "stable" "main" "v0.40";    [ "$status" -ne 0 ]
 }
 
+@test "resolve_target: rc defaults to main, accepts main or the line branch, rejects a foreign source" {
+  run resolve_target "rc" "" "v0.40";          [ "$output" = "main" ]
+  run resolve_target "rc" "main" "v0.40";      [ "$output" = "main" ]
+  run resolve_target "rc" "v0.40" "v0.40";     [ "$output" = "v0.40" ]
+  run resolve_target "rc" "my-feature" "v0.40"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"rc releases are cut from main or the v0.40 release branch"* ]]
+}
+
+@test "resolve_target: alpha/beta default to main, accept main, reject anything else" {
+  run resolve_target "alpha" "" "v0.40";     [ "$output" = "main" ]
+  run resolve_target "alpha" "main" "v0.40"; [ "$output" = "main" ]
+  run resolve_target "beta" "" "v0.40";      [ "$output" = "main" ]
+  run resolve_target "alpha" "v0.40" "v0.40"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"alpha releases are cut from main only"* ]]
+  run resolve_target "beta" "v0.40" "v0.40"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"beta releases are cut from main only"* ]]
+}
+
 # ---- main: feature-branch prereleases (-next / -next.internal) ----
 
 @test "next: cut from a feature branch, pro-only, tags the feature head" {
@@ -451,6 +472,12 @@ EOF
   [[ "$output" == *"require the source-branch input"* ]]
 }
 
+@test "next.internal: a missing source-branch is a hard error" {
+  INPUT_VERSION="v0.40.0-next.internal.1" INPUT_DRY_RUN="true" run main
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"require the source-branch input"* ]]
+}
+
 @test "next: main and vX.Y sources are rejected (feature branch only)" {
   INPUT_VERSION="v0.40.0-next.1" INPUT_SOURCE_BRANCH="main" INPUT_DRY_RUN="true" run main
   [ "$status" -ne 0 ]
@@ -467,4 +494,18 @@ EOF
   INPUT_VERSION="v0.35.0-alpha.1" INPUT_DRY_RUN="true" run main
   [ "$status" -ne 0 ]
   [[ "$output" == *"not supported on the legacy line v0.35"* ]]
+}
+
+@test "legacy: a foreign source-branch is rejected (must be the line branch)" {
+  INPUT_VERSION="v0.35.4" INPUT_SOURCE_BRANCH="my-feature" INPUT_DRY_RUN="true" run main
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"legacy v0.35 releases are cut from the v0.35 branch, not 'my-feature'"* ]]
+}
+
+@test "legacy: an explicit source-branch equal to the line branch is accepted" {
+  export GH_STUB_BRANCHES="loft-sh/vcluster:v0.35 loft-sh/vcluster-pro:v0.35"
+  INPUT_VERSION="v0.35.4" INPUT_SOURCE_BRANCH="v0.35" INPUT_DRY_RUN="true" run main
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"-> legacy (line v0.35)"* ]]
+  [[ "$output" == *"gh workflow run release.yaml --repo loft-sh/vcluster --ref v0.35.4"* ]]
 }


### PR DESCRIPTION
## What

Teaches the single release dispatcher the team's source-branch rules. Today the router ignores the prerelease suffix and routes every version by era + minor to a `vX.Y`-or-`main` target, which cannot express:

| Suffix | Allowed source |
|---|---|
| `-alpha` / `-beta` | `main` only |
| `-rc` | `main` or `vX.Y` (default `main`) |
| stable | `vX.Y` only |
| `-next` / `-next.internal` | short-lived feature branch (`source-branch` required), pro-only |

## How

- `classify_suffix` (fail-closed — `-devpod.alpha` and other unrouted legal tags are rejected, never guessed), `is_feature_branch`, `resolve_target` pure helpers.
- `-next`/`-next.internal` short-circuit the era routing and always build `loft-sh/vcluster-pro` only (they are prereleases of a future monorepo-era line, cut from a feature branch head).
- Legacy lines (`< v0.37`) accept only `rc`/stable from the `vX.Y` branch.
- **Behavior change:** stable with a missing `vX.Y` branch now fails loudly instead of falling back to `main` (matrix: stable is release-branch only).
- New `source-branch` input threaded through `action.yml`.

## Tests

`bats` extended to cover every matrix cell (48 tests, all green); `shellcheck` clean. Verified end-to-end on the `vClusterLabs-Experiments` fixture repos.

Part of DEVOPS-1050.