### PR TITLE
fix(run-ginkgo): tolerate null SpecReports in generate-summary.sh

### DIFF
--- a/.github/actions/run-ginkgo/src/generate-summary.sh
+++ b/.github/actions/run-ginkgo/src/generate-summary.sh
@@ -22,13 +22,15 @@ echo "Generating failure summary from JSON report..."
 
 command -v jq >/dev/null || { echo "::error::jq is required but not found"; exit 1; }
 
-# Count as failed: anything not passed, skipped, or pending
+# Count as failed: anything not passed, skipped, or pending. Suites matching zero specs
+# under the label filter (e.g. a discovered package with no matching labels) report
+# "SpecReports": null rather than [] - default to [] so they don't abort the whole script.
 STATS=$(jq -r '
   {
-    failed: ([.[].SpecReports[] | select(.State | IN("passed", "skipped", "pending") | not)] | length),
-    passed: ([.[].SpecReports[] | select(.State == "passed")] | length),
-    skipped: ([.[].SpecReports[] | select(.State == "skipped")] | length),
-    pending: ([.[].SpecReports[] | select(.State == "pending")] | length),
+    failed: ([.[] | (.SpecReports // [])[] | select(.State | IN("passed", "skipped", "pending") | not)] | length),
+    passed: ([.[] | (.SpecReports // [])[] | select(.State == "passed")] | length),
+    skipped: ([.[] | (.SpecReports // [])[] | select(.State == "skipped")] | length),
+    pending: ([.[] | (.SpecReports // [])[] | select(.State == "pending")] | length),
     total_specs: (.[0].PreRunStats.TotalSpecs // 0),
     specs_to_run: (.[0].PreRunStats.SpecsThatWillRun // 0),
     runtime: ((.[0].RunTime // 0) / 1000000000 | floor)
@@ -67,7 +69,7 @@ RUNTIME=$(echo "$STATS" | jq -r '.runtime')
   if [[ "$FAILED_COUNT" -gt 0 ]]; then
     echo ""
     echo "*Failed Tests:*"
-    jq -r '[.[].SpecReports[] | select(.State | IN("passed", "skipped", "pending") | not)] |
+    jq -r '[.[] | (.SpecReports // [])[] | select(.State | IN("passed", "skipped", "pending") | not)] |
       .[] |
       "❌ [" + (.State | ascii_upcase) + "] [" + .LeafNodeType + "]" +
       (if .ContainerHierarchyTexts then " " + (.ContainerHierarchyTexts | join(" ")) else "" end) +

--- a/.github/actions/run-ginkgo/test/fixtures/with-null-specreports.json
+++ b/.github/actions/run-ginkgo/test/fixtures/with-null-specreports.json
@@ -1,0 +1,18 @@
+[
+  {
+    "PreRunStats": { "TotalSpecs": 5, "SpecsThatWillRun": 5 },
+    "RunTime": 180000000000,
+    "SpecReports": [
+      { "State": "passed", "LeafNodeType": "It", "LeafNodeText": "creates a vcluster", "ContainerHierarchyTexts": ["VCluster", "Lifecycle"], "LeafNodeLocation": { "FileName": "lifecycle_test.go", "LineNumber": 10 } },
+      { "State": "failed", "LeafNodeType": "It", "LeafNodeText": "syncs pods", "ContainerHierarchyTexts": ["VCluster", "Sync"], "LeafNodeLocation": { "FileName": "sync_test.go", "LineNumber": 20 } },
+      { "State": "passed", "LeafNodeType": "It", "LeafNodeText": "connects to vcluster", "ContainerHierarchyTexts": ["VCluster", "Lifecycle"], "LeafNodeLocation": { "FileName": "lifecycle_test.go", "LineNumber": 30 } },
+      { "State": "skipped", "LeafNodeType": "It", "LeafNodeText": "deletes a vcluster", "ContainerHierarchyTexts": ["VCluster", "Lifecycle"], "LeafNodeLocation": { "FileName": "lifecycle_test.go", "LineNumber": 40 } },
+      { "State": "panicked", "LeafNodeType": "It", "LeafNodeText": "handles network policies", "ContainerHierarchyTexts": ["VCluster", "Networking"], "LeafNodeLocation": { "FileName": "network_test.go", "LineNumber": 50 } }
+    ]
+  },
+  {
+    "PreRunStats": { "TotalSpecs": 0, "SpecsThatWillRun": 0 },
+    "RunTime": 0,
+    "SpecReports": null
+  }
+]

--- a/.github/actions/run-ginkgo/test/generate-summary.bats
+++ b/.github/actions/run-ginkgo/test/generate-summary.bats
@@ -155,6 +155,24 @@ get_summary_line() {
   [[ "$summary" == *"All tests passed!"* ]]
 }
 
+# --- Suite with zero matched specs (SpecReports: null) ---
+
+@test "a suite with null SpecReports does not abort the script" {
+  REPORT_FILE="$FIXTURES/with-null-specreports.json" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+@test "a suite with null SpecReports is excluded from counts of the other suite" {
+  REPORT_FILE="$FIXTURES/with-null-specreports.json" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+
+  local summary
+  summary="$(get_summary)"
+  [[ "$summary" == *"Failed: 2"* ]]
+  [[ "$summary" == *"Passed: 2"* ]]
+  [[ "$summary" == *"Skipped: 1"* ]]
+}
+
 # --- Missing report file ---
 
 @test "missing report file produces fallback message" {


### PR DESCRIPTION
## Summary
- `generate-summary.sh`'s jq filters assumed every suite entry in the ginkgo JSON report has an iterable `SpecReports` array. When `ginkgo -r` discovers a suite package that matches zero specs under the caller's `--label-filter` (e.g. a suite gated to run only via its own dedicated workflow_dispatch), Ginkgo serializes that suite's report as `"SpecReports": null` instead of `[]`.
- `.[].SpecReports[]` then throws `jq: error (... ): Cannot iterate over null (null)`, and under `set -euo pipefail` the whole script aborts before writing the `failure-summary` output - silently discarding the real per-test summary for every other suite in the run.
- Fix: default to `[]` with `(.SpecReports // [])[]` everywhere the script iterates spec reports.

## Root cause context
Found while investigating why `vcluster-pro`'s nightly E2E Slack alerts never show the same detailed `*Test Results Summary:*`/`*Failed Tests:*` breakdown that `loft-enterprise`'s do. `vcluster-pro`'s `e2e-nightly.yaml` runs `ginkgo -r .` across the whole `e2e/` tree; one discovered package (`e2e/selinux`, gated to a dedicated workflow via `labels.NonDefault`) always matches zero specs under the nightly's `pr || !non-default` filter, hits this null case, and crashes the summary generation on every run.

## Test plan
- [x] Added `test/fixtures/with-null-specreports.json` (two suites: one with real spec reports and failures, one with `SpecReports: null`) and two new bats cases asserting the script no longer aborts and correctly aggregates only the real suite's counts.
- [x] Ran the full `run-ginkgo` bats suite (51 tests) via `bats/bats:1.11.0` (with `jq` installed) - all pass, no regressions.