### PR TITLE
feat(backport): split/re-root backports for pre-monorepo (<=v0.36) release lines

### DIFF
--- a/.github/actions/backport-legacy-allowlist/README.md
+++ b/.github/actions/backport-legacy-allowlist/README.md
@@ -1,0 +1,78 @@
+# backport-legacy-allowlist
+
+Gate `backport-to-*` labels down to the **in-support, pre-monorepo (`<= v0.36`)**
+release lines, and emit them as a JSON array for a matrix.
+
+This is the allow-list guard for the legacy backport flow. It lives at the
+shared-CI layer (invoked from the reusable `backport.yaml`) so the same gate
+protects both the monorepo's split flow and the OSS side's external-contributor
+PR flow. It pairs with [`backport-legacy-split`](../backport-legacy-split), which
+does the per-target re-root: this action decides *which* targets are eligible;
+that action decides *how* each one is applied.
+
+## What it allows
+
+A `backport-to-v0.<minor>` label qualifies when `<minor> <= max-minor`
+(default `36`; `>= v0.37` is the monorepo era, handled by the plain cherry-pick
+path) **and** the line passes its own lifecycle check:
+
+- **listed** in the lifecycle doc → allowed iff `status != "eol"` **and** its
+  `eolDate` is in the future;
+- **not listed**, and above the highest listed `0.x` minor → allowed as a
+  **freshly cut line** not yet in the doc (e.g. `v0.36`);
+- otherwise → dropped with a warning (end-of-life, or an unknown/gap line — the
+  gate **fails closed**).
+
+Each line is judged on its own `eolDate` rather than a `[min, max]` range, so a
+**non-contiguous** lifecycle (an EOL line sitting between two supported ones)
+can't let the EOL line slip through — a safety gate must fail closed in the
+direction it exists to block.
+
+Labels that are not `backport-to-v0.x` (other labels, or `v1+` monorepo-era
+lines) are ignored.
+
+## Lifecycle source & fallback
+
+Support is read from `lifecycle-url` (default
+`https://www.vcluster.com/docs/api/lifecycle/vcluster.json`, shape
+`{versions:[{version,status,eolDate}]}`) so the gate self-prunes as lines reach
+EOL. On any fetch/parse failure the action falls back to a **contiguous**
+`[fallback-min-minor, max-minor]` window (default lower bound `31`) — the best
+it can do without the doc — and logs a warning, so a doc outage never silently
+widens or empties the allow-list.
+
+## Inputs
+
+<!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
+
+|       INPUT        |  TYPE  | REQUIRED |                            DEFAULT                            |                                                                                                              DESCRIPTION                                                                                                              |
+|--------------------|--------|----------|---------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| fallback-min-minor | string |  false   |                            `"31"`                             |                                            Lowest in-support 0.x minor to assume <br>when the lifecycle doc cannot be <br>read. Points at v0.31 per the <br>lifecycle doc as of 2026-07.                                              |
+|    label-prefix    | string |  false   |                       `"backport-to-"`                        |                                                                                                  Prefix that marks a backport label.                                                                                                  |
+|       labels       | string |   true   |                                                               |                              JSON array of label names on <br>the source PR, e.g. toJSON(github.event.pull_request.labels.*.name). Only <br>labels matching '<label-prefix>v0.<minor>' are considered.                                |
+|   lifecycle-url    | string |  false   | `"https://www.vcluster.com/docs/api/lifecycle/vcluster.json"` |                                            vCluster lifecycle JSON used to prune <br>end-of-life lines. On fetch/parse failure the <br>action falls back to a hardcoded <br>lower bound.                                              |
+|     max-minor      | string |  false   |                            `"36"`                             | Highest 0.x minor that is still <br>pre-monorepo (old layout). Lines above this are <br>the monorepo era and are handled <br>by the cherry-pick path, not here. <br>The era boundary is v0.37, so <br>the last legacy line is v0.36.  |
+
+<!-- AUTO-DOC-INPUT:END -->
+
+## Outputs
+
+<!-- AUTO-DOC-OUTPUT:START - Do not remove or modify this section -->
+
+|   OUTPUT    |  TYPE  |                                                  DESCRIPTION                                                  |
+|-------------|--------|---------------------------------------------------------------------------------------------------------------|
+| has-targets | string |                     "true" when at least one legacy <br>target qualified, else "false".                       |
+|   targets   | string | JSON array of allowed legacy target <br>branches, e.g. ["v0.35","v0.34"]. Empty array when <br>none qualify.  |
+
+<!-- AUTO-DOC-OUTPUT:END -->
+
+Feed `targets` into a matrix (`fromJSON`) and gate the job on `has-targets`.
+
+## Tests
+
+`bats` against a local `file://` lifecycle fixture with a pinned `TODAY`, so the
+EOL math is hermetic and deterministic:
+
+```bash
+bats .github/actions/backport-legacy-allowlist/test
+```

--- a/.github/actions/backport-legacy-allowlist/action.yml
+++ b/.github/actions/backport-legacy-allowlist/action.yml
@@ -1,0 +1,45 @@
+name: 'backport-legacy-allowlist'
+description: "Gate backport-to-* labels to in-support pre-monorepo (<= v0.36) release lines. Reads the vCluster lifecycle doc so the allow-list self-prunes as lines reach EOL, and emits the allowed legacy targets as a JSON array for a matrix. Monorepo-era (>= v0.37) and end-of-life lines are dropped."
+
+inputs:
+  labels:
+    description: "JSON array of label names on the source PR, e.g. toJSON(github.event.pull_request.labels.*.name). Only labels matching '<label-prefix>v0.<minor>' are considered."
+    required: true
+  label-prefix:
+    description: "Prefix that marks a backport label."
+    required: false
+    default: "backport-to-"
+  max-minor:
+    description: "Highest 0.x minor that is still pre-monorepo (old layout). Lines above this are the monorepo era and are handled by the cherry-pick path, not here. The era boundary is v0.37, so the last legacy line is v0.36."
+    required: false
+    default: "36"
+  lifecycle-url:
+    description: "vCluster lifecycle JSON used to prune end-of-life lines. On fetch/parse failure the action falls back to a hardcoded lower bound."
+    required: false
+    default: "https://www.vcluster.com/docs/api/lifecycle/vcluster.json"
+  fallback-min-minor:
+    description: "Lowest in-support 0.x minor to assume when the lifecycle doc cannot be read. Points at v0.31 per the lifecycle doc as of 2026-07."
+    required: false
+    default: "31"
+
+outputs:
+  targets:
+    description: "JSON array of allowed legacy target branches, e.g. [\"v0.35\",\"v0.34\"]. Empty array when none qualify."
+    value: ${{ steps.allowlist.outputs.targets }}
+  has-targets:
+    description: "\"true\" when at least one legacy target qualified, else \"false\"."
+    value: ${{ steps.allowlist.outputs.has-targets }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Compute legacy allow-list
+      id: allowlist
+      shell: bash
+      env:
+        LABELS: ${{ inputs.labels }}
+        LABEL_PREFIX: ${{ inputs.label-prefix }}
+        MAX_MINOR: ${{ inputs.max-minor }}
+        LIFECYCLE_URL: ${{ inputs.lifecycle-url }}
+        FALLBACK_MIN_MINOR: ${{ inputs.fallback-min-minor }}
+      run: ${{ github.action_path }}/run.sh

--- a/.github/actions/backport-legacy-allowlist/run.sh
+++ b/.github/actions/backport-legacy-allowlist/run.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Gate backport-to-* labels to in-support pre-monorepo (<= v0.36) release lines.
+#
+# The monorepo era boundary is v0.37: lines >= v0.37 share the monorepo layout
+# and are backported by the plain cherry-pick path, so they are dropped here.
+# Lines <= v0.36 use the split/re-root flow (see backport-legacy-split), but only
+# while they are still in support -- backporting a security fix onto an
+# end-of-life line is wasted work and can mislead consumers into thinking a dead
+# line is maintained.
+#
+# Support is read from the vCluster lifecycle doc so the gate self-prunes as
+# lines reach EOL. Each requested line is checked against its OWN doc entry --
+# not a min/max range -- so a non-contiguous lifecycle (e.g. an EOL line sitting
+# between two supported ones) can't slip an EOL line through. A safety gate must
+# fail closed in the direction it exists to block. Per requested 0.x minor:
+#   - listed in the doc  -> allow iff status != "eol" AND eolDate is in the future
+#   - not listed, above the highest listed 0.x minor (and <= MAX_MINOR)
+#                        -> allow as a freshly cut line not yet in the doc (v0.36)
+#   - otherwise          -> drop (EOL, or an unknown/gap line -> fail closed)
+# On any fetch/parse failure we fall back to a contiguous [FALLBACK_MIN_MINOR,
+# MAX_MINOR] window (the best we can do without the doc) so an outage never
+# silently widens or empties the allow-list.
+#
+# Required environment variables:
+#   LABELS              JSON array of PR label names, e.g. the output of
+#                       toJSON(github.event.pull_request.labels.*.name). A
+#                       blank value is treated as no labels.
+#
+# Optional environment variables:
+#   LABEL_PREFIX        Backport label prefix (default backport-to-).
+#   MAX_MINOR           Highest legacy 0.x minor (default 36).
+#   LIFECYCLE_URL       Lifecycle JSON URL.
+#   FALLBACK_MIN_MINOR  Lower-bound minor when the doc can't be read (default 31).
+#   TODAY               Override "today" as YYYY-MM-DD (tests; default: UTC now).
+#   GITHUB_OUTPUT       Actions output file; defaults to /dev/null off-CI.
+
+# Provided (possibly empty) by the action's required `labels` input.
+LABELS="${LABELS-}"
+LABEL_PREFIX="${LABEL_PREFIX:-backport-to-}"
+MAX_MINOR="${MAX_MINOR:-36}"
+LIFECYCLE_URL="${LIFECYCLE_URL:-https://www.vcluster.com/docs/api/lifecycle/vcluster.json}"
+FALLBACK_MIN_MINOR="${FALLBACK_MIN_MINOR:-31}"
+TODAY="${TODAY:-$(date -u +%Y-%m-%d)}"
+GITHUB_OUTPUT="${GITHUB_OUTPUT:-/dev/null}"
+
+# --- lifecycle data --------------------------------------------------------
+# have_doc=true when the doc parsed (so we can check each line's own eolDate).
+# Only a FETCH/PARSE failure forces the contiguous fallback window -- a doc that
+# parsed but lists no 0.x lines is NOT a failure: it means every legacy 0.x line
+# is gone (vCluster fully on 1.x), so max_listed=-1 and nothing qualifies (fail
+# closed). max_listed is the highest 0.x minor present; freshly cut lines are
+# above it.
+json=""
+have_doc=false     # true once the doc is FETCHED; its content then governs
+parsed=false       # true once jq extracted a valid max_listed from it
+max_listed=-1
+if json="$(curl -fsSL --max-time 20 "$LIFECYCLE_URL" 2>/dev/null)" && [ -n "$json" ]; then
+  have_doc=true
+  # Highest listed 0.x minor. Defensive at EVERY step so no doc shape can abort
+  # the parse -- an abort would leave the fallback window in play and fail OPEN
+  # (re-allow EOL lines), the trap the last three rounds kept hitting:
+  #   (.versions?)[]?         tolerates a missing/non-array versions AND a
+  #                           non-object top-level body (the `?` on the index too);
+  #   select(type=="object")  drops scalar/array/bool rows before indexing .version;
+  #   select(.version|type=="string")  drops rows with a missing/non-string version;
+  #   tonumber?               drops a row whose minor isn't numeric ("0","0.x","0.36-rc").
+  # On ANY valid JSON this yields a number or -1 and never errors; only a
+  # genuinely non-JSON body makes jq fail.
+  if ml="$(jq -r '
+        [ (.versions?)[]?
+          | select(type == "object")
+          | select(.version | type == "string")
+          | select((.version | split(".")[0]) == "0")
+          | (.version | split(".")[1] | tonumber?)
+        ] | max // -1
+      ' <<<"$json" 2>/dev/null)" && [[ "$ml" =~ ^-?[0-9]+$ ]]; then
+    parsed=true
+    max_listed="$ml"
+  fi
+fi
+
+# A FETCHED doc governs regardless of parseability: an unparseable body leaves
+# max_listed=-1 and we FAIL CLOSED (allow nothing), never the widening fallback.
+# The contiguous fallback is reserved for a genuine FETCH failure (curl/empty).
+if $have_doc && [ "$max_listed" -ge 0 ]; then
+  echo "lifecycle doc read; highest listed line v0.${max_listed} (today=${TODAY})"
+elif $have_doc && $parsed; then
+  echo "lifecycle doc read; no in-support 0.x lines listed -> all legacy lines treated as EOL (today=${TODAY})"
+elif $have_doc; then
+  echo "::warning::lifecycle doc from ${LIFECYCLE_URL} is not valid JSON; failing closed (treating all legacy lines as EOL)"
+else
+  echo "::warning::could not fetch lifecycle doc from ${LIFECYCLE_URL}; falling back to contiguous window v0.${FALLBACK_MIN_MINOR} .. v0.${MAX_MINOR}"
+fi
+
+# line_supported <minor> -> 0 if the line should be allowed, 1 otherwise.
+# Sets REASON on rejection. Uses each line's own eolDate (fail closed).
+line_supported() {
+  local minor="$1" row status eol
+  if $have_doc; then
+    row="$(
+      jq -r --arg m "$minor" '
+        (.versions?)[]?
+        | select(type == "object")
+        | select(.version | type == "string")
+        | select((.version | split(".")[0]) == "0" and (.version | split(".")[1]) == $m)
+        | "\(.status)\t\(.eolDate)"
+      ' <<<"$json" 2>/dev/null | head -n1
+    )"
+    if [ -n "$row" ]; then
+      status="${row%%$'\t'*}"
+      status="${status,,}"   # case-insensitive so "EOL"/"Eol" is still eol
+      eol="${row#*$'\t'}"
+      # Fail closed on missing/mangled fields. jq renders a JSON null/number/
+      # object as text ("null", "5", "{...}"), which would pass a bare `!= "eol"`.
+      # Require status to be a plain lowercase word (rejects null/number/object/
+      # empty) that isn't "eol"/"null", AND a real future ISO eolDate. The eolDate
+      # gate is authoritative -- any non-eol status (active/eos/future statuses)
+      # with a future date is in support; a past/absent/mangled date always drops.
+      # ISO dates compare lexicographically; equal to today counts as EOL.
+      if [[ "$status" =~ ^[a-z]+$ ]] && [ "$status" != "eol" ] && [ "$status" != "null" ] \
+        && [[ "$eol" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] \
+        && [[ "$eol" > "$TODAY" ]]; then
+        return 0
+      fi
+      REASON="end-of-life or unknown lifecycle (status=${status}, eol=${eol})"
+      return 1
+    fi
+    # Freshly cut line -> allow only the SINGLE next minor above the doc's newest
+    # listed 0.x line (e.g. v0.36 when the doc's highest is v0.35). Restricting to
+    # max_listed+1 (rather than any minor > max_listed) bounds the blast radius if
+    # the doc ever drops an EOL row instead of retaining it as `eol`: at most the
+    # one just-above line can be mistaken for fresh, and a two-lines-ahead gap
+    # fails closed. Requires at least one 0.x line listed (max_listed >= 0).
+    if [ "$max_listed" -ge 0 ] && [ "$minor" -eq "$((max_listed + 1))" ]; then
+      return 0
+    fi
+    if [ "$max_listed" -ge 0 ]; then
+      REASON="not in lifecycle doc as an in-support line (highest listed 0.x is v0.${max_listed})"
+    else
+      REASON="no in-support 0.x lines in the lifecycle doc (all legacy lines are EOL)"
+    fi
+    return 1
+  fi
+  # No doc: contiguous fallback window.
+  if [ "$minor" -ge "$FALLBACK_MIN_MINOR" ]; then
+    return 0
+  fi
+  REASON="below fallback min v0.${FALLBACK_MIN_MINOR}"
+  return 1
+}
+
+# --- classify each backport label ------------------------------------------
+# LABELS is a JSON array of label names; a blank value means no labels.
+labels_json="$LABELS"
+[ -n "${labels_json//[[:space:]]/}" ] || labels_json="[]"
+# Capture jq's output to a variable first: reading via `mapfile < <(jq ...)` would
+# take mapfile's exit status (always 0), not jq's, so malformed input would slip
+# through as an empty list instead of erroring.
+if ! label_lines="$(jq -r '.[]' <<<"$labels_json" 2>/dev/null)"; then
+  echo "::error::LABELS is not a valid JSON array: ${labels_json}"
+  exit 1
+fi
+mapfile -t label_names <<<"$label_lines"
+
+declare -a allowed=()
+seen=" "
+for label in "${label_names[@]}"; do
+  [ -n "$label" ] || continue
+  # Only 0.x lines can be legacy; strip the prefix and require a v0.<minor> tail.
+  case "$label" in
+    "${LABEL_PREFIX}"*) branch="${label#"${LABEL_PREFIX}"}" ;;
+    *) continue ;;
+  esac
+  # No leading zeros: `[ -eq ]` reads decimal, so an unnormalized "036" would
+  # match the v0.36 boundary yet emit a bogus "v0.036" branch target downstream.
+  [[ "$branch" =~ ^v0\.(0|[1-9][0-9]*)$ ]] || {
+    # v1+ (or a non v0.x branch) is monorepo era, not a legacy target.
+    echo "skip ${label}: not a v0.x line (monorepo era or unrecognized)"
+    continue
+  }
+  minor="${BASH_REMATCH[1]}"
+
+  if [ "$minor" -gt "$MAX_MINOR" ]; then
+    echo "skip ${branch}: >= v0.$((MAX_MINOR + 1)) is the monorepo era (handled by cherry-pick)"
+    continue
+  fi
+  REASON=""
+  if ! line_supported "$minor"; then
+    echo "::warning::skip ${branch}: ${REASON}; not backporting"
+    continue
+  fi
+  case "$seen" in *" ${branch} "*) continue ;; esac
+  seen="${seen}${branch} "
+  allowed+=("$branch")
+  echo "allow ${branch}"
+done
+
+# --- emit JSON array + flag ------------------------------------------------
+if [ "${#allowed[@]}" -eq 0 ]; then
+  targets="[]"
+  has="false"
+else
+  targets="$(printf '%s\n' "${allowed[@]}" | jq -R . | jq -cs .)"
+  has="true"
+fi
+
+echo "targets=${targets}" >> "$GITHUB_OUTPUT"
+echo "has-targets=${has}" >> "$GITHUB_OUTPUT"
+echo "legacy targets: ${targets}"

--- a/.github/actions/backport-legacy-allowlist/test/run.bats
+++ b/.github/actions/backport-legacy-allowlist/test/run.bats
@@ -1,0 +1,281 @@
+#!/usr/bin/env bats
+# Tests for run.sh
+#
+# The lifecycle doc is served from a local file:// URL so the tests are
+# hermetic (no network) and TODAY is pinned for deterministic EOL math. A
+# bogus URL exercises the fallback path. LABELS is a JSON array, matching what
+# toJSON(github.event.pull_request.labels.*.name) yields in the workflow.
+
+# jq-encode the argument list into a JSON array of label names.
+labels_json() { printf '%s\n' "$@" | jq -R . | jq -cs .; }
+
+setup() {
+  ROOT=$(mktemp -d)
+  export ROOT
+  SCRIPT="$BATS_TEST_DIRNAME/../run.sh"
+  export GITHUB_OUTPUT="$ROOT/output"
+  : > "$GITHUB_OUTPUT"
+
+  # Descending support ladder mirroring the real doc: v0.31+ in-support,
+  # v0.30 and below EOL. v0.36 is intentionally ABSENT (freshly cut line).
+  export LIFECYCLE_URL="file://$ROOT/lifecycle.json"
+  cat > "$ROOT/lifecycle.json" <<'JSON'
+{"versions":[
+  {"version":"0.35.0","status":"active","eolDate":"2026-12-16"},
+  {"version":"0.34.0","status":"active","eolDate":"2026-10-29"},
+  {"version":"0.33.0","status":"eos","eolDate":"2026-09-13"},
+  {"version":"0.32.0","status":"eos","eolDate":"2026-08-18"},
+  {"version":"0.31.0","status":"eos","eolDate":"2026-07-29"},
+  {"version":"0.30.0","status":"eol","eolDate":"2026-04-28"},
+  {"version":"0.24.0","status":"eol","eolDate":"2025-09-14"}
+]}
+JSON
+
+  export TODAY="2026-07-15"
+  export MAX_MINOR=36
+}
+
+teardown() { rm -rf "$ROOT"; }
+
+out() { grep "^$1=" "$GITHUB_OUTPUT" | tail -n1 | cut -d= -f2-; }
+
+@test "in-support legacy labels are allowed; ordering follows the labels" {
+  LABELS="$(labels_json backport-to-v0.35 backport-to-v0.31)" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(out targets)" = '["v0.35","v0.31"]' ]
+  [ "$(out has-targets)" = "true" ]
+}
+
+@test "end-of-life line (v0.30) is dropped" {
+  LABELS="$(labels_json backport-to-v0.30)" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(out targets)" = "[]" ]
+  [ "$(out has-targets)" = "false" ]
+  [[ "$output" == *"end-of-life"* ]]
+}
+
+@test "monorepo-era line (v0.37) is dropped as too new" {
+  LABELS="$(labels_json backport-to-v0.37)" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(out targets)" = "[]" ]
+  # A bug that emitted has-targets=true alongside targets=[] in the >MAX_MINOR
+  # path would slip past a targets-only assertion; pin both outputs.
+  [ "$(out has-targets)" = "false" ]
+  [[ "$output" == *"monorepo era"* ]]
+}
+
+@test "freshly cut v0.36, absent from the doc, is allowed (<= max, >= min)" {
+  LABELS="$(labels_json backport-to-v0.36)" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(out targets)" = '["v0.36"]' ]
+}
+
+@test "non-backport and non-v0.x labels are ignored" {
+  LABELS="$(labels_json kind/bug backport-to-v1.0 backport-to-v0.34)" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(out targets)" = '["v0.34"]' ]
+}
+
+@test "labels containing spaces are handled (JSON array, not split)" {
+  LABELS="$(labels_json 'good first issue' backport-to-v0.34)" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(out targets)" = '["v0.34"]' ]
+}
+
+@test "duplicate labels collapse to one target" {
+  LABELS="$(labels_json backport-to-v0.34 backport-to-v0.34)" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(out targets)" = '["v0.34"]' ]
+}
+
+@test "EOL boundary is exclusive on the eol date itself" {
+  # On v0.31's eolDate, it is no longer in support -> min becomes v0.32.
+  TODAY="2026-07-29" LABELS="$(labels_json backport-to-v0.31 backport-to-v0.32)" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(out targets)" = '["v0.32"]' ]
+}
+
+@test "unreadable lifecycle doc falls back to hardcoded min minor" {
+  LIFECYCLE_URL="file://$ROOT/does-not-exist.json" \
+    LABELS="$(labels_json backport-to-v0.31 backport-to-v0.30)" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  # Fallback min is 31: v0.31 allowed, v0.30 dropped.
+  [ "$(out targets)" = '["v0.31"]' ]
+  [[ "$output" == *"falling back"* ]]
+}
+
+@test "non-contiguous lifecycle: an EOL line between supported ones is dropped" {
+  # Regression guard: a range-based [min,max] gate would allow v0.33 here
+  # (min supported = 32). The per-line check drops it on its own eolDate.
+  cat > "$ROOT/lifecycle.json" <<'JSON'
+{"versions":[
+  {"version":"0.35.0","status":"active","eolDate":"2026-12-16"},
+  {"version":"0.34.0","status":"active","eolDate":"2026-10-29"},
+  {"version":"0.33.0","status":"eol","eolDate":"2026-01-10"},
+  {"version":"0.32.0","status":"active","eolDate":"2026-11-01"}
+]}
+JSON
+  LABELS="$(labels_json backport-to-v0.35 backport-to-v0.33 backport-to-v0.32)" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(out targets)" = '["v0.35","v0.32"]' ]
+  [[ "$output" == *"end-of-life"* ]]
+}
+
+@test "line missing from the doc and below the newest listed line is dropped" {
+  cat > "$ROOT/lifecycle.json" <<'JSON'
+{"versions":[
+  {"version":"0.35.0","status":"active","eolDate":"2026-12-16"},
+  {"version":"0.34.0","status":"active","eolDate":"2026-10-29"}
+]}
+JSON
+  # v0.32 is unlisted and 32 < 35 -> treated as EOL/unknown, fail closed.
+  LABELS="$(labels_json backport-to-v0.34 backport-to-v0.32)" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(out targets)" = '["v0.34"]' ]
+}
+
+@test "line with null/missing eolDate is dropped (fail closed)" {
+  cat > "$ROOT/lifecycle.json" <<'JSON'
+{"versions":[
+  {"version":"0.35.0","status":"active","eolDate":"2026-12-16"},
+  {"version":"0.34.0","status":"active","eolDate":null}
+]}
+JSON
+  # "null" renders as a string that sorts > any date; must NOT be treated as
+  # in-support just because status != eol.
+  LABELS="$(labels_json backport-to-v0.35 backport-to-v0.34)" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(out targets)" = '["v0.35"]' ]
+}
+
+@test "line with null/missing status is dropped (fail closed)" {
+  cat > "$ROOT/lifecycle.json" <<'JSON'
+{"versions":[
+  {"version":"0.35.0","status":"active","eolDate":"2026-12-16"},
+  {"version":"0.34.0","status":null,"eolDate":"2026-12-16"}
+]}
+JSON
+  # v0.34 has a future eolDate but a null status -> must NOT be treated as
+  # in-support just because status != "eol".
+  LABELS="$(labels_json backport-to-v0.35 backport-to-v0.34)" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(out targets)" = '["v0.35"]' ]
+}
+
+@test "a malformed version row is skipped, not fallback-opened (EOL line stays dropped)" {
+  cat > "$ROOT/lifecycle.json" <<'JSON'
+{"versions":[
+  {"version":"0.35.0","status":"active","eolDate":"2026-12-16"},
+  "junk-scalar-row",
+  {"version":0.34,"status":"active","eolDate":"2026-12-16"},
+  {"version":"0.x","status":"active","eolDate":"2026-12-16"},
+  {"version":"0","status":"active","eolDate":"2026-12-16"},
+  [1,2],
+  {"version":"0.32.0","status":"eol","eolDate":"2020-01-01"}
+]}
+JSON
+  # None of these bad rows -- non-object (scalar/array), non-string version, or a
+  # non-numeric minor ("0.x"/"0", which would break tonumber) -- may abort the
+  # parse into the contiguous fallback window (which would re-allow the EOL v0.32).
+  LABELS="$(labels_json backport-to-v0.35 backport-to-v0.32)" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(out targets)" = '["v0.35"]' ]
+}
+
+@test "a leading-zero minor label is rejected (no bogus branch target)" {
+  # v0.036 must not be normalized to v0.36 (bash -eq reads decimal); reject it.
+  LABELS="$(labels_json backport-to-v0.036 backport-to-v0.35)" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(out targets)" = '["v0.35"]' ]
+  [[ "$output" == *"not a v0.x line"* ]]
+}
+
+@test "a non-string status is dropped despite a future eolDate (fail closed)" {
+  cat > "$ROOT/lifecycle.json" <<'JSON'
+{"versions":[
+  {"version":"0.35.0","status":"active","eolDate":"2026-12-16"},
+  {"version":"0.34.0","status":5,"eolDate":"2027-01-01"}
+]}
+JSON
+  LABELS="$(labels_json backport-to-v0.35 backport-to-v0.34)" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(out targets)" = '["v0.35"]' ]
+}
+
+@test "a fetched top-level non-object doc fails closed (not the fallback window)" {
+  printf '[1,2,3]\n' > "$ROOT/lifecycle.json"
+  # v0.32 is inside the fallback window [31,36]; a top-level array must NOT open it.
+  LABELS="$(labels_json backport-to-v0.32)" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(out targets)" = "[]" ]
+}
+
+@test "a fetched but non-JSON doc fails closed (not the fallback window)" {
+  printf 'totally not json\n' > "$ROOT/lifecycle.json"
+  LABELS="$(labels_json backport-to-v0.32)" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(out targets)" = "[]" ]
+  [[ "$output" == *"not valid JSON"* ]]
+}
+
+@test "freshly-cut allows only the single next line above the doc's newest" {
+  cat > "$ROOT/lifecycle.json" <<'JSON'
+{"versions":[
+  {"version":"0.34.0","status":"active","eolDate":"2026-12-16"},
+  {"version":"0.33.0","status":"active","eolDate":"2026-12-16"}
+]}
+JSON
+  # max_listed=34: v0.35 (==max+1) is freshly-cut-allowed; v0.36 (two ahead) is
+  # NOT (fail closed).
+  LABELS="$(labels_json backport-to-v0.35 backport-to-v0.36)" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(out targets)" = '["v0.35"]' ]
+}
+
+@test "status is matched case-insensitively" {
+  cat > "$ROOT/lifecycle.json" <<'JSON'
+{"versions":[
+  {"version":"0.35.0","status":"ACTIVE","eolDate":"2026-12-16"},
+  {"version":"0.34.0","status":"EOL","eolDate":"2026-12-16"}
+]}
+JSON
+  # "EOL" with a (mislabeled) future eolDate must still be dropped.
+  LABELS="$(labels_json backport-to-v0.35 backport-to-v0.34)" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(out targets)" = '["v0.35"]' ]
+}
+
+@test "doc that parses but lists no 0.x lines allows nothing (not the fallback window)" {
+  cat > "$ROOT/lifecycle.json" <<'JSON'
+{"versions":[
+  {"version":"1.1.0","status":"active","eolDate":"2027-12-16"},
+  {"version":"1.0.0","status":"active","eolDate":"2027-06-16"}
+]}
+JSON
+  # A parsed doc with no 0.x lines means every legacy line is gone -> allow none.
+  # (A range-fallback would wrongly re-allow v0.31-36.)
+  LABELS="$(labels_json backport-to-v0.35 backport-to-v0.34)" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(out targets)" = "[]" ]
+  [ "$(out has-targets)" = "false" ]
+}
+
+@test "empty JSON array yields empty targets" {
+  LABELS="[]" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(out targets)" = "[]" ]
+  [ "$(out has-targets)" = "false" ]
+}
+
+@test "blank labels input is treated as no labels" {
+  LABELS="" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(out targets)" = "[]" ]
+  [ "$(out has-targets)" = "false" ]
+}
+
+@test "malformed (non-JSON) labels input fails loudly" {
+  LABELS="not-json" run bash "$SCRIPT"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not a valid JSON array"* ]]
+}

--- a/.github/actions/backport-legacy-split/README.md
+++ b/.github/actions/backport-legacy-split/README.md
@@ -1,0 +1,144 @@
+# backport-legacy-split
+
+Backport a merged **monorepo** commit into a **pre-monorepo** (`<= v0.36`)
+release line.
+
+This action exists for the vCluster setup where `vcluster-pro` is the monorepo —
+pro code at the repo root, OSS code mirrored under
+`staging/github.com/loft-sh/vcluster/` — while the legacy `v0.19`–`v0.36`
+release branches predate that merge and still use the **old layout**: the pro
+repo keeps pro code at root and pulls OSS via `go.mod`, and `loft-sh/vcluster`
+keeps OSS code at root.
+
+Because the layouts differ, a plain cherry-pick of a monorepo commit onto a
+legacy branch is wrong: for an OSS change it would **recreate the `staging/`
+tree** on the legacy branch instead of patching the real paths. This action
+routes by the commit's changed paths instead.
+
+> Boundary: `<= v0.36` uses this split flow; `>= v0.37` is the monorepo era and
+> is propagated by the subtree mirror, not backported here.
+
+## Routing
+
+| Commit touches | Action |
+| -- | -- |
+| pro paths only (nothing under the prefix) | apply the whole diff onto the **pro repo** legacy branch (same root layout, no re-root) |
+| the subtree prefix only | re-root the diff to OSS layout and open a backport branch/PR on the **OSS repo** |
+| both | **two** backport branches/PRs, opened in parallel: OSS half → OSS repo, pro half → pro repo |
+
+> Under `legacy-split`, sorenlouv is scoped to the monorepo era (`>= v0.37`), so
+> it does **not** cover pro-only legacy backports — this action handles them.
+
+The pro half of a mixed commit (and a pro-only commit) is
+`git diff -- ':(exclude)<prefix>'`, so it **carries the root `go.mod` diff as-is**
+(unrelated dependency bumps ride along).
+The action does **not** compute the `loft-sh/vcluster` pin and **does not cut
+releases or tags** — a human sequences the two merges and reconciles the pin.
+
+## How the re-root works
+
+`git diff --binary --relative=<prefix>/ <base> <head>` both **filters** the diff
+to the subtree and **strips** the prefix in one step, yielding an OSS-rooted patch
+that `git apply` lands on the OSS checkout. The trailing slash matches on a
+component boundary (so a sibling module like `<prefix>-pro` can't leak in), and
+`--binary` carries binary file changes (a plain diff emits an unappliable "Binary
+files differ" placeholder). This is **not** `git subtree split` (used by
+`subtree-mirror`), which re-roots full history and is the wrong tool for a single
+backport.
+
+## Diff range (any merge strategy)
+
+The backport is the PR's own change set. When `pr-number` is set, the action
+fetches the PR head (`refs/pull/<n>/head`, via `github-token`) and diffs
+`merge-base(<commit>^1, <pr-head>)..<pr-head>` — exactly GitHub's "Files changed".
+
+This is correct for **every** merge strategy. A squash flattens the commits and a
+rebase replays them, but the PR head is unchanged, so its diff is the full PR
+either way. Anchoring the merge base on the merge commit's **first parent**
+`<commit>^1` also handles a true merge commit, whose *second* parent is the PR
+head — `merge-base(<commit>, <pr-head>)` would collapse to the PR head and diff
+nothing, while the first parent is the base side and gives the real fork point.
+It **excludes base-branch drift** (the merge base is the stable fork point) and
+does **not** depend on the mutable `pull_request.base.sha`. Using the merge
+commit's own tree (`<commit>^..<commit>`) would instead capture only the *last*
+commit of a rebase-merged PR — silently dropping the rest — which is why we diff
+the PR head.
+
+Without `pr-number` (standalone/test runs) it falls back to `<commit>^..<commit>`,
+correct for a single-commit / squash case.
+
+## Conflicts
+
+Legacy code diverges from the monorepo, so patches will not always apply
+cleanly. The patch is applied with `git apply --3way`; for that to produce real
+conflict markers across two repos, the monorepo's object store is exposed to the
+target checkout via an `objects/info/alternates` link (the re-rooted patch keeps
+blob **content**, so `--3way` matches preimage blobs by SHA). On conflict the
+markers are committed as-is and `<side>-conflicts=true` is emitted (parity with
+the backport tool's `commitConflicts: true`). The PR is opened as a **draft** so
+it can't be auto-merged with markers in it — `auto-approve-bot-prs` approves any
+`backport/` PR, and committed markers read as valid (mergeable) content, so draft
+is the state GitHub refuses to merge until a human resolves and marks it ready.
+
+If `git apply --3way` fails outright (e.g. a file the patch changes was deleted
+or renamed on the legacy branch, so its preimage isn't in the target index),
+nothing is staged and the run **fails loudly** with an actionable error rather
+than pushing an empty backport.
+
+## Inputs
+
+<!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
+
+|     INPUT      |  TYPE  | REQUIRED | DEFAULT  |                                                                                                                                                         DESCRIPTION                                                                                                                                                         |
+|----------------|--------|----------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|     commit     | string |  false   |          |                                                                                       Monorepo merge commit to backport (the tip). <br>Names the backport branch; also the <br>diff HEAD in the fallback path. <br>Defaults to HEAD.                                                                                        |
+|   create-pr    | string |  false   | `"true"` |                                                                                                                  true = open a PR per <br>pushed backport branch via gh. false <br>= push branches only.                                                                                                                    |
+|  github-token  | string |   true   |          |                                                                                             Token with write access to both <br>repos and permission to open PRs. <br>Used to build push remotes and <br>by gh; never logged.                                                                                               |
+|    oss-repo    | string |   true   |          |                                                                                                                                    OSS repository as owner/repo, e.g. loft-sh/vcluster.                                                                                                                                     |
+|   pr-number    | string |  false   |          | Source PR number. When set, the <br>PR head is fetched from refs/pull/<n>/head <br>(via github-token) and the diff is merge-base(commit^1, pr-head)..pr-head <br>-- GitHub's 'Files changed', correct for <br>any merge strategy (squash, rebase, or merge commit). Omit (e.g. tests) <br>to fall back to commit^..commit.  |
+|    pro-repo    | string |   true   |          |                                                                                              Pro repository as owner/repo, e.g. loft-sh/vcluster-pro. <br>Target for pro-only commits and the <br>pro half of a mixed commit.                                                                                               |
+| subtree-prefix | string |   true   |          |                                                               Path of the OSS subtree within <br>the monorepo, e.g. staging/github.com/loft-sh/vcluster. Requires a <br>full-history checkout of the monorepo as <br>the working directory (fetch-depth: 0).                                                                |
+| target-branch  | string |   true   |          |                                                                                               Legacy release branch to backport onto, <br>e.g. v0.35. Must exist on the <br>OSS repo (and, for mixed commits, the pro repo).                                                                                                |
+
+<!-- AUTO-DOC-INPUT:END -->
+
+## Outputs
+
+<!-- AUTO-DOC-OUTPUT:START - Do not remove or modify this section -->
+
+|     OUTPUT      |  TYPE  |                                 DESCRIPTION                                  |
+|-----------------|--------|------------------------------------------------------------------------------|
+| backport-branch | string |         The backport branch name pushed to <br>the target repo(s).           |
+|  oss-conflicts  | string |          true when the OSS half applied <br>with merge conflicts.            |
+|   oss-pushed    | string |              true when an OSS backport branch <br>was pushed.                |
+|  pro-conflicts  | string |          true when the pro half applied <br>with merge conflicts.            |
+|   pro-pushed    | string | true when a pro backport branch <br>was pushed (pro-only or mixed commits).  |
+|      route      | string |       Classification of the commit: pro-only | <br>oss-only | mixed.         |
+
+<!-- AUTO-DOC-OUTPUT:END -->
+
+## Notes
+
+- Backport branches use the `backport/` prefix so `auto-approve-bot-prs` and
+  `cleanup-backport-branches` keep working.
+- **Linear linking:** these PRs are **not** auto-linked to Linear sub-issues.
+  `link-backport-prs` runs in the reusable workflow's `backport` job against the
+  caller repo keyed on the source PR, and only matches sorenlouv-created PRs; it
+  does not cover the cross-repo PRs this action opens. Cross-repo linking is a
+  separate follow-up (see DEVOPS-1051); link these PRs manually for now.
+- Re-runs are idempotent and safe for the conflicted-PR flow: once a PR is open
+  for the head->base pair, a re-run leaves the branch **and** PR untouched, so a
+  human's manual conflict resolution on that branch is never clobbered. The
+  branch is (force-)created only when no PR exists yet (first run, or a leftover
+  branch from a prior run whose PR creation failed).
+- The `>= v0.37` / EOL allow-list guard lives in the **shared reusable
+  `backport.yaml`**, not in this action.
+
+## Tests
+
+`bats` against local temporary repos (a monorepo plus bare legacy OSS and pro
+remotes); pushes go to local bare repos, not the network:
+
+```bash
+bats .github/actions/backport-legacy-split/test
+```

--- a/.github/actions/backport-legacy-split/action.yml
+++ b/.github/actions/backport-legacy-split/action.yml
@@ -1,0 +1,72 @@
+name: 'backport-legacy-split'
+description: "Backport a merged monorepo commit into a pre-monorepo (<= v0.36) release line. Routes by changed path: pro-only (defer to cherry-pick), OSS-only (re-root to OSS layout + PR on the OSS repo), or mixed (two parallel PRs). Never cuts releases; conflicts open a conflicted PR."
+
+inputs:
+  subtree-prefix:
+    description: "Path of the OSS subtree within the monorepo, e.g. staging/github.com/loft-sh/vcluster. Requires a full-history checkout of the monorepo as the working directory (fetch-depth: 0)."
+    required: true
+  target-branch:
+    description: "Legacy release branch to backport onto, e.g. v0.35. Must exist on the OSS repo (and, for mixed commits, the pro repo)."
+    required: true
+  oss-repo:
+    description: "OSS repository as owner/repo, e.g. loft-sh/vcluster."
+    required: true
+  pro-repo:
+    description: "Pro repository as owner/repo, e.g. loft-sh/vcluster-pro. Target for pro-only commits and the pro half of a mixed commit."
+    required: true
+  github-token:
+    description: "Token with write access to both repos and permission to open PRs. Used to build push remotes and by gh; never logged."
+    required: true
+  commit:
+    description: "Monorepo merge commit to backport (the tip). Names the backport branch; also the diff HEAD in the fallback path. Defaults to HEAD."
+    required: false
+    default: ""
+  pr-number:
+    description: "Source PR number. When set, the PR head is fetched from refs/pull/<n>/head (via github-token) and the diff is merge-base(commit^1, pr-head)..pr-head -- GitHub's 'Files changed', correct for any merge strategy (squash, rebase, or merge commit). Omit (e.g. tests) to fall back to commit^..commit."
+    required: false
+    default: ""
+  create-pr:
+    description: "true = open a PR per pushed backport branch via gh. false = push branches only."
+    required: false
+    default: "true"
+
+outputs:
+  route:
+    description: "Classification of the commit: pro-only | oss-only | mixed."
+    value: ${{ steps.backport.outputs.route }}
+  backport-branch:
+    description: "The backport branch name pushed to the target repo(s)."
+    value: ${{ steps.backport.outputs.backport-branch }}
+  oss-pushed:
+    description: "true when an OSS backport branch was pushed."
+    value: ${{ steps.backport.outputs.oss-pushed }}
+  pro-pushed:
+    description: "true when a pro backport branch was pushed (pro-only or mixed commits)."
+    value: ${{ steps.backport.outputs.pro-pushed }}
+  oss-conflicts:
+    description: "true when the OSS half applied with merge conflicts."
+    value: ${{ steps.backport.outputs.oss-conflicts }}
+  pro-conflicts:
+    description: "true when the pro half applied with merge conflicts."
+    value: ${{ steps.backport.outputs.pro-conflicts }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Backport to legacy line
+      id: backport
+      shell: bash
+      env:
+        SUBTREE_PREFIX: ${{ inputs.subtree-prefix }}
+        TARGET_BRANCH: ${{ inputs.target-branch }}
+        COMMIT: ${{ inputs.commit }}
+        PR_NUMBER: ${{ inputs.pr-number }}
+        CREATE_PR: ${{ inputs.create-pr }}
+        OSS_REPO: ${{ inputs.oss-repo }}
+        PRO_REPO: ${{ inputs.pro-repo }}
+        # Token-less remotes: run.sh authenticates via http.extraheader in the
+        # environment (git_auth), so the PAT never appears in argv / .git/config.
+        OSS_REMOTE: https://github.com/${{ inputs.oss-repo }}.git
+        PRO_REMOTE: https://github.com/${{ inputs.pro-repo }}.git
+        GH_TOKEN: ${{ inputs.github-token }}
+      run: ${{ github.action_path }}/run.sh

--- a/.github/actions/backport-legacy-split/run.sh
+++ b/.github/actions/backport-legacy-split/run.sh
@@ -1,0 +1,345 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Backport a merged monorepo commit into a pre-monorepo (<= v0.36) release line.
+#
+# The monorepo carries pro code at the repo root and OSS code under a subtree
+# prefix (staging/github.com/loft-sh/vcluster). Legacy release branches predate
+# that layout: the pro repo keeps pro code at root and pulls OSS via go.mod; the
+# OSS repo keeps OSS code at root. A plain cherry-pick of a monorepo commit onto
+# a legacy branch is therefore wrong -- for an OSS change it would recreate the
+# staging/ tree on the legacy branch instead of patching the real paths.
+#
+# This action routes by the commit's changed paths:
+#
+#   pro-only  (nothing under the subtree prefix) -> apply the whole diff onto the
+#             pro repo's legacy branch. The legacy pro branch keeps pro code at
+#             root -- the same layout as the monorepo root -- so this is a
+#             same-path apply, no re-root. (sorenlouv is scoped to the monorepo
+#             era >= v0.37 under legacy-split, so it does NOT cover this.)
+#   oss-only  (only paths under the subtree prefix) -> re-root the diff to OSS
+#             layout and open a backport branch/PR on the OSS repo.
+#   mixed     (both) -> split the commit by path into an OSS half and a pro half
+#             and open TWO backport branches/PRs, in parallel: the OSS half on
+#             the OSS repo, the pro half on the pro repo (carrying its root
+#             go.mod diff as-is). No ordering, no release cutting; humans
+#             sequence the two merges and reconcile the loft-sh/vcluster pin.
+#
+# Re-root primitive: `git diff --relative=<prefix> <sha>^ <sha>` both filters the
+# diff to the subtree AND strips the prefix, yielding an OSS-rooted patch that
+# `git apply` lands on the OSS checkout. This is NOT `git subtree split` (which
+# re-roots full history and is the wrong tool for a single commit).
+#
+# 3-way apply across repos: `git apply --3way` needs the patch's preimage blobs
+# present in the target repo, otherwise it fails wholesale on any divergence.
+# The re-rooted patch keeps blob *content* (only path headers change), so we
+# expose the monorepo's object store to the target checkout via an alternates
+# link; --3way then matches preimage blobs by content SHA and produces real
+# conflict markers on divergent legacy code (parity with the backport tool's
+# commitConflicts=true). Conflicts are committed as-is and <side>-conflicts=true
+# is emitted so the caller can label the PR for manual resolution.
+#
+# Required environment variables:
+#   SUBTREE_PREFIX  Subtree path in the monorepo, e.g.
+#                   staging/github.com/loft-sh/vcluster. Requires a full-history
+#                   checkout of the monorepo as CWD (fetch-depth: 0).
+#   TARGET_BRANCH   Legacy release branch to backport onto, e.g. v0.35.
+#   OSS_REMOTE      Pushable URL/path of the OSS repo (loft-sh/vcluster).
+#                   Required for oss-only and mixed.
+#   PRO_REMOTE      Pushable URL/path of the pro repo (vcluster-pro).
+#                   Required for pro-only and mixed.
+#
+# What we backport is the PR's own change set. When PR_NUMBER is set we fetch the
+# PR head (refs/pull/N/head) and diff `merge-base(COMMIT^1, PR_HEAD)..PR_HEAD` --
+# exactly GitHub's "Files changed". Anchoring on the merge commit's FIRST parent
+# makes this correct for every strategy: squash flattens and rebase replays (PR
+# head unchanged either way), and for a true merge commit the PR head is the 2nd
+# parent -- so merge-base against COMMIT itself would collapse to the PR head and
+# diff empty, whereas the first parent is the base side and gives the real fork
+# point. It also excludes base-branch drift (the merge base is the stable fork
+# point), with no reliance on the mutable pull_request.base.sha. Without PR_NUMBER
+# (standalone/tests) it falls back to COMMIT^..COMMIT (single-commit / squash).
+#
+# Optional environment variables:
+#   COMMIT          Monorepo merge commit to backport (default HEAD). Names the
+#                   backport branch; also the diff HEAD in the fallback path.
+#   PR_NUMBER       Source PR number. When set, the PR head is fetched from
+#                   refs/pull/N/head (needs GH_TOKEN) and the diff range is
+#                   merge-base(COMMIT^1, PR_HEAD)..PR_HEAD. Unset (tests) uses
+#                   COMMIT^..COMMIT.
+#   CREATE_PR       "true" opens a PR per pushed branch via gh; "false" pushes
+#                   branches only. Unset defaults to "false" for standalone/test
+#                   runs; the action.yml `create-pr` input defaults to "true".
+#                   Requires GH_TOKEN and OSS_REPO / PRO_REPO (owner/repo slugs).
+#   OSS_REPO        owner/repo slug for `gh pr create` on the OSS side.
+#   PRO_REPO        owner/repo slug for `gh pr create` on the pro side.
+#   WORKDIR         Scratch dir for target checkouts (default: mktemp -d).
+#   GITHUB_OUTPUT   Standard Actions output file; defaults to /dev/null so the
+#                   script is runnable outside CI.
+
+SUBTREE_PREFIX="${SUBTREE_PREFIX:?SUBTREE_PREFIX is required}"
+SUBTREE_PREFIX="${SUBTREE_PREFIX%/}"   # normalize: match on component boundaries
+TARGET_BRANCH="${TARGET_BRANCH:?TARGET_BRANCH is required}"
+COMMIT="${COMMIT:-}"; [ -n "$COMMIT" ] || COMMIT=HEAD
+CREATE_PR="${CREATE_PR:-false}"
+GITHUB_OUTPUT="${GITHUB_OUTPUT:-/dev/null}"
+WORKDIR="${WORKDIR:-$(mktemp -d)}"
+mkdir -p "$WORKDIR"
+
+MONOREPO_DIR="$(git rev-parse --show-toplevel)"
+MONO_OBJECTS="$(git -C "$MONOREPO_DIR" rev-parse --absolute-git-dir)/objects"
+
+emit() { echo "$1=$2" >> "$GITHUB_OUTPUT"; }
+
+# Run git with the PAT supplied via http.extraheader in the ENVIRONMENT (never
+# argv), so token-bearing clone/fetch/push never leak the credential into `ps` or
+# a persisted .git/config. Remotes are token-less URLs (see action.yml). No-op
+# auth when GH_TOKEN is unset (standalone/tests against local-path remotes).
+git_auth() {
+  if [ -n "${GH_TOKEN:-}" ]; then
+    GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=http.extraheader \
+      GIT_CONFIG_VALUE_0="AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\n')" \
+      git "$@"
+  else
+    git "$@"
+  fi
+}
+
+# Defaults so callers can read every output unconditionally.
+emit route ""
+emit backport-branch ""
+emit oss-pushed false
+emit pro-pushed false
+emit oss-conflicts false
+emit pro-conflicts false
+
+SHA="$(git rev-parse "$COMMIT")"
+SHORT="$(git rev-parse --short "$COMMIT")"
+BACKPORT_BRANCH="backport/${TARGET_BRANCH}/${SHORT}"
+emit backport-branch "$BACKPORT_BRANCH"
+
+# --- diff range ------------------------------------------------------------
+# We backport what the PR changed. Deriving that from the merge commit alone is
+# unreliable: COMMIT^ is the base only for a squash/merge-commit; a rebase-merge
+# replays each commit, so COMMIT^ would be just the last one. Instead, when
+# PR_NUMBER is set we fetch the PR's own head (refs/pull/N/head) and diff from its
+# merge base to it -- exactly GitHub's "Files changed". That is correct for every
+# merge strategy AND excludes base-branch drift (the merge base is the stable fork
+# point), with no dependency on the mutable pull_request.base.sha. Without
+# PR_NUMBER (standalone/tests) we fall back to COMMIT^..COMMIT (single-commit).
+DIFF_HEAD="$SHA"
+if [ -n "${PR_NUMBER:-}" ]; then
+  : "${GH_TOKEN:?GH_TOKEN is required to fetch the PR head}"
+  # git_auth keeps the credential off argv (see helper); the checkout uses
+  # persist-credentials:false and these repos are private.
+  if ! fetch_err="$(git_auth fetch -q --no-tags origin "refs/pull/${PR_NUMBER}/head" 2>&1)"; then
+    echo "::error::failed to fetch refs/pull/${PR_NUMBER}/head (needed to compute the PR's full diff)"
+    [ -n "$fetch_err" ] && echo "${fetch_err//${GH_TOKEN}/***}"
+    exit 1
+  fi
+  PR_HEAD="$(git rev-parse FETCH_HEAD)"
+  DIFF_HEAD="$PR_HEAD"
+  # Anchor the merge base on the merge commit's FIRST parent. For a true merge
+  # commit the PR head is the 2nd parent, so merge-base(merge_commit, pr_head)
+  # would collapse to pr_head and yield an empty diff; the first parent is the
+  # base side, so its merge base with the PR head is the real fork point. This is
+  # the fork point for squash and rebase too, so it's correct for every strategy.
+  DIFF_BASE="$(git merge-base "${SHA}^1" "$PR_HEAD")" \
+    || { echo "::error::no merge base between ${SHA}^1 and PR head ${PR_HEAD}"; exit 1; }
+else
+  DIFF_BASE="${SHA}^"
+fi
+echo "diff range: ${DIFF_BASE} .. ${DIFF_HEAD}"
+
+# Files the PR changed -- drives classification. core.quotePath=false so a
+# non-ASCII path isn't dquote/octal-escaped (which would break the
+# "${SUBTREE_PREFIX}"/* match and misroute the commit).
+# Capture into a variable first: `mapfile < <(git diff ...)` reads from a process
+# substitution, so a git-diff failure is invisible to `set -euo pipefail`
+# (mapfile succeeds with zero lines) and would surface as the misleading "changes
+# no files" below instead of the real error.
+changed_raw="$(git -c core.quotePath=false diff --name-only "${DIFF_BASE}" "${DIFF_HEAD}")" \
+  || { echo "::error::git diff ${DIFF_BASE}..${DIFF_HEAD} failed"; exit 1; }
+mapfile -t changed <<<"$changed_raw"
+
+# --- classify changed paths ------------------------------------------------
+oss=false
+pro=false
+for f in "${changed[@]}"; do
+  case "$f" in
+    "") ;;
+    "${SUBTREE_PREFIX}"/*) oss=true ;;
+    *) pro=true ;;
+  esac
+done
+
+if $oss && $pro; then
+  route="mixed"
+elif $oss; then
+  route="oss-only"
+elif $pro; then
+  route="pro-only"
+else
+  echo "::error::commit ${SHA} changes no files"
+  exit 1
+fi
+emit route "$route"
+echo "route=${route} (oss=${oss} pro=${pro}) commit=${SHA} target=${TARGET_BRANCH}"
+
+# backport_side <side> <remote> <slug> <patch-file>
+#
+# Clones TARGET_BRANCH from <remote>, applies <patch-file> with a 3-way merge
+# (conflict markers on divergence), commits, pushes the backport branch, and --
+# when CREATE_PR=true -- opens a PR on <slug> via gh.
+backport_side() {
+  local side="$1" remote="$2" slug="$3" patch="$4"
+  local checkout="${WORKDIR}/${side}"
+
+  if [ ! -s "$patch" ]; then
+    echo "::warning::${side}: empty patch for ${route}; skipping"
+    return 0
+  fi
+
+  # Before any git work: if a PR is already open for this head->base -- or we
+  # can't tell -- leave the branch and PR untouched and skip. The conflicted-PR
+  # flow means a human may have resolved markers directly on that branch, so a
+  # re-run (e.g. a re-labeled source PR) must not clobber it; checking first also
+  # avoids a throwaway clone/apply/commit. Fail safe: keep gh's exit status
+  # separate from its output (a `|| true` would conflate a transient query
+  # failure with a genuine "no PR" and then clobber + fail the create).
+  if [ "$CREATE_PR" = "true" ]; then
+    : "${slug:?repo slug (OSS_REPO/PRO_REPO) is required when CREATE_PR=true}"
+    : "${GH_TOKEN:?GH_TOKEN is required when CREATE_PR=true}"
+    local existing="" rc=0
+    existing="$(gh pr list --repo "$slug" --head "$BACKPORT_BRANCH" --base "$TARGET_BRANCH" --state open --json number --jq '.[0].number // empty' 2>/dev/null)" || rc=$?
+    if [ "$rc" -ne 0 ]; then
+      echo "::warning::${side}: could not query open PRs (gh exit ${rc}); leaving branch and PR as-is rather than risk clobbering an open PR. Re-run to retry."
+      return 0
+    fi
+    if [ -n "$existing" ]; then
+      echo "${side}: PR #${existing} already open for ${BACKPORT_BRANCH} -> ${TARGET_BRANCH}; leaving branch and PR as-is (may hold manual conflict resolution)"
+      return 0
+    fi
+  fi
+
+  # Capture stderr so a real failure (auth, network) is surfaced instead of being
+  # silently misattributed to a missing branch. git_auth supplies credentials via
+  # the environment; the remote URL is token-less, but scrub it anyway for tidiness.
+  local clone_err
+  if ! clone_err="$(git_auth clone -q --branch "$TARGET_BRANCH" --single-branch "$remote" "$checkout" 2>&1)"; then
+    echo "::error::${side}: failed to clone branch '${TARGET_BRANCH}' from ${slug:-the target repo} (missing branch, auth, or network)"
+    [ -n "$clone_err" ] && echo "${clone_err//${remote}/<remote>}"
+    exit 1
+  fi
+  git -C "$checkout" checkout -q -b "$BACKPORT_BRANCH"
+
+  # Expose the monorepo's objects to the target checkout so `git apply --3way`
+  # can find the patch's preimage blobs by content SHA (see header).
+  echo "$MONO_OBJECTS" >> "${checkout}/.git/objects/info/alternates"
+
+  # A conflicted 3-way apply leaves the index unmerged; `git add -A` below stages
+  # the marked files (parity with the backport tool's commitConflicts=true), so
+  # the branch is created BEFORE applying.
+  local conflicts=false
+  if git -C "$checkout" apply --3way --whitespace=nowarn "$patch"; then
+    echo "${side}: patch applied cleanly"
+  else
+    conflicts=true
+    echo "::warning::${side}: applied with conflicts; opening a conflicted PR for manual resolution"
+  fi
+
+  local msg="backport: ${SHORT} to ${TARGET_BRANCH} (${side})
+
+Backport of monorepo commit ${SHA} (${side} half) onto ${TARGET_BRANCH}."
+  if [ "$conflicts" = true ]; then
+    msg="${msg}
+
+Applied with merge conflicts that need manual resolution."
+  fi
+
+  git -C "$checkout" add -A
+  # Anything staged (clean changes OR conflict markers) -> commit below. Nothing
+  # staged has two causes to separate:
+  #   already applied -> the patch's net effect (incl. a deletion/rename, which a
+  #     forward --3way reports as a failure rather than a no-op) is ALREADY on the
+  #     branch, e.g. a re-backport / re-label. A clean REVERSE apply proves this.
+  #     Skip.
+  #   genuinely unappliable -> reverse-check also fails (e.g. a file the patch
+  #     changes was deleted/renamed on the legacy branch). Fail loudly rather than
+  #     let `git commit` emit an opaque "nothing to commit" and crash the job.
+  if git -C "$checkout" diff --cached --quiet; then
+    if git -C "$checkout" apply --reverse --check "$patch" 2>/dev/null; then
+      echo "::warning::${side}: no changes to apply (already present on ${TARGET_BRANCH}?); skipping"
+      return 0
+    fi
+    echo "::error::${side}: cannot 3-way apply onto ${TARGET_BRANCH} -- a file the patch changes was likely deleted or renamed on the legacy branch (or is absent there). Resolve manually."
+    exit 1
+  fi
+  # Emit only on the commit path so a skipped/failed side keeps the default
+  # <side>-conflicts=false (emitted up front) rather than a phantom true.
+  emit "${side}-conflicts" "$conflicts"
+  git -C "$checkout" commit -q -m "$msg"
+
+  # No open PR (checked before cloning), so nothing to protect: (re)create the
+  # branch. Force keeps a re-run before the PR exists idempotent -- e.g. a
+  # leftover branch from a prior run whose PR creation failed -- instead of
+  # failing on a non-fast-forward. The branch name is deterministic
+  # (backport/<target>/<short-sha>). Capture output and scrub $remote (which may
+  # carry a token in its URL) so a push failure can't leak it to the log; git
+  # prints the remote URL on its "To <remote>" / error lines.
+  local push_err
+  if ! push_err="$(git_auth -C "$checkout" push --force "$remote" "$BACKPORT_BRANCH" 2>&1)"; then
+    echo "::error::${side}: failed to push ${BACKPORT_BRANCH} to ${slug:-the target repo}"
+    [ -n "$push_err" ] && echo "${push_err//${remote}/<remote>}"
+    exit 1
+  fi
+  emit "${side}-pushed" true
+  echo "${side}: pushed ${BACKPORT_BRANCH} -> ${slug:-the target repo}"
+
+  if [ "$CREATE_PR" = "true" ]; then
+    local title body
+    title="[${TARGET_BRANCH}] backport ${SHORT} (${side})"
+    body="Automated backport of \`${SHA}\` (${side} half) onto \`${TARGET_BRANCH}\`."
+    local -a create_args=(--repo "$slug" --head "$BACKPORT_BRANCH" --base "$TARGET_BRANCH" --title "$title")
+    if [ "$conflicts" = true ]; then
+      # Open as a DRAFT so it cannot be auto-merged: the committed conflict
+      # markers are valid content (git reports the PR mergeable), and
+      # auto-approve-bot-prs approves any `backport/` PR from a trusted author --
+      # a draft is the one state GitHub refuses to merge until a human marks it
+      # ready. Resolve the markers, then mark ready for review.
+      body="${body}
+
+> :warning: Applied with **merge conflicts**. Opened as a draft so it can't be
+> auto-merged. Resolve the conflict markers, then mark this PR ready for review."
+      create_args+=(--draft)
+    fi
+    gh pr create "${create_args[@]}" --body "$body"
+  fi
+}
+
+# OSS half (oss-only and mixed): re-root staging/... to OSS layout.
+if [ "$route" = "oss-only" ] || [ "$route" = "mixed" ]; then
+  : "${OSS_REMOTE:?OSS_REMOTE is required for ${route}}"
+  # Trailing slash: match on a component boundary so a sibling module dir sharing
+  # the prefix string (e.g. staging/.../vcluster-pro) can't leak into the OSS
+  # patch. --binary: carry binary file changes (a plain diff emits an unappliable
+  # "Binary files differ" placeholder).
+  git diff --binary --relative="${SUBTREE_PREFIX}/" "${DIFF_BASE}" "${DIFF_HEAD}" > "${WORKDIR}/oss.patch"
+  backport_side oss "$OSS_REMOTE" "${OSS_REPO:-}" "${WORKDIR}/oss.patch"
+fi
+
+# Pro side (pro-only and mixed): everything outside the subtree, including root
+# go.mod. For pro-only this is the whole commit; the legacy pro branch is the
+# same root layout as the monorepo root, so it applies without re-rooting.
+if [ "$route" = "pro-only" ] || [ "$route" = "mixed" ]; then
+  : "${PRO_REMOTE:?PRO_REMOTE is required for ${route}}"
+  # In a mixed backport the OSS half above already pushed its branch / opened its
+  # PR; if the pro half below fails, this note keeps the partial-completion
+  # context in the annotations so the operator knows a plain re-run retries the
+  # pro side (the finished OSS side is skipped via its open-PR guard).
+  if [ "$route" = "mixed" ]; then
+    echo "::notice::mixed backport: OSS half done; if the pro half fails, re-run to retry it (OSS side is skipped via its open PR). If the OSS PR was merged/closed meanwhile, finish the pro side manually."
+  fi
+  git diff --binary "${DIFF_BASE}" "${DIFF_HEAD}" -- . ":(exclude)${SUBTREE_PREFIX}" > "${WORKDIR}/pro.patch"
+  backport_side pro "$PRO_REMOTE" "${PRO_REPO:-}" "${WORKDIR}/pro.patch"
+fi

--- a/.github/actions/backport-legacy-split/test/run.bats
+++ b/.github/actions/backport-legacy-split/test/run.bats
@@ -1,0 +1,540 @@
+#!/usr/bin/env bats
+# Tests for run.sh
+#
+# Uses real temporary git repos: a "monorepo" (pro code at root + an OSS subtree
+# under the prefix) and two bare "legacy" remotes (an OSS repo and a pro repo,
+# each with a v0.35 branch in the old root layout). The re-root, path-partition
+# and 3-way apply logic is exercised end to end; pushes go to local bare repos,
+# not the network. CREATE_PR is left unset so the git surgery is tested without
+# gh.
+
+setup() {
+  ROOT=$(mktemp -d)
+  export ROOT
+  export GIT_AUTHOR_NAME=test GIT_AUTHOR_EMAIL=test@test
+  export GIT_COMMITTER_NAME=test GIT_COMMITTER_EMAIL=test@test
+  export GIT_CONFIG_GLOBAL="$ROOT/gitconfig"
+  git config --file "$GIT_CONFIG_GLOBAL" init.defaultBranch main
+  git config --file "$GIT_CONFIG_GLOBAL" protocol.file.allow always
+
+  SCRIPT="$BATS_TEST_DIRNAME/../run.sh"
+  export PFX="staging/github.com/loft-sh/vcluster"
+
+  # Bare legacy OSS remote: OSS content at root, on a v0.35 branch.
+  export OSS_REMOTE="$ROOT/oss.git"
+  git init -q --bare "$OSS_REMOTE"
+  git init -q "$ROOT/oss-seed"
+  (
+    cd "$ROOT/oss-seed"
+    git checkout -q -b v0.35
+    printf 'line1\nline2\nline3\n' > app.go
+    git add -A && git commit -qm "oss legacy: seed"
+    git push -q "$OSS_REMOTE" v0.35
+  )
+
+  # Bare legacy pro remote: pro content + go.mod at root, on a v0.35 branch.
+  export PRO_REMOTE="$ROOT/pro.git"
+  git init -q --bare "$PRO_REMOTE"
+  git init -q "$ROOT/pro-seed"
+  (
+    cd "$ROOT/pro-seed"
+    git checkout -q -b v0.35
+    printf 'package main\n' > main.go
+    printf 'module github.com/loft-sh/vcluster-pro\n\nrequire github.com/loft-sh/vcluster v0.35.1\n' > go.mod
+    git add -A && git commit -qm "pro legacy: seed"
+    git push -q "$PRO_REMOTE" v0.35
+  )
+
+  # Monorepo: OSS under the prefix (same base content as the OSS remote), pro at
+  # root (same base content as the pro remote).
+  export MONO="$ROOT/mono"
+  git init -q "$MONO"
+  cd "$MONO"
+  git checkout -q -b main
+  mkdir -p "$PFX"
+  printf 'line1\nline2\nline3\n' > "$PFX/app.go"
+  printf 'package main\n' > main.go
+  printf 'module github.com/loft-sh/vcluster-pro\n\nrequire github.com/loft-sh/vcluster v0.36.0\n' > go.mod
+  git add -A && git commit -qm "monorepo: seed"
+
+  export SUBTREE_PREFIX="$PFX"
+  export TARGET_BRANCH=v0.35
+  export WORKDIR="$ROOT/work"
+  export GITHUB_OUTPUT="$ROOT/output"
+  : > "$GITHUB_OUTPUT"
+}
+
+teardown() {
+  rm -rf "$ROOT"
+}
+
+# Install a fake `gh` on PATH so the CREATE_PR=true paths can be exercised
+# hermetically (no network). Controlled by env:
+#   GH_PRLIST=empty|exists|fail  -- what `gh pr list` returns (default empty)
+#   GH_CREATE_LOG=<file>         -- `gh pr create` appends its argv here (one/line)
+install_fake_gh() {
+  mkdir -p "$ROOT/bin"
+  cat > "$ROOT/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+if [ "$1" = pr ] && [ "$2" = list ]; then
+  printf '%s\n' "$@" >> "${GH_PRLIST_LOG:-/dev/null}"
+  case "${GH_PRLIST:-empty}" in
+    fail) exit 3 ;;
+    exists) echo 42 ;;
+    *) : ;;
+  esac
+  exit 0
+fi
+if [ "$1" = pr ] && [ "$2" = create ]; then
+  printf '%s\n' "$@" >> "${GH_CREATE_LOG:?}"
+  echo "https://github.com/x/y/pull/99"
+fi
+exit 0
+STUB
+  chmod +x "$ROOT/bin/gh"
+  export PATH="$ROOT/bin:$PATH"
+  export CREATE_PR=true GH_TOKEN=dummy OSS_REPO=loft-sh/vcluster PRO_REPO=loft-sh/vcluster-pro
+  export GH_CREATE_LOG="$ROOT/gh-create.log"; : > "$GH_CREATE_LOG"
+  export GH_PRLIST_LOG="$ROOT/gh-prlist.log"; : > "$GH_PRLIST_LOG"
+}
+
+output_value() { grep "^$1=" "$GITHUB_OUTPUT" | tail -n1 | cut -d= -f2-; }
+
+# Content of <path> on <branch> in a bare remote.
+remote_file() { git -C "$1" show "$2:$3"; }
+# All tracked paths on <branch> in a bare remote.
+remote_paths() { git -C "$1" ls-tree -r --name-only "$2"; }
+
+short() { git -C "$MONO" rev-parse --short HEAD; }
+
+# --- classification --------------------------------------------------------
+
+@test "pro-only commit applies onto the pro legacy branch (no OSS push)" {
+  cd "$MONO"
+  printf 'package main // v2\n' > main.go
+  git commit -qam "pro: change"
+  local br="backport/v0.35/$(short)"
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(output_value route)" = "pro-only" ]
+  [ "$(output_value pro-pushed)" = "true" ]
+  [ "$(output_value oss-pushed)" = "false" ]
+  [ "$(output_value pro-conflicts)" = "false" ]
+  # Pro change landed at root on the pro remote, and no staging/ tree appeared.
+  run bash -c "git -C '$PRO_REMOTE' show '$br:main.go' | grep -q 'v2'"
+  [ "$status" -eq 0 ]
+  run bash -c "git -C '$PRO_REMOTE' ls-tree -r --name-only '$br' | grep staging"
+  [ "$status" -ne 0 ]
+}
+
+@test "re-running the same commit is idempotent (force-push, existing branch)" {
+  cd "$MONO"
+  printf 'line1\nCHANGED\nline3\n' > "$PFX/app.go"
+  git commit -qam "oss: change"
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(output_value oss-pushed)" = "true" ]
+
+  # Second run targets the same deterministic branch already on the remote;
+  # the force-push must not fail on a non-fast-forward.
+  : > "$GITHUB_OUTPUT"
+  rm -rf "$WORKDIR"
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(output_value oss-pushed)" = "true" ]
+}
+
+# --- oss-only: re-root -----------------------------------------------------
+
+@test "oss-only commit re-roots and pushes onto the OSS legacy branch" {
+  cd "$MONO"
+  printf 'line1\nCHANGED\nline3\n' > "$PFX/app.go"
+  git commit -qam "oss: change"
+  local br="backport/v0.35/$(short)"
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(output_value route)" = "oss-only" ]
+  [ "$(output_value oss-pushed)" = "true" ]
+  [ "$(output_value oss-conflicts)" = "false" ]
+  [ "$(output_value backport-branch)" = "$br" ]
+  # Change landed at the OSS root path (prefix stripped), not under staging/.
+  [ "$(remote_file "$OSS_REMOTE" "$br" app.go)" = "$(printf 'line1\nCHANGED\nline3')" ]
+  run bash -c "git -C '$OSS_REMOTE' ls-tree -r --name-only '$br' | grep staging"
+  [ "$status" -ne 0 ]
+}
+
+@test "multi-commit PR (same file): PR-head diff captures every commit" {
+  cd "$MONO"
+  # PR head: two commits editing the SAME OSS file (the shape the old file-name
+  # guard missed). Then a squash-style merge commit on main carrying both changes.
+  git checkout -q -b prhead
+  printf 'line1-c1\nline2\nline3\n' > "$PFX/app.go"; git commit -qam c1
+  printf 'line1-c1\nline2\nline3-c2\n' > "$PFX/app.go"; git commit -qam c2
+  local prhead; prhead="$(git rev-parse HEAD)"
+  git checkout -q main
+  printf 'line1-c1\nline2\nline3-c2\n' > "$PFX/app.go"; git commit -qam "squash (#1)"
+  local mergec; mergec="$(git rev-parse HEAD)"
+  local br="backport/v0.35/$(git rev-parse --short "$mergec")"
+
+  # Expose the PR head as refs/pull/1/head on an origin the action can fetch.
+  local origin="$ROOT/origin.git"
+  git init -q --bare "$origin"
+  git push -q "$origin" main
+  git push -q "$origin" "$prhead:refs/pull/1/head"
+  git remote add origin "$origin"
+
+  COMMIT="$mergec" PR_NUMBER=1 GH_TOKEN=dummy run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(output_value route)" = "oss-only" ]
+  [ "$(output_value oss-pushed)" = "true" ]
+  # BOTH commits' edits land (not just the last one).
+  run bash -c "git -C '$OSS_REMOTE' show '$br:app.go' | grep -q 'line1-c1'"
+  [ "$status" -eq 0 ]
+  run bash -c "git -C '$OSS_REMOTE' show '$br:app.go' | grep -q 'line3-c2'"
+  [ "$status" -eq 0 ]
+}
+
+@test "merge-commit PR: first-parent merge base captures the whole PR" {
+  cd "$MONO"
+  git checkout -q -b prheadmc
+  printf 'line1-c1\nline2\nline3\n' > "$PFX/app.go"; git commit -qam c1
+  printf 'line1-c1\nline2\nline3-c2\n' > "$PFX/app.go"; git commit -qam c2
+  local prhead; prhead="$(git rev-parse HEAD)"
+  git checkout -q main
+  # base drift on a different path so the --no-ff merge is clean
+  printf 'x\n' > basefile.txt; git add -A; git commit -qm "base drift"
+  git merge -q --no-ff -m "merge PR (#2)" "$prhead"
+  local mergec; mergec="$(git rev-parse HEAD)"
+  local br="backport/v0.35/$(git rev-parse --short "$mergec")"
+
+  local origin="$ROOT/origin2.git"
+  git init -q --bare "$origin"
+  git push -q "$origin" main
+  git push -q "$origin" "$prhead:refs/pull/2/head"
+  git remote add origin "$origin"
+
+  # merge-base(mergec, prhead) would be prhead (2nd parent) -> empty diff; the
+  # ^1 anchor uses the base side, so both commits' edits must land.
+  COMMIT="$mergec" PR_NUMBER=2 GH_TOKEN=dummy run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(output_value route)" = "oss-only" ]
+  run bash -c "git -C '$OSS_REMOTE' show '$br:app.go' | grep -q 'line1-c1'"
+  [ "$status" -eq 0 ]
+  run bash -c "git -C '$OSS_REMOTE' show '$br:app.go' | grep -q 'line3-c2'"
+  [ "$status" -eq 0 ]
+}
+
+@test "oss-only commit with a non-ASCII path classifies correctly (quotePath)" {
+  cd "$MONO"
+  printf 'x\n' > "$PFX/café.go"
+  git add -A && git commit -qm "oss: non-ascii filename"
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  # Without core.quotePath=false, git would print "staging/.../caf\303\251.go"
+  # (leading quote) and the prefix match would miss -> misrouted to pro-only.
+  [ "$(output_value route)" = "oss-only" ]
+  [ "$(output_value oss-pushed)" = "true" ]
+}
+
+@test "sibling module sharing the prefix string does not leak into the OSS patch" {
+  cd "$MONO"
+  # One commit: modify the real subtree file AND add a NEW file in a sibling dir
+  # whose name starts with the prefix string but is a different component.
+  printf 'line1\nOSS\nline3\n' > "$PFX/app.go"
+  mkdir -p "${PFX}-pro"
+  printf 'pkg sib\n' > "${PFX}-pro/sib.go"
+  git add -A && git commit -qm "oss + sibling"
+  local br="backport/v0.35/$(short)"
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(output_value route)" = "mixed" ]
+  # OSS patch carries ONLY the real subtree file, re-rooted to app.go -- no
+  # '-pro/sib.go' garbage path leaked in by byte-prefix matching.
+  run bash -c "git -C '$OSS_REMOTE' show '$br:app.go' | grep -q OSS"
+  [ "$status" -eq 0 ]
+  run bash -c "git -C '$OSS_REMOTE' ls-tree -r --name-only '$br' | grep -- '-pro'"
+  [ "$status" -ne 0 ]
+}
+
+@test "binary file change is carried (needs --binary)" {
+  cd "$MONO"
+  printf '\x00\x01\x02\x03BIN\n' > "$PFX/blob.bin"
+  git add -A && git commit -qm "oss: add binary"
+  local br="backport/v0.35/$(short)"
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(output_value route)" = "oss-only" ]
+  [ "$(output_value oss-pushed)" = "true" ]
+  [ "$(output_value oss-conflicts)" = "false" ]
+  # The binary landed on the OSS branch (a plain diff would emit an unappliable
+  # "Binary files differ" placeholder and fail the apply).
+  run bash -c "git -C '$OSS_REMOTE' show '$br:blob.bin' | tr -d '\0' | grep -q BIN"
+  [ "$status" -eq 0 ]
+}
+
+@test "apply that stages nothing due to a failure fails loudly (not 'nothing to commit')" {
+  # Legacy branch deleted a file the patch modifies -> git apply --3way fails
+  # with "does not exist in index" and stages nothing. Must error clearly, not
+  # crash with an opaque "nothing to commit".
+  git clone -q --branch v0.35 --single-branch "$OSS_REMOTE" "$ROOT/ossdel"
+  (
+    cd "$ROOT/ossdel"
+    git rm -q app.go && git commit -qm "drop app.go" && git push -q origin v0.35
+  )
+  cd "$MONO"
+  printf 'line1\nMOD\nline3\n' > "$PFX/app.go"
+  git commit -qam "oss: modify app.go"
+
+  run bash "$SCRIPT"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"cannot 3-way apply"* ]]
+  [ "$(output_value oss-pushed)" = "false" ]
+}
+
+@test "re-backport of an already-applied DELETION skips (not a loud fail)" {
+  # Legacy branch already lacks app.go; the backport also deletes app.go. A
+  # forward --3way of a delete-of-absent-file fails, but the reverse-check proves
+  # the deletion is already applied -> skip, don't hard-fail.
+  git clone -q --branch v0.35 --single-branch "$OSS_REMOTE" "$ROOT/ossdel2"
+  (
+    cd "$ROOT/ossdel2"
+    git rm -q app.go && git commit -qm "already deleted app.go" && git push -q origin v0.35
+  )
+  cd "$MONO"
+  git rm -q "$PFX/app.go"
+  git commit -qm "oss: delete app.go"
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(output_value oss-pushed)" = "false" ]
+  # Nothing applied -> conflicts must stay false (no phantom conflict output).
+  [ "$(output_value oss-conflicts)" = "false" ]
+  [[ "$output" == *"no changes to apply"* ]]
+}
+
+@test "no-op apply (change already on the legacy branch) skips instead of erroring" {
+  # Make the OSS legacy branch already carry the exact change we'll backport.
+  git clone -q --branch v0.35 --single-branch "$OSS_REMOTE" "$ROOT/ossdup"
+  (
+    cd "$ROOT/ossdup"
+    printf 'line1\nALREADY\nline3\n' > app.go
+    git commit -qam "already applied" && git push -q origin v0.35
+  )
+  cd "$MONO"
+  printf 'line1\nALREADY\nline3\n' > "$PFX/app.go"
+  git commit -qam "oss: same change"
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(output_value oss-pushed)" = "false" ]
+  [[ "$output" == *"no changes to apply"* ]]
+}
+
+@test "oss-only commit onto a divergent branch commits conflict markers" {
+  # Make the OSS legacy branch diverge on the same line.
+  git clone -q --branch v0.35 --single-branch "$OSS_REMOTE" "$ROOT/ossdiv"
+  (
+    cd "$ROOT/ossdiv"
+    printf 'line1\nLEGACY-DIVERGENT\nline3\n' > app.go
+    git commit -qam "oss legacy: divergent" && git push -q origin v0.35
+  )
+
+  cd "$MONO"
+  printf 'line1\nCHANGED\nline3\n' > "$PFX/app.go"
+  git commit -qam "oss: change"
+  local br="backport/v0.35/$(short)"
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(output_value oss-conflicts)" = "true" ]
+  [ "$(output_value oss-pushed)" = "true" ]
+  run bash -c "git -C '$OSS_REMOTE' show '$br:app.go' | grep -q '<<<<<<<'"
+  [ "$status" -eq 0 ]
+}
+
+@test "pro-only commit onto a divergent pro branch commits conflict markers" {
+  # Symmetric to the OSS-divergent case, exercising the pro half of backport_side:
+  # a bug that left `conflicts` always false on the pro side (or mis-keyed the
+  # `emit "${side}-conflicts"`) would open a conflicted pro PR as non-draft and
+  # emit pro-conflicts=false. Diverge the pro legacy branch on the same line the
+  # commit touches so the 3-way apply must produce markers.
+  git clone -q --branch v0.35 --single-branch "$PRO_REMOTE" "$ROOT/prodiv"
+  (
+    cd "$ROOT/prodiv"
+    printf 'package main // LEGACY-DIVERGENT\n' > main.go
+    git commit -qam "pro legacy: divergent" && git push -q origin v0.35
+  )
+
+  cd "$MONO"
+  printf 'package main // v2\n' > main.go
+  git commit -qam "pro: change"
+  local br="backport/v0.35/$(short)"
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(output_value route)" = "pro-only" ]
+  [ "$(output_value pro-conflicts)" = "true" ]
+  [ "$(output_value pro-pushed)" = "true" ]
+  [ "$(output_value oss-pushed)" = "false" ]
+  run bash -c "git -C '$PRO_REMOTE' show '$br:main.go' | grep -q '<<<<<<<'"
+  [ "$status" -eq 0 ]
+}
+
+# --- mixed: split ----------------------------------------------------------
+
+@test "mixed commit opens both halves; pro half keeps go.mod and no staging tree" {
+  cd "$MONO"
+  printf 'line1\nOSS-CHANGE\nline3\n' > "$PFX/app.go"
+  printf 'package main // pro change\n' > main.go
+  printf 'module github.com/loft-sh/vcluster-pro\n\nrequire github.com/loft-sh/vcluster v0.36.0\nrequire example.com/dep v1.2.3\n' > go.mod
+  git commit -qam "mixed: oss + pro + go.mod"
+  local br="backport/v0.35/$(short)"
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(output_value route)" = "mixed" ]
+  [ "$(output_value oss-pushed)" = "true" ]
+  [ "$(output_value pro-pushed)" = "true" ]
+
+  # OSS half: re-rooted OSS change only, no pro files.
+  [ "$(remote_file "$OSS_REMOTE" "$br" app.go)" = "$(printf 'line1\nOSS-CHANGE\nline3')" ]
+  run bash -c "git -C '$OSS_REMOTE' ls-tree -r --name-only '$br' | grep -E 'main.go|go.mod|staging'"
+  [ "$status" -ne 0 ]
+
+  # Pro half: pro change + go.mod dep bump carried, and NO staging/ tree created.
+  run bash -c "git -C '$PRO_REMOTE' show '$br:main.go' | grep -q 'pro change'"
+  [ "$status" -eq 0 ]
+  run bash -c "git -C '$PRO_REMOTE' show '$br:go.mod' | grep -q 'example.com/dep'"
+  [ "$status" -eq 0 ]
+  run bash -c "git -C '$PRO_REMOTE' ls-tree -r --name-only '$br' | grep staging"
+  [ "$status" -ne 0 ]
+}
+
+# --- CREATE_PR=true paths (fake gh, hermetic) ------------------------------
+
+@test "create-pr: a clean backport opens a non-draft PR" {
+  install_fake_gh                       # GH_PRLIST defaults to empty -> proceed
+  cd "$MONO"
+  printf 'line1\nOSS\nline3\n' > "$PFX/app.go"
+  git commit -qam "oss: change"
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(output_value oss-pushed)" = "true" ]
+  grep -q '^create$' "$GH_CREATE_LOG"
+  run grep -Fxq -- --draft "$GH_CREATE_LOG"
+  [ "$status" -ne 0 ]                   # clean PR is NOT a draft
+}
+
+@test "create-pr: an existing open PR is detected and the side is skipped" {
+  install_fake_gh
+  export GH_PRLIST=exists
+  cd "$MONO"
+  printf 'line1\nOSS\nline3\n' > "$PFX/app.go"
+  git commit -qam "oss: change"
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(output_value oss-pushed)" = "false" ]
+  [[ "$output" == *"already open"* ]]
+  [ ! -s "$GH_CREATE_LOG" ]             # no PR created
+}
+
+@test "create-pr: a failed open-PR query fails safe (skip, don't clobber)" {
+  install_fake_gh
+  export GH_PRLIST=fail
+  cd "$MONO"
+  printf 'line1\nOSS\nline3\n' > "$PFX/app.go"
+  git commit -qam "oss: change"
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(output_value oss-pushed)" = "false" ]
+  [[ "$output" == *"could not query open PRs"* ]]
+  [ ! -s "$GH_CREATE_LOG" ]
+}
+
+@test "create-pr: a mixed commit opens two PRs, and the open-PR query is well-formed" {
+  install_fake_gh
+  cd "$MONO"
+  printf 'line1\nOSS\nline3\n' > "$PFX/app.go"
+  printf 'package main // pro\n' > main.go
+  git commit -qam "mixed: oss + pro"
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(output_value route)" = "mixed" ]
+  # One create per side (oss + pro), neither a draft (clean apply).
+  [ "$(grep -c '^create$' "$GH_CREATE_LOG")" -eq 2 ]
+  run grep -Fxq -- --draft "$GH_CREATE_LOG"
+  [ "$status" -ne 0 ]
+  # Each half targeted its OWN repo. A presence-only check (both slugs appear)
+  # would also pass on a slug SWAP -- OSS half -> vcluster-pro, pro half ->
+  # vcluster -- since each slug still logs exactly once. The OSS half is always
+  # processed before the pro half, so pin the pairing by ORDER: the OSS slug's
+  # --repo line must precede the pro slug's. The fake gh logs every argv token on
+  # its own line, so each slug is a whole-line match (-x), and vcluster-pro won't
+  # match the vcluster line.
+  local oss_ln pro_ln
+  oss_ln="$(grep -nxF -- 'loft-sh/vcluster' "$GH_CREATE_LOG" | head -n1 | cut -d: -f1)"
+  pro_ln="$(grep -nxF -- 'loft-sh/vcluster-pro' "$GH_CREATE_LOG" | head -n1 | cut -d: -f1)"
+  [ -n "$oss_ln" ] && [ -n "$pro_ln" ]
+  [ "$oss_ln" -lt "$pro_ln" ]
+  # The existing-PR guard queried open PRs for the deterministic head/base --
+  # a regression to that filter would skip forever or clobber.
+  grep -Fxq -- --state "$GH_PRLIST_LOG"
+  grep -Fxq -- open "$GH_PRLIST_LOG"
+  grep -q "backport/v0.35/" "$GH_PRLIST_LOG"
+}
+
+@test "create-pr: a conflicted backport opens a DRAFT PR" {
+  install_fake_gh
+  # Diverge the OSS legacy branch so the apply conflicts.
+  git clone -q --branch v0.35 --single-branch "$OSS_REMOTE" "$ROOT/ossdiv"
+  (
+    cd "$ROOT/ossdiv"
+    printf 'line1\nLEGACY\nline3\n' > app.go
+    git commit -qam "oss legacy: divergent" && git push -q origin v0.35
+  )
+  cd "$MONO"
+  printf 'line1\nOSS\nline3\n' > "$PFX/app.go"
+  git commit -qam "oss: change"
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(output_value oss-conflicts)" = "true" ]
+  [ "$(output_value oss-pushed)" = "true" ]
+  grep -Fxq -- --draft "$GH_CREATE_LOG"  # conflicted PR opened as draft
+}
+
+# --- guards ----------------------------------------------------------------
+
+@test "missing required env fails" {
+  cd "$MONO"
+  printf 'line1\nX\nline3\n' > "$PFX/app.go"
+  git commit -qam "oss: change"
+  unset SUBTREE_PREFIX
+  run bash "$SCRIPT"
+  [ "$status" -ne 0 ]
+}
+
+@test "a commit that changes no files fails loudly" {
+  # An empty commit has no diff under either the subtree prefix or the pro root,
+  # so classification leaves oss=pro=false and the guard must error rather than
+  # push an empty backport branch. Guards against a regression that skipped the
+  # check and silently continued past an empty diff.
+  cd "$MONO"
+  git commit -q --allow-empty -m "empty: no file changes"
+
+  run bash "$SCRIPT"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"changes no files"* ]]
+  [ "$(output_value oss-pushed)" = "false" ]
+  [ "$(output_value pro-pushed)" = "false" ]
+}

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -2,6 +2,33 @@ name: Automatic backport action
 
 on:
   workflow_call:
+    inputs:
+      legacy-split:
+        description: >-
+          Enable the pre-monorepo (<= v0.36) split/re-root backport flow. When
+          true this workflow empties auto_backport_label_prefix so sorenlouv
+          honors the caller's .backportrc.json branchLabelMapping regex (which
+          MUST be scoped to the monorepo era, >= v0.37), and a companion job
+          routes <= v0.36 targets through backport-legacy-split. Requires
+          subtree-prefix, oss-repo and pro-repo.
+        type: boolean
+        required: false
+        default: false
+      subtree-prefix:
+        description: 'OSS subtree path in the monorepo, e.g. staging/github.com/loft-sh/vcluster. Required when legacy-split is true.'
+        type: string
+        required: false
+        default: ''
+      oss-repo:
+        description: 'OSS repo as owner/repo for legacy OSS-side backport PRs. Required when legacy-split is true.'
+        type: string
+        required: false
+        default: ''
+      pro-repo:
+        description: 'Pro repo as owner/repo for the pro half of mixed legacy backports. Required when legacy-split is true.'
+        type: string
+        required: false
+        default: ''
     secrets:
       gh-access-token:
         description: 'GitHub PAT for creating backport PRs'
@@ -9,6 +36,14 @@ on:
       linear-token:
         description: 'Linear API token for linking backport PRs to their matching Linear sub-issue. Optional; linking is skipped when not provided.'
         required: false
+
+# Serialize runs for the same source PR so two rapid label events can't both race
+# past the open-PR check and double-create the same deterministic backport branch
+# (the second gh pr create would fail "already exists"). Queue, don't cancel, so
+# an in-flight backport always finishes.
+concurrency:
+  group: backport-${{ github.repository }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
 
 jobs:
   backport:
@@ -23,6 +58,7 @@ jobs:
       ) &&
       (github.event.action == 'closed' || startsWith(github.event.label.name, 'backport-to-'))
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
     steps:
@@ -39,7 +75,13 @@ jobs:
         uses: sorenlouv/backport-github-action@9460b7102fea25466026ce806c9ebf873ac48721 # v11.0.0
         with:
           github_token: ${{ secrets.gh-access-token }} # zizmor: ignore[secrets-outside-env] -- PAT passed via workflow_call, not a repo secret
-          auto_backport_label_prefix: backport-to-
+          # With legacy-split on, scope sorenlouv to the monorepo era (>= v0.37)
+          # by deferring to the caller's branchLabelMapping regex: an empty
+          # prefix makes the action pass branchLabelMapping: undefined, which the
+          # backport tool strips (excludeUndefined) so the file's mapping wins.
+          # The `== false && A || B` form is required because GHA's `A && x || B`
+          # collapses when x is the empty string.
+          auto_backport_label_prefix: ${{ inputs.legacy-split == false && 'backport-to-' || '' }}
 
       # Link each backport PR to the matching Linear sub-issue ([X.Y] Copy of ...)
       # so it closes on merge. Advisory: never fails the job, and is skipped when
@@ -63,3 +105,88 @@ jobs:
       - name: Debug log
         if: ${{ failure() }}
         run: cat ~/.backport/backport.debug.log
+
+  # --- pre-monorepo (<= v0.36) split/re-root flow ---------------------------
+  # sorenlouv (above) only cherry-picks monorepo-era (>= v0.37) targets. Legacy
+  # lines predate the monorepo layout, so a cherry-pick there would recreate the
+  # staging/ tree; they are re-rooted and PR'd by backport-legacy-split instead.
+  legacy-classify:
+    name: Classify legacy targets
+    if: |
+      inputs.legacy-split &&
+      github.event.pull_request.merged == true &&
+      contains(join(github.event.pull_request.labels.*.name, ','), 'backport-to-') &&
+      (github.event.action == 'closed' || startsWith(github.event.label.name, 'backport-to-'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    outputs:
+      targets: ${{ steps.allowlist.outputs.targets }}
+      has-targets: ${{ steps.allowlist.outputs.has-targets }}
+    steps:
+      - name: Validate legacy-split inputs
+        env:
+          SUBTREE_PREFIX: ${{ inputs.subtree-prefix }}
+          OSS_REPO: ${{ inputs.oss-repo }}
+          PRO_REPO: ${{ inputs.pro-repo }}
+        shell: bash
+        run: |
+          missing=()
+          [ -n "$SUBTREE_PREFIX" ] || missing+=(subtree-prefix)
+          [ -n "$OSS_REPO" ] || missing+=(oss-repo)
+          [ -n "$PRO_REPO" ] || missing+=(pro-repo)
+          if [ "${#missing[@]}" -gt 0 ]; then
+            echo "::error::legacy-split is enabled but required input(s) empty: ${missing[*]}. Set them in the caller (uses: backport.yaml with: ...)."
+            exit 1
+          fi
+
+      - name: Compute in-support legacy allow-list
+        id: allowlist
+        uses: loft-sh/github-actions/.github/actions/backport-legacy-allowlist@backport-legacy-allowlist/v1 # zizmor: ignore[unpinned-uses] -- internal loft-sh/github-actions ref; reusable workflows check out the CALLER repo, so a local ./.github/actions path is not present here. @backport-legacy-allowlist/v1 is the floating coordination tag kept aligned with backport/v1 (see DEVOPS-923 pin-drift class).
+        with:
+          labels: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+          max-minor: '36'
+
+  legacy-backport:
+    name: Backport ${{ matrix.target }} (legacy)
+    needs: legacy-classify
+    if: needs.legacy-classify.outputs.has-targets == 'true'
+    runs-on: ubuntu-latest
+    # Bound clone + apply + push so a GitHub service stall can't strand the
+    # matrix slot up to the 6h wall-clock default.
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ${{ fromJSON(needs.legacy-classify.outputs.targets) }}
+    steps:
+      - name: Checkout monorepo at the merged commit
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Pin to the merge commit so it AND its parent (the diff base) are
+          # present locally; on a pull_request_target closed event the default
+          # checkout ref is the pre-merge base SHA, which would not contain it.
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install GH CLI
+        uses: dev-hanz-ops/install-gh-cli-action@af38ce09b1ec248aeb08eea2b16bbecea9e059f8 # v0.2.1
+
+      - name: Backport to ${{ matrix.target }}
+        uses: loft-sh/github-actions/.github/actions/backport-legacy-split@backport-legacy-split/v1 # zizmor: ignore[unpinned-uses] -- internal loft-sh/github-actions ref; reusable workflows check out the CALLER repo, so a local ./.github/actions path is not present here. @backport-legacy-split/v1 is the floating coordination tag kept aligned with backport/v1 (see DEVOPS-923 pin-drift class).
+        with:
+          subtree-prefix: ${{ inputs.subtree-prefix }}
+          target-branch: ${{ matrix.target }}
+          oss-repo: ${{ inputs.oss-repo }}
+          pro-repo: ${{ inputs.pro-repo }}
+          github-token: ${{ secrets.gh-access-token }}
+          commit: ${{ github.event.pull_request.merge_commit_sha }}
+          # PR number so the action diffs the PR head (refs/pull/N/head) from its
+          # merge base -- GitHub's "Files changed" -- capturing every commit of a
+          # rebase-merged PR, not just the merge tip.
+          pr-number: ${{ github.event.pull_request.number }}
+          create-pr: 'true'

--- a/.github/workflows/test-backport-legacy-allowlist.yaml
+++ b/.github/workflows/test-backport-legacy-allowlist.yaml
@@ -1,0 +1,21 @@
+name: Test backport-legacy-allowlist
+
+on:
+  pull_request:
+    paths:
+      - '.github/actions/backport-legacy-allowlist/**'
+      - '.github/workflows/test-backport-legacy-allowlist.yaml'
+
+permissions: {}
+
+jobs:
+  bats:
+    name: Run bats tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
+        with:
+          tests: .github/actions/backport-legacy-allowlist/test

--- a/.github/workflows/test-backport-legacy-split.yaml
+++ b/.github/workflows/test-backport-legacy-split.yaml
@@ -1,0 +1,21 @@
+name: Test backport-legacy-split
+
+on:
+  pull_request:
+    paths:
+      - '.github/actions/backport-legacy-split/**'
+      - '.github/workflows/test-backport-legacy-split.yaml'
+
+permissions: {}
+
+jobs:
+  bats:
+    name: Run bats tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
+        with:
+          tests: .github/actions/backport-legacy-split/test

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-semver-validation test-linear-pr-commenter test-link-backport-prs test-release-notification test-linear-release-sync test-aws-test-infra test-cleanup-head-charts test-ci-test-notify test-auto-approve-bot-prs test-ai-pr-review test-ai-step test-publish-helm-chart test-govulncheck test-go-licenses test-run-ginkgo test-sticky-pr-comment test-repository-dispatch test-parse-label-filter test-release-branch-freeze test-vcluster-release test-subtree-mirror build-linear-release-sync lint install-auto-doc generate-docs check-docs help
+.PHONY: test test-semver-validation test-linear-pr-commenter test-link-backport-prs test-release-notification test-linear-release-sync test-aws-test-infra test-cleanup-head-charts test-ci-test-notify test-auto-approve-bot-prs test-ai-pr-review test-ai-step test-publish-helm-chart test-govulncheck test-go-licenses test-run-ginkgo test-sticky-pr-comment test-repository-dispatch test-parse-label-filter test-release-branch-freeze test-vcluster-release test-subtree-mirror test-backport-legacy-allowlist test-backport-legacy-split build-linear-release-sync lint install-auto-doc generate-docs check-docs help
 
 ACTIONS_DIR := .github/actions
 WORKFLOWS_DIR := .github/workflows
@@ -93,7 +93,7 @@ check-docs: generate-docs ## verify docs are up to date (fails if drift detected
 help: ## show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-30s %s\n", $$1, $$2}'
 
-test: test-semver-validation test-linear-pr-commenter test-link-backport-prs test-release-notification test-linear-release-sync test-aws-test-infra test-cleanup-head-charts test-auto-approve-bot-prs test-ai-pr-review test-ai-step test-ci-test-notify test-go-licenses test-publish-helm-chart test-govulncheck test-run-ginkgo test-sticky-pr-comment test-repository-dispatch test-parse-label-filter test-release-branch-freeze test-vcluster-release test-subtree-mirror ## run all action tests
+test: test-semver-validation test-linear-pr-commenter test-link-backport-prs test-release-notification test-linear-release-sync test-aws-test-infra test-cleanup-head-charts test-auto-approve-bot-prs test-ai-pr-review test-ai-step test-ci-test-notify test-go-licenses test-publish-helm-chart test-govulncheck test-run-ginkgo test-sticky-pr-comment test-repository-dispatch test-parse-label-filter test-release-branch-freeze test-vcluster-release test-subtree-mirror test-backport-legacy-allowlist test-backport-legacy-split ## run all action tests
 
 test-semver-validation: ## run semver-validation unit tests
 	cd $(ACTIONS_DIR)/semver-validation && npm ci --silent && NODE_OPTIONS=--experimental-vm-modules npx jest --ci --coverage --watchAll=false
@@ -157,6 +157,12 @@ test-vcluster-release: ## run vcluster-release bats tests
 
 test-subtree-mirror: ## run subtree-mirror bats tests
 	bats $(ACTIONS_DIR)/subtree-mirror/test/run.bats
+
+test-backport-legacy-allowlist: ## run backport-legacy-allowlist bats tests
+	bats $(ACTIONS_DIR)/backport-legacy-allowlist/test/run.bats
+
+test-backport-legacy-split: ## run backport-legacy-split bats tests
+	bats $(ACTIONS_DIR)/backport-legacy-split/test/run.bats
 
 build-linear-release-sync: ## build linear-release-sync binary (linux/amd64)
 	cd $(ACTIONS_DIR)/linear-release-sync/src && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-s -w" -o ../linear-release-sync-linux-amd64 .

--- a/docs/backport-legacy-branches-spike.md
+++ b/docs/backport-legacy-branches-spike.md
@@ -1,0 +1,59 @@
+# Decision record: backporting monorepo PRs to pre-monorepo (≤ v0.36) lines
+
+**Ticket:** DEVOPS-1051
+
+This is a durable decision record for *why* the legacy backport path is shaped
+the way it is. The concrete mechanics (routing, re-root, diff range, conflict
+handling, allow-list) are documented in the living action READMEs
+([`backport-legacy-split`](../.github/actions/backport-legacy-split/README.md),
+[`backport-legacy-allowlist`](../.github/actions/backport-legacy-allowlist/README.md))
+and the reusable [`backport.yaml`](../.github/workflows/backport.yaml); this file
+only records the choices, not the implementation.
+
+## Context
+
+After the vCluster OSS → pro monorepo merge, `vcluster-pro` carries pro code at
+the repo root and OSS code under `staging/github.com/loft-sh/vcluster/`. The
+legacy release branches predate that layout (pro at root, OSS pulled via
+`go.mod`; `loft-sh/vcluster` keeps OSS at root). A plain cherry-pick of a
+monorepo commit onto a legacy branch is therefore wrong — for an OSS change it
+recreates the `staging/` tree instead of patching the real paths.
+
+## Decisions
+
+1. **A new companion action, not an extension of `sorenlouv`.** sorenlouv does a
+   single-repo, label-driven cherry-pick; it has no notion of path re-rooting,
+   cross-repo targets, or splitting one commit into two PRs. Those four
+   capabilities (route-by-path, re-root, cross-repo PR, mixed split) live in a
+   dedicated `backport-legacy-split` action; sorenlouv stays for the monorepo-era
+   cherry-pick.
+
+2. **Era boundary is v0.37.** The split/re-root flow covers **≤ v0.36**; the
+   monorepo era (mirror/FF propagation, plain cherry-pick) is **≥ v0.37**. Aligns
+   with the release-era cutover (`loft-sh/github-actions` `d9da3aa`).
+
+3. **Prerequisite for the monorepo merge, not blocked by it.** Merging without a
+   working ≤ v0.36 backport path would strand the legacy lines (no security-fix
+   delivery). The action is therefore built and validated against bats fixtures
+   that reproduce the post-merge layout, and must be green before the merge lands.
+
+4. **Route by changed path; mixed = two PRs in parallel.** pro-only → pro repo;
+   OSS-only → re-rooted PR on `loft-sh/vcluster`; mixed → both, in parallel. No
+   forced ordering, no "new OSS API" detection, and the action never cuts
+   releases or tags. The pro half carries the PR's root `go.mod` diff as-is; the
+   `loft-sh/vcluster` pin is human-reconciled during the sequenced merge (a
+   conflicted PR is the expected mechanism).
+
+5. **Allow-list at the shared-workflow layer.** The ≤ v0.36 / EOL guard lives in
+   the reusable `backport.yaml` (not `targetBranchChoices`, which is
+   interactive-only and never read by the label-driven CI flow), so it also caps
+   the OSS side's external-contributor PR flow. In-support lines are derived
+   dynamically from the vCluster lifecycle doc
+   (`https://www.vcluster.com/docs/api/lifecycle/vcluster.json`), failing closed,
+   with a hardcoded fallback only on a fetch/parse failure.
+
+## Adjacent wiring preserved
+
+Backport branches use the `backport/` prefix and the bot token so
+`auto-approve-bot-prs`, `cleanup-backport-branches`, and `link-backport-prs`
+keep working. (Cross-repo Linear linking for legacy PRs is a tracked follow-up.)

--- a/docs/workflows/backport.md
+++ b/docs/workflows/backport.md
@@ -5,7 +5,14 @@ Creates backport PRs when a merged PR is labeled with `backport/<branch>`.
 ## Inputs
 
 <!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
-No inputs.
+
+|     INPUT      |  TYPE   | REQUIRED | DEFAULT |                                                                                                                                                                                                   DESCRIPTION                                                                                                                                                                                                   |
+|----------------|---------|----------|---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|  legacy-split  | boolean |  false   | `false` | Enable the pre-monorepo (<= v0.36) split/re-root backport <br>flow. When true this workflow empties <br>auto_backport_label_prefix so sorenlouv honors the caller's <br>.backportrc.json branchLabelMapping regex (which MUST be scoped to the monorepo era, >= v0.37), and a <br>companion job routes <= v0.36 targets <br>through backport-legacy-split. Requires subtree-prefix, oss-repo and <br>pro-repo.  |
+|    oss-repo    | string  |  false   |         |                                                                                                                                                      OSS repo as owner/repo for legacy <br>OSS-side backport PRs. Required when legacy-split <br>is true.                                                                                                                                                       |
+|    pro-repo    | string  |  false   |         |                                                                                                                                                 Pro repo as owner/repo for the <br>pro half of mixed legacy backports. <br>Required when legacy-split is true.                                                                                                                                                  |
+| subtree-prefix | string  |  false   |         |                                                                                                                                            OSS subtree path in the monorepo, <br>e.g. staging/github.com/loft-sh/vcluster. Required when legacy-split is <br>true.                                                                                                                                              |
+
 <!-- AUTO-DOC-INPUT:END -->
 
 ## Secrets


### PR DESCRIPTION
## Summary

After the vCluster OSS → vCluster Pro monorepo merge, a plain cherry-pick of a `main` commit onto a legacy (`<= v0.36`) release branch is wrong: the layouts differ (monorepo carries OSS under `staging/github.com/loft-sh/vcluster/`, legacy branches are old-layout), so a cherry-pick would recreate the `staging/` tree instead of patching the real paths. This adds the pre-monorepo backport path so legacy lines still get security-fix delivery. Prerequisite for the monorepo merge (DEVOPS-852).

- **`backport-legacy-split`** action — routes a merged monorepo commit by changed path: pro-only → apply onto the **pro repo** legacy branch (same root layout, no re-root); oss-only → re-root the subtree and PR onto `loft-sh/vcluster`; mixed → both, in parallel. The backport is the PR's own change set — it fetches the PR head (`refs/pull/<n>/head`) and diffs `merge-base(<merge_commit>^1, pr_head)..pr_head` (GitHub's "Files changed"), correct for squash/rebase/merge-commit and immune to base-branch drift. OSS re-root is `git diff --binary --relative=<prefix>/` (trailing slash = component boundary so a sibling module can't leak; `--binary` carries binary changes). Applies with `git apply --3way` across repos via an `objects/info/alternates` link, so divergence commits real conflict markers and the PR opens as a **draft** (so it can't be auto-merged with markers in it). Re-runs are idempotent (skip when an open PR exists; force-push otherwise) and safe for in-progress conflict resolution; an unappliable patch fails loudly; auth is via `http.extraheader` in the environment so the token never reaches argv/`.git/config`.
- **`backport-legacy-allowlist`** action — the allow-list guard at the shared-workflow layer: reads the vCluster lifecycle doc and gates `backport-to-*` labels to in-support `<= v0.36` lines, emitting a JSON matrix. Each line is judged on **its own `eolDate`** (fail closed), so a non-contiguous lifecycle can't slip an EOL line through; a freshly-cut line above the doc's coverage (e.g. `v0.36`) still qualifies; a doc that lists no `0.x` lines allows nothing; only a fetch/parse failure falls back to a contiguous `[fallback-min, 36]` window.
- **`backport.yaml`** wiring — new opt-in `legacy-split` input (plus `subtree-prefix`/`oss-repo`/`pro-repo`). When on, `auto_backport_label_prefix` is emptied so `sorenlouv` honors the caller's era-scoped `branchLabelMapping` (`>= v0.37`), and `legacy-classify` → `legacy-backport` route `<= v0.36` targets through the split flow (per-job timeouts bound clone/apply/push).

The path is **additive**: default-off, no new required inputs/secrets, `sorenlouv` behavior byte-identical when `legacy-split` is unset. All consumers SHA-pin, so re-pointing `backport/v1` is inert (see DEVOPS-1051 for the compatibility analysis).

## Test plan

- `bats` for both actions (45 tests): re-root, path partition, `--binary`, sibling-boundary, non-ASCII path, multi-commit + merge-commit diff range, conflict markers on **both** sides (oss and pro), the empty-commit guard, no-op skip, failed-apply loud error, idempotent force-push, missing-env, and — via a fake `gh` on `PATH` — the `CREATE_PR` paths (clean non-draft create, existing-PR skip, failed-query fail-safe, mixed double-create with **per-repo targeting**, draft-on-conflict) (21 split); allow-list boundaries, EOL pruning, non-contiguous lifecycle, doc-gap and no-`0.x` fail-closed, null-`eolDate`/null-`status` fail-closed, freshly-cut v0.36, fallback, JSON label parsing (24 allowlist). Both suites run under `make test` via per-action targets (`test-backport-legacy-split`, `test-backport-legacy-allowlist`). Hermetic — local git repos (incl. a `file://` pull ref) and a `file://` lifecycle fixture with pinned `TODAY`.
- `shellcheck` clean on both `run.sh`; `actionlint` + `zizmor` clean on all workflows/actions; `make check-docs` clean.
- The `sorenlouv` scoping (empty prefix → file `branchLabelMapping` governs) was verified against the `backport` v11.0.0 source (`excludeUndefined` strips the undefined mapping) and the era regex against a 14-case matrix. The diff-range primitive was verified empirically across squash/rebase/merge-commit and base-drift.

## Test coverage note

The `gh` decision logic in `backport-legacy-split` — the open-PR fail-safe query, the skip-if-PR-exists branch, and `gh pr create` (incl. `--draft` on conflict, and which `--repo` each half targets) — is unit-covered via a fake `gh` on `PATH`. What remains **e2e-only** is the authenticated `refs/pull/<n>/head` fetch against a real private remote (the bats pull-ref fixture is a local `file://` remote, so it doesn't exercise the `http.extraheader` auth) and the real cross-repo push. Those are covered by the DEVOPS-1051 experiments-org rehearsal; ideally land the e2e caller before flipping `legacy-split: true` in the sibling vcluster-pro PR.

## Merge-time coordination

Land this, then **atomically** cut/re-point the coordination tags (`backport/v1`, `backport-legacy-split/v1`, `backport-legacy-allowlist/v1`) to the merge commit — a caller that sets `legacy-split: true` after `backport/v1` moves but before both sibling tags exist hits an unresolvable `uses:`. The sibling `vcluster-pro` PR (`.backportrc.json` era regex + caller `legacy-split: true`) bumps its pin to that SHA and merges together. The no-double-backport guarantee rests on that era regex (`>= v0.37`), so confirm it has landed before enabling `legacy-split`.

References DEVOPS-1051
