### PR TITLE
feat(linear-release-sync): comment on shipped issues regardless of status

### DIFF
--- a/.github/actions/linear-release-sync/README.md
+++ b/.github/actions/linear-release-sync/README.md
@@ -7,9 +7,10 @@ A GitHub Action that syncs Linear issues to the "Released" state when a GitHub r
 - Fetches all team keys from Linear to filter false positive issue IDs (e.g. `pr-3354`, `snap-1`)
 - Extracts Linear issue IDs from PR descriptions and branch names (e.g., `ENG-1234`, `DEVOPS-471`)
 - Strict time-based filtering: only includes PRs merged before the release was published
-- Moves issues from "Ready for Release" to "Released" state
+- Moves issues from "Ready for Release" to "Released" state (only issues in that state are moved)
 - Adds release comments with version and date
 - For stable releases on already-released issues, adds "Now available in stable release" comments
+- For stable releases, comments on shipped issues regardless of status: an issue whose PRs are in the release but which is not in "Ready for Release" (e.g. moved back to "In Progress" by a follow-up docs PR) gets a status-neutral "Shipped in `<tag>`" comment and is left in place, so the shipment is tracked without claiming the issue is done. Prereleases stay quiet to avoid re-commenting per RC, and the comment is deduplicated per tag (DEVOPS-1099)
 - Classifies a release as stable from the tag name: a tag with no semver prerelease component (e.g. `v0.34.4`) or one beginning with `patch` (e.g. `v0.28.2-patch.1`) is treated as a real release and syncs, while `-rc`/`-alpha`/`-beta`/`-dev`/`-pre`/`-next` tags are prereleases and are skipped. The tag is used rather than GitHub's `prerelease` flag because that flag is human-set and a release is often published as a prerelease first and promoted to stable later
 - Skips CVE issues automatically
 - Supports dry-run mode for previewing changes

--- a/.github/actions/linear-release-sync/src/linear.go
+++ b/.github/actions/linear-release-sync/src/linear.go
@@ -481,12 +481,17 @@ func (l *LinearClient) ListIssueComments(ctx context.Context, issueID string) ([
 	return bodies, nil
 }
 
-// hasReleaseComment reports whether any comment body starts with "<prefix> <releaseTag>".
+// hasReleaseComment reports whether any comment body starts with "<prefix> <releaseTag> (released ".
 // It is used to make the release comments idempotent per tag, so a cherry-pick released in
 // a later version still gets its own comment while a repeated sync of the same tag does not
 // re-comment (vcluster and vcluster-pro cut identical tags against the same Linear issue).
+//
+// The trailing " (released " delimiter is required, not cosmetic: both release comment bodies
+// place it immediately after the tag, and matching it prevents a shorter tag from falsely
+// matching a longer one (e.g. releaseTag "v0.28.2" must NOT dedup against an existing
+// "...v0.28.20 (released ..." comment, which would silently suppress the v0.28.2 comment).
 func hasReleaseComment(comments []string, prefix, releaseTag string) bool {
-	expected := fmt.Sprintf("%s %s", prefix, releaseTag)
+	expected := fmt.Sprintf("%s %s (released ", prefix, releaseTag)
 	for _, body := range comments {
 		if strings.HasPrefix(body, expected) {
 			return true

--- a/.github/actions/linear-release-sync/src/linear.go
+++ b/.github/actions/linear-release-sync/src/linear.go
@@ -20,7 +20,7 @@ type releaseAction int
 
 const (
 	// actionSkip leaves the issue untouched: a CVE, an issue already released on a
-	// prior prerelease, or an issue not yet in the ready-for-release state.
+	// prior prerelease, or an issue that is not ready and shipped only in a prerelease.
 	actionSkip releaseAction = iota
 	// actionMoveToReleased moves the issue to Released and adds the "first released" comment.
 	actionMoveToReleased
@@ -28,6 +28,11 @@ const (
 	// release, so (subject to the tag-scoped dedup check) add the "Now available in
 	// stable release" comment.
 	actionStableComment
+	// actionCommentOnly means the issue's PRs shipped in this (stable) release but the
+	// issue is not in the ready-for-release state, so it is NOT moved. Add a status-neutral
+	// "Shipped in" comment (subject to the tag-scoped dedup check) so the shipment is
+	// tracked without claiming the issue is done. DEVOPS-1099.
+	actionCommentOnly
 )
 
 func (a releaseAction) String() string {
@@ -38,6 +43,8 @@ func (a releaseAction) String() string {
 		return "move-to-released"
 	case actionStableComment:
 		return "stable-comment"
+	case actionCommentOnly:
+		return "comment-only"
 	default:
 		return fmt.Sprintf("releaseAction(%d)", int(a))
 	}
@@ -64,11 +71,21 @@ func decideReleaseAction(issueID string, alreadyReleased, isStable, inReadyForRe
 		return actionStableComment
 	}
 
-	// Not released yet: only act on issues sitting in the ready-for-release state.
-	if !inReadyForRelease {
-		return actionSkip
+	// Not released yet.
+	if inReadyForRelease {
+		return actionMoveToReleased
 	}
-	return actionMoveToReleased
+
+	// Not released and not ready for release: the issue's PRs shipped in this release but
+	// it is not marked ready, so it must not be moved to Released. On a stable release,
+	// post a status-neutral "Shipped in" comment so the shipment is still tracked (a docs
+	// PR or follow-up can move an issue back out of the ready set, so it would otherwise be
+	// silently skipped). On a prerelease, stay quiet to avoid re-commenting on the same
+	// not-ready issue for every RC. DEVOPS-1099.
+	if isStable {
+		return actionCommentOnly
+	}
+	return actionSkip
 }
 
 // AvailableWorkflowState lists all workflow states for a team (for debugging)
@@ -323,6 +340,12 @@ func (l *LinearClient) MoveIssueToState(ctx context.Context, dryRun bool, issueI
 	alreadyReleased := issueDetails.StateID == releasedStateID
 	inReadyForRelease := issueDetails.StateName == readyForReleaseStateName
 
+	// releaseComment is the text posted at the end. Each acting branch sets it; the two
+	// comment-without-move branches also run a tag-scoped dedup check first, because they
+	// leave the issue in place and so would otherwise re-comment on every later sync (and
+	// vcluster + vcluster-pro cut identical tags against the same Linear issue, DEVOPS-1006).
+	var releaseComment string
+
 	switch decideReleaseAction(issueID, alreadyReleased, isStable, inReadyForRelease) {
 	case actionSkip:
 		logger.Debug("Skipping issue", "issueID", issueID, "alreadyReleased", alreadyReleased, "isStable", isStable, "currentState", issueDetails.StateName)
@@ -335,11 +358,29 @@ func (l *LinearClient) MoveIssueToState(ctx context.Context, dryRun bool, issueI
 		if err != nil {
 			return fmt.Errorf("list issue comments: %w", err)
 		}
-		if hasStableReleaseComment(comments, releaseTagName) {
+		if hasReleaseComment(comments, stableReleaseCommentPrefix, releaseTagName) {
 			logger.Debug("Issue already has stable release comment, skipping", "issueID", issueID)
 			return nil
 		}
 		logger.Debug("Issue already released, adding stable release comment", "issueID", issueID)
+		// Distinct wording from the "first released in" pattern used by linear-webhook-service.
+		releaseComment = fmt.Sprintf("%s %v (released %v)", stableReleaseCommentPrefix, releaseTagName, releaseDate)
+
+	case actionCommentOnly:
+		// The issue's PRs shipped in this stable release but it is not in the ready-for-release
+		// state, so do not move it. Post a status-neutral "Shipped in" comment once per tag so
+		// the shipment is tracked without claiming the issue is done (DEVOPS-1099). There is no
+		// state transition to make this idempotent, so the tag-scoped dedup check is required.
+		comments, err := l.ListIssueComments(ctx, issueID)
+		if err != nil {
+			return fmt.Errorf("list issue comments: %w", err)
+		}
+		if hasReleaseComment(comments, shippedCommentPrefix, releaseTagName) {
+			logger.Debug("Issue already has shipped comment, skipping", "issueID", issueID)
+			return nil
+		}
+		logger.Debug("Issue not ready for release, adding shipped comment", "issueID", issueID, "currentState", issueDetails.StateName)
+		releaseComment = fmt.Sprintf("%s %v (released %v). This issue is not in %q, so it was not moved to the released state.", shippedCommentPrefix, releaseTagName, releaseDate, readyForReleaseStateName)
 
 	case actionMoveToReleased:
 		// Update issue state to Released
@@ -351,15 +392,6 @@ func (l *LinearClient) MoveIssueToState(ctx context.Context, dryRun bool, issueI
 			logger.Info("Would update issue state", "issueID", issueID, "releasedStateID", releasedStateID)
 		}
 		logger.Info("Moved issue to desired state", "issueID", issueID, "stateID", releasedStateID)
-	}
-
-	// Add release comment
-	// Use different text for stable releases on already-released issues to avoid
-	// confusion with the "first released in" pattern used by linear-webhook-service
-	var releaseComment string
-	if alreadyReleased && isStable {
-		releaseComment = fmt.Sprintf("Now available in stable release %v (released %v)", releaseTagName, releaseDate)
-	} else {
 		releaseComment = fmt.Sprintf("This issue was first released in %v on %v", releaseTagName, releaseDate)
 	}
 
@@ -399,6 +431,11 @@ func (l *LinearClient) updateIssueState(ctx context.Context, issueID, releasedSt
 
 // stableReleaseCommentPrefix is the prefix used to identify stable release comments.
 const stableReleaseCommentPrefix = "Now available in stable release"
+
+// shippedCommentPrefix is the prefix used to identify the status-neutral "shipped in a
+// release but not moved" comment posted for issues whose PRs shipped while the issue was
+// not in the ready-for-release state (DEVOPS-1099).
+const shippedCommentPrefix = "Shipped in"
 
 // ListIssueComments returns the body text of all comments on the given issue.
 // It paginates through all comments to avoid missing any beyond the default page size.
@@ -444,18 +481,25 @@ func (l *LinearClient) ListIssueComments(ctx context.Context, issueID string) ([
 	return bodies, nil
 }
 
-// hasStableReleaseComment checks whether any of the given comment bodies
-// indicate that a stable release comment for the specific release tag has
-// already been posted. This is scoped to the tag so that cherry-picks released
-// in a later stable version still get their own comment.
-func hasStableReleaseComment(comments []string, releaseTag string) bool {
-	expected := fmt.Sprintf("%s %s", stableReleaseCommentPrefix, releaseTag)
+// hasReleaseComment reports whether any comment body starts with "<prefix> <releaseTag>".
+// It is used to make the release comments idempotent per tag, so a cherry-pick released in
+// a later version still gets its own comment while a repeated sync of the same tag does not
+// re-comment (vcluster and vcluster-pro cut identical tags against the same Linear issue).
+func hasReleaseComment(comments []string, prefix, releaseTag string) bool {
+	expected := fmt.Sprintf("%s %s", prefix, releaseTag)
 	for _, body := range comments {
 		if strings.HasPrefix(body, expected) {
 			return true
 		}
 	}
 	return false
+}
+
+// hasStableReleaseComment checks whether a stable release comment for the specific release
+// tag has already been posted. Scoped to the tag so cherry-picks in a later stable version
+// still get their own comment.
+func hasStableReleaseComment(comments []string, releaseTag string) bool {
+	return hasReleaseComment(comments, stableReleaseCommentPrefix, releaseTag)
 }
 
 // createComment creates a comment on the given issue.

--- a/.github/actions/linear-release-sync/src/linear_test.go
+++ b/.github/actions/linear-release-sync/src/linear_test.go
@@ -420,6 +420,54 @@ func TestHasStableReleaseComment(t *testing.T) {
 	}
 }
 
+// TestShippedCommentDedup drives the real dedup guard (hasReleaseComment in linear.go) for
+// the DEVOPS-1099 "Shipped in" comment. Unlike actionMoveToReleased, the comment-only path
+// leaves the issue in place, so this per-tag guard is the only thing preventing a repeat
+// comment on every later sync of the same tag (and across vcluster + vcluster-pro, which cut
+// identical tags against the same issue). Hardcoded expectations, so an inversion fails here.
+func TestShippedCommentDedup(t *testing.T) {
+	testCases := []struct {
+		name       string
+		comments   []string
+		releaseTag string
+		expected   bool
+	}{
+		{
+			name:       "no comments",
+			comments:   nil,
+			releaseTag: "v0.27.0",
+			expected:   false,
+		},
+		{
+			name:       "has matching shipped comment",
+			comments:   []string{"Shipped in v0.27.0 (released 2025-02-01). This issue is not in \"Ready for Release\", so it was not moved to the released state."},
+			releaseTag: "v0.27.0",
+			expected:   true,
+		},
+		{
+			name:       "shipped comment for a different tag does not match",
+			comments:   []string{"Shipped in v0.27.0 (released 2025-02-01)."},
+			releaseTag: "v0.27.1",
+			expected:   false,
+		},
+		{
+			name:       "stable release comment is not a shipped comment",
+			comments:   []string{"Now available in stable release v0.27.0 (released 2025-02-01)"},
+			releaseTag: "v0.27.0",
+			expected:   false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := hasReleaseComment(tc.comments, shippedCommentPrefix, tc.releaseTag)
+			if result != tc.expected {
+				t.Errorf("hasReleaseComment(%v, %q, %q) = %v, want %v", tc.comments, shippedCommentPrefix, tc.releaseTag, result, tc.expected)
+			}
+		})
+	}
+}
+
 func TestStableReleaseCommentText(t *testing.T) {
 	// Test the comment text logic for different scenarios
 	testCases := []struct {
@@ -488,9 +536,11 @@ func TestDecideReleaseAction(t *testing.T) {
 		want              releaseAction
 	}{
 		{"cve is always skipped", "CVE-1234", false, true, true, actionSkip},
+		{"cve not ready on stable release is still skipped", "CVE-9999", false, true, false, actionSkip},
 		{"ready for release, stable -> move", "ENG-1", false, true, true, actionMoveToReleased},
 		{"ready for release, prerelease -> move", "ENG-2", false, false, true, actionMoveToReleased},
-		{"not ready and not released -> skip", "ENG-3", false, true, false, actionSkip},
+		{"not ready, not released, stable -> comment only (DEVOPS-1099)", "ENG-3", false, true, false, actionCommentOnly},
+		{"not ready, not released, prerelease -> skip (no RC spam)", "ENG-7", false, false, false, actionSkip},
 		{"already released, prerelease (rc/alpha) -> skip", "ENG-4", true, false, false, actionSkip},
 		{"already released, stable backport patch (DEVOPS-1006) -> stable comment", "ENG-5", true, true, false, actionStableComment},
 		{"already released, stable -> stable comment", "ENG-6", true, true, true, actionStableComment},

--- a/.github/actions/linear-release-sync/src/linear_test.go
+++ b/.github/actions/linear-release-sync/src/linear_test.go
@@ -408,6 +408,14 @@ func TestHasStableReleaseComment(t *testing.T) {
 			releaseTag: "v0.27.0",
 			expected:   false,
 		},
+		{
+			// A shorter tag must not falsely match a longer one via HasPrefix
+			// ("v0.28.2" vs "v0.28.20"), which would silently suppress the comment.
+			name:       "prefix-collision tag is not falsely deduped",
+			comments:   []string{"Now available in stable release v0.28.20 (released 2025-02-01)"},
+			releaseTag: "v0.28.2",
+			expected:   false,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -454,6 +462,14 @@ func TestShippedCommentDedup(t *testing.T) {
 			name:       "stable release comment is not a shipped comment",
 			comments:   []string{"Now available in stable release v0.27.0 (released 2025-02-01)"},
 			releaseTag: "v0.27.0",
+			expected:   false,
+		},
+		{
+			// A shorter tag must not falsely match a longer one via HasPrefix
+			// ("v0.28.2" vs "v0.28.20"), which would silently suppress the comment.
+			name:       "prefix-collision tag is not falsely deduped",
+			comments:   []string{"Shipped in v0.28.20 (released 2025-02-01). This issue is not in \"Ready for Release\", so it was not moved to the released state."},
+			releaseTag: "v0.28.2",
 			expected:   false,
 		},
 	}


### PR DESCRIPTION
## Summary

The `linear-release-sync` bot silently skipped any issue whose PRs shipped in a release but which was not in "Ready for Release" at sync time: no comment, no transition. That is what produced the DEVOPS-1099 report (ENGPLAT-758 had merged PRs and RCs but no comment) because a follow-up docs PR moved the issue back to "In Progress", out of the ready set. The only branch that commented also moved the state, so a non-ready issue fell through to a bare skip.

This decouples the availability comment from the state transition. On stable releases a non-ready, non-released issue now gets a status-neutral "Shipped in `<tag>`" comment and is left in place. The move to Released still happens only from "Ready for Release".

## Key Changes

- New `actionCommentOnly` branch in `decideReleaseAction`: a non-ready, non-released issue on a stable release is commented, not moved. Prereleases still skip, so a not-ready issue does not collect a comment on every RC.
- Status-neutral wording: `Shipped in <tag> (released <date>). This issue is not in "Ready for Release", so it was not moved to the released state.` Distinct from the "first released in" pattern used by `linear-webhook-service` and from "Now available in stable release".
- Per-tag dedup for the new comment (`hasReleaseComment`, generalized from `hasStableReleaseComment`). Required because there is no state change to make it idempotent, and vcluster + vcluster-pro cut identical tags against the same Linear issue (DEVOPS-1006).
- Move-to-Released behavior unchanged (only from "Ready for Release").
- Tests: extended `TestDecideReleaseAction`, added `TestShippedCommentDedup`; README updated. `go test ./...` green locally.

## Answer to the original question (for the issue)

The bot only ever acts on two states: "Ready for Release" (move to Released + "first released" comment) and "Released" (a one-time stable comment). Every other state, including "In Progress", was skipped entirely. ENGPLAT-758 was in "In Progress" at release time, so it got nothing. This PR adds the third case Denise asked for.

## Dependencies / rollout

- No new inputs, and the action interface is unchanged, so no caller repo needs a YAML edit.
- Callers (all in each repo's `.github/workflows/release.yaml`): `vcluster`, `vcluster-pro`, `loft-enterprise`, `vnode-internal` (SHA-pinned to the current v1 commit `0eaac50` with a `# linear-release-sync/v1` comment), and `salesforce-actions-server` (moving `@linear-release-sync/v1`). None pass `linear-teams` / `linear-projects` / state-name overrides, so all run with default `Ready for Release` / `Released` and no team filter.
- The composite action downloads its Go binary from the `linear-release-sync/v1` release at runtime, so behavior lives in that release asset, not the SHA-pinned wrapper. Re-cutting the v1 binary therefore reaches every caller at once, SHA-pinned or not; the SHA pin does not insulate them.
- Rollout is decoupled from merge (merging is a safe no-op). To ship, after merge run the release workflow on `main`, which rebuilds from source, runs `go test`, and clobbers the v1 release asset:
  `gh workflow run release-linear-release-sync.yaml -f tag=linear-release-sync/v1`
- Blast radius: only issues previously skipped (shipped but not in `Ready for Release`), on stable releases of those repos, one comment per issue per tag.

## TODO

- [ ] Confirm the "Shipped in" comment wording reads well
- [ ] After merge: re-cut the v1 binary via `gh workflow run release-linear-release-sync.yaml -f tag=linear-release-sync/v1` (force-pushing the tag does not trigger the release workflow)

Closes DEVOPS-1099