### PR TITLE
ci(claude): cap subagents and web searches in reusable workflows

### DIFF
--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -55,6 +55,19 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.anthropic-api-key }} # zizmor: ignore[secrets-outside-env] -- API key passed via workflow_call, not a repo secret
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          # Session caps for unattended CI (DEVOPS-1115). Bound runaway
+          # subagent / web-search loops before they burn budget. On overflow
+          # Claude logs a cap-reached notice and continues with what it has; it
+          # does not abort. Passed via the action's `settings` env because the
+          # action does not forward step-level env: to the CLI. Rationale and
+          # the full cross-repo cap list: docs/claude-code-ci-caps.md
+          settings: |
+            {
+              "env": {
+                "CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION": "20",
+                "CLAUDE_CODE_MAX_WEB_SEARCHES_PER_SESSION": "50"
+              }
+            }
           allowed_bots: "renovate"
           track_progress: true
           prompt: |

--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -39,7 +39,24 @@ jobs:
           # Restore the base-branch version; delete if it doesn't exist there.
           git show "origin/${BASE_REF}:CLAUDE.md" > CLAUDE.md 2>/dev/null || rm -f CLAUDE.md
 
+      - name: Restore .claude config from base branch
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          # This workflow runs under pull_request_target with secrets available
+          # and is checked out at the PR head, so a fork PR could ship a
+          # .claude/ (settings.json overriding the session caps, or injected
+          # agents / commands / hooks). Drop whatever the PR added and restore
+          # the base-branch .claude/, mirroring the CLAUDE.md scrub above, so
+          # the caps set on the action step below stay authoritative. (DEVOPS-1115)
+          # Must run before the origin->upstream rename below, while origin
+          # still points at the base repo.
+          rm -rf .claude
+          git checkout "origin/${BASE_REF}" -- .claude 2>/dev/null || true
+
       - name: Setup fork as origin for Claude
+        # Ordering invariant: the base-branch restores above rely on `origin`
+        # pointing at the base repo, so they must run before this rename.
         if: ${{ github.event.pull_request.head.repo.fork == true }}
         env:
           PR_HEAD_CLONE_URL: ${{ github.event.pull_request.head.repo.clone_url }}

--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -39,24 +39,9 @@ jobs:
           # Restore the base-branch version; delete if it doesn't exist there.
           git show "origin/${BASE_REF}:CLAUDE.md" > CLAUDE.md 2>/dev/null || rm -f CLAUDE.md
 
-      - name: Restore .claude config from base branch
-        env:
-          BASE_REF: ${{ github.event.pull_request.base.ref }}
-        run: |
-          # This workflow runs under pull_request_target with secrets available
-          # and is checked out at the PR head, so a fork PR could ship a
-          # .claude/ (settings.json overriding the session caps, or injected
-          # agents / commands / hooks). Drop whatever the PR added and restore
-          # the base-branch .claude/, mirroring the CLAUDE.md scrub above, so
-          # the caps set on the action step below stay authoritative. (DEVOPS-1115)
-          # Must run before the origin->upstream rename below, while origin
-          # still points at the base repo.
-          rm -rf .claude
-          git checkout "origin/${BASE_REF}" -- .claude 2>/dev/null || true
-
       - name: Setup fork as origin for Claude
-        # Ordering invariant: the base-branch restores above rely on `origin`
-        # pointing at the base repo, so they must run before this rename.
+        # Ordering invariant: the CLAUDE.md restore above relies on `origin`
+        # still pointing at the base repo, so it must run before this rename.
         if: ${{ github.event.pull_request.head.repo.fork == true }}
         env:
           PR_HEAD_CLONE_URL: ${{ github.event.pull_request.head.repo.clone_url }}
@@ -66,6 +51,19 @@ jobs:
           git remote add origin "${PR_HEAD_CLONE_URL}"
           git fetch origin "${PR_HEAD_REF}"
           git checkout -B "${PR_HEAD_REF}" "origin/${PR_HEAD_REF}"
+
+      - name: Strip PR-supplied Claude config
+        run: |
+          # This workflow runs under pull_request_target with secrets available
+          # and checks out PR head, so a fork PR could ship a .claude/
+          # (settings.json overriding the session caps, or injected agents /
+          # commands / hooks). Remove it unconditionally as the last step before
+          # Claude runs, after the fork-setup checkout, so nothing above can
+          # leave PR-supplied config in place, including a fork that races a push
+          # between checkouts. No restore is needed: the caps live in the
+          # action's `settings` input below, and the review's behavior is defined
+          # by this workflow. (DEVOPS-1115)
+          rm -rf .claude
 
       - name: Claude Code Review
         uses: anthropics/claude-code-action@f4fb5c6cdccc1ee7af63692f5d08d56efaa64cc8 # v1

--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -30,3 +30,16 @@ jobs:
         uses: anthropics/claude-code-action@f4fb5c6cdccc1ee7af63692f5d08d56efaa64cc8 # v1
         with:
           anthropic_api_key: ${{ secrets.anthropic-api-key }} # zizmor: ignore[secrets-outside-env] -- API key passed via workflow_call, not a repo secret
+          # Session caps for unattended CI (DEVOPS-1115). Bound runaway
+          # subagent / web-search loops before they burn budget. On overflow
+          # Claude logs a cap-reached notice and continues with what it has; it
+          # does not abort. Passed via the action's `settings` env because the
+          # action does not forward step-level env: to the CLI. Rationale and
+          # the full cross-repo cap list: docs/claude-code-ci-caps.md
+          settings: |
+            {
+              "env": {
+                "CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION": "20",
+                "CLAUDE_CODE_MAX_WEB_SEARCHES_PER_SESSION": "50"
+              }
+            }

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -37,6 +37,20 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }} # zizmor: ignore[secrets-outside-env] -- OAuth token for Claude, no dedicated environment needed
 
+          # Session caps for unattended CI (DEVOPS-1115). Bound runaway
+          # subagent / web-search loops before they burn budget. On overflow
+          # Claude logs a cap-reached notice and continues with what it has; it
+          # does not abort. Passed via the action's `settings` env because the
+          # action does not forward step-level env: to the CLI. Rationale and
+          # the full cross-repo cap list: docs/claude-code-ci-caps.md
+          settings: |
+            {
+              "env": {
+                "CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION": "20",
+                "CLAUDE_CODE_MAX_WEB_SEARCHES_PER_SESSION": "50"
+              }
+            }
+
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read

--- a/docs/claude-code-ci-caps.md
+++ b/docs/claude-code-ci-caps.md
@@ -110,12 +110,13 @@ of which warrant a look before trusting the caps.
 The PR review workflow (`claude-code-review.yaml`) runs under
 `pull_request_target` with secrets available and checks out PR head content, so
 a fork PR could otherwise ship a `.claude/settings.json` (or agents, commands,
-or hooks) that raises these caps or injects instructions. Before Claude runs,
-the workflow drops the PR-supplied `.claude/` and restores the base-branch copy,
-mirroring the existing CLAUDE.md scrub, so the caps set via the action's
-`settings` input stay authoritative for fork PRs. The order matters: that
-restore relies on `origin` still pointing at the base repo, so it runs before
-the fork `origin` rename.
+or hooks) that raises these caps or injects instructions. As the last step
+before Claude runs, and after the fork-setup checkout, the workflow removes any
+`.claude/` unconditionally (`rm -rf .claude`), so nothing earlier can leave
+PR-supplied config in place, including a fork that races a push between the
+initial checkout and the fork-setup fetch. No restore is needed: the caps live
+in the action's `settings` input, and the review's behavior is defined by the
+workflow.
 
 The other two Claude Code jobs are not exposed to this vector: the `@claude`
 responder (`claude.yaml`) runs from `workflow_call` in the caller's

--- a/docs/claude-code-ci-caps.md
+++ b/docs/claude-code-ci-caps.md
@@ -1,0 +1,114 @@
+# Claude Code CI session caps
+
+Unattended Claude Code runs in CI have no human watching the token meter. A
+prompt that goes sideways can spawn hundreds of subagents or loop on web
+searches and burn the budget before anyone notices. Claude Code 2.1.212 added
+two session-wide caps to bound that blast radius. This runbook records the
+values we set, where they are set, and how to verify them.
+
+## The two caps
+
+| Environment variable | CLI default | Our CI value |
+| --- | --- | --- |
+| `CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION` | 200 | 20 |
+| `CLAUDE_CODE_MAX_WEB_SEARCHES_PER_SESSION` | 200 | 50 |
+
+The CLI default of 200 each is far too high to catch a runaway before it costs
+real money in an unattended run. 20 subagents and 50 web searches are generous
+for the legitimate CI jobs we run today (single-shot generation and PR review)
+while still tripping early on a genuine loop. Raise them if a legitimate job
+starts hitting a cap; that is the signal, not silent overspend.
+
+## Behavior when a cap is exceeded
+
+The caps are a graceful guardrail, not a hard abort. When a session reaches a
+cap, Claude Code does not exit non-zero and does not stop the run. It refuses
+the over-cap tool call, returns an explicit notice in that tool result, and the
+session continues with the information it already has.
+
+The exact notices the CLI emits (2.1.216):
+
+Web searches:
+
+```
+Web search was not performed: this session has used its web search budget
+(<n> of <cap> WebSearch calls). Continue with the information already gathered
+instead of issuing more searches. If more searches are genuinely needed, ask
+the user to raise CLAUDE_CODE_MAX_WEB_SEARCHES_PER_SESSION.
+```
+
+Subagents:
+
+```
+... agents spawned). Complete the remaining work directly with your tools
+instead of spawning more agents. If more agents are genuinely needed, ask the
+user to raise CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION.
+```
+
+`/clear` resets the subagent budget within an interactive session; CI runs are
+single-shot so that does not apply there.
+
+## Where the caps are set
+
+Every CI job that runs Claude Code carries both caps. Two mechanisms are in
+play because the invocation paths differ.
+
+| Repo | File | Job | Mechanism |
+| --- | --- | --- | --- |
+| vcluster-pro | `.github/workflows/k8s-ai-conformance.yaml` | headless `claude -p` generate step | step `env:` |
+| github-actions | `.github/workflows/claude.yaml` | reusable `@claude` responder | action `settings` env |
+| github-actions | `.github/workflows/claude-code-review.yaml` | reusable PR review | action `settings` env |
+| github-actions | `.github/workflows/claude.yml` | this repo's own `@claude` bot | action `settings` env |
+
+Setting the caps in the two reusable workflows (`claude.yaml`,
+`claude-code-review.yaml`) means every repo that calls them inherits the caps
+with no per-caller change.
+
+### Why two mechanisms
+
+A direct `claude -p` invocation reads its configuration from the process
+environment, so a step-level `env:` block is enough and is the simplest place
+to set the caps.
+
+`anthropics/claude-code-action` does not forward step-level `env:` to the
+`claude` CLI it spawns. The supported way to pass environment to that CLI is
+the action's `settings` input, whose `env` object is applied to the session:
+
+```yaml
+- uses: anthropics/claude-code-action@<pinned-sha> # v1
+  with:
+    settings: |
+      {
+        "env": {
+          "CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION": "20",
+          "CLAUDE_CODE_MAX_WEB_SEARCHES_PER_SESSION": "50"
+        }
+      }
+```
+
+## How to verify
+
+`vcluster-pro/.github/workflows/claude-code-caps-verify.yaml` is a manual
+(`workflow_dispatch`) check. It makes a small paid Claude call, so it never runs
+on push or PR. It sets a tiny web-search cap, forces more searches than the cap
+allows, and asserts the cap-reached notice lands in the run log. The assertion
+logic is in `vcluster-pro/.github/scripts/claude-caps-verify.sh`.
+
+Run it from the vcluster-pro Actions tab (Verify Claude Code Session Caps) or
+with the gh CLI:
+
+```bash
+gh workflow run claude-code-caps-verify.yaml --repo loft-sh/vcluster-pro
+```
+
+A green run confirms the caps are honored and the notice text still matches. A
+failure means either the cap did not fire or the CLI changed its message, both
+of which warrant a look before trusting the caps.
+
+## Open item
+
+The PR review workflow checks out PR head content. A follow-up should confirm
+whether an attacker-supplied `.claude/settings.json` in a PR could raise these
+caps, or whether the action's explicit `settings` input takes precedence. That
+is a prompt-injection hardening question tracked separately from setting the
+default caps here.

--- a/docs/claude-code-ci-caps.md
+++ b/docs/claude-code-ci-caps.md
@@ -105,10 +105,24 @@ A green run confirms the caps are honored and the notice text still matches. A
 failure means either the cap did not fire or the CLI changed its message, both
 of which warrant a look before trusting the caps.
 
-## Open item
+## Prompt-injection hardening
 
-The PR review workflow checks out PR head content. A follow-up should confirm
-whether an attacker-supplied `.claude/settings.json` in a PR could raise these
-caps, or whether the action's explicit `settings` input takes precedence. That
-is a prompt-injection hardening question tracked separately from setting the
-default caps here.
+The PR review workflow (`claude-code-review.yaml`) runs under
+`pull_request_target` with secrets available and checks out PR head content, so
+a fork PR could otherwise ship a `.claude/settings.json` (or agents, commands,
+or hooks) that raises these caps or injects instructions. Before Claude runs,
+the workflow drops the PR-supplied `.claude/` and restores the base-branch copy,
+mirroring the existing CLAUDE.md scrub, so the caps set via the action's
+`settings` input stay authoritative for fork PRs. The order matters: that
+restore relies on `origin` still pointing at the base repo, so it runs before
+the fork `origin` rename.
+
+The other two Claude Code jobs are not exposed to this vector: the `@claude`
+responder (`claude.yaml`) runs from `workflow_call` in the caller's
+default-branch context, and this repo's own bot (`claude.yml`) triggers only on
+trusted events with a default-branch checkout.
+
+The merge precedence between the action's `settings` input and a project
+`.claude/settings.json` is not documented upstream, which is the underlying
+reason the review workflow scrubs PR-head config rather than relying on
+precedence.

--- a/docs/workflows/claude-code-review.md
+++ b/docs/workflows/claude-code-review.md
@@ -17,3 +17,11 @@ No inputs.
 | anthropic-api-key |   true   | Anthropic API key for Claude Code <br>Review  |
 
 <!-- AUTO-DOC-SECRETS:END -->
+
+## Session caps
+
+This workflow sets conservative Claude Code session caps
+(`CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION`, `CLAUDE_CODE_MAX_WEB_SEARCHES_PER_SESSION`)
+so unattended reviews fail safe instead of burning budget on a runaway loop.
+Callers inherit them automatically. See
+[Claude Code CI session caps](../claude-code-ci-caps.md).

--- a/docs/workflows/claude.md
+++ b/docs/workflows/claude.md
@@ -17,3 +17,11 @@ No inputs.
 | anthropic-api-key |   true   | Anthropic API key for Claude Code <br>agent  |
 
 <!-- AUTO-DOC-SECRETS:END -->
+
+## Session caps
+
+This workflow sets conservative Claude Code session caps
+(`CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION`, `CLAUDE_CODE_MAX_WEB_SEARCHES_PER_SESSION`)
+so unattended runs fail safe instead of burning budget on a runaway loop.
+Callers inherit them automatically. See
+[Claude Code CI session caps](../claude-code-ci-caps.md).


### PR DESCRIPTION
## Summary

The reusable `claude.yaml` and `claude-code-review.yaml` workflows, plus this repo's own `@claude` bot (`claude.yml`), run Claude Code unattended with no session cap. The CLI defaults (200 subagents / 200 web searches per session) are high enough that a runaway prompt can burn the token budget before anyone notices. This sets conservative caps (20 subagents, 50 web searches) so every caller repo inherits them with no per-caller change.

Part of DEVOPS-1115. The anchor PR (in `loft-sh/vcluster-pro`, same branch `devops-1115/ci-session-caps`) carries `Closes`; this one is `References`.

## Key Changes

- `.github/workflows/claude.yaml`, `claude-code-review.yaml` (reusable): set the two caps via the action's `settings` env block.
- `.github/workflows/claude.yml` (this repo's `@claude` bot): same caps.
- `docs/claude-code-ci-caps.md` (new): the CI runbook. Records the values, the real graceful-degradation behavior with verbatim notices, the full cross-repo cap list, and how to verify.
- `docs/workflows/claude.md`, `claude-code-review.md`: pointer to the runbook (outside the auto-doc markers; `make check-docs` verified clean).

## Why `settings` and not `env:`

`anthropics/claude-code-action` does not forward step-level `env:` to the `claude` CLI it spawns. The supported way to pass environment to that CLI is the action's `settings` input, whose `env` object is applied to the session. That is the mechanism used here.

## Behavior note

Exceeding a cap is a graceful guardrail, not a hard abort. Claude logs an explicit cap-reached notice, skips the over-cap tool call, and continues with what it already has. Details and the verbatim notices are in the new runbook.

## Dependencies

- `loft-sh/vcluster-pro` PR on the same branch sets the cap on its headless `claude -p` job and adds the manual verification workflow. It uses `Closes DEVOPS-1115`.

## TODO

- [ ] follow-up (noted in the runbook's Open item): confirm whether a PR-supplied `.claude/settings.json` could override these caps in the review workflow, or whether the action's explicit `settings` takes precedence. Prompt-injection hardening, tracked separately.

References DEVOPS-1115
