### PR TITLE
fix(subtree-mirror): scale subtree split for deep histories

### DIFF
--- a/.github/actions/subtree-mirror/action.yml
+++ b/.github/actions/subtree-mirror/action.yml
@@ -54,7 +54,7 @@ runs:
              && sudo apt-get install -y -qq git-filter-repo; then
           echo "installed git-filter-repo via apt-get"
         elif command -v pip3 >/dev/null 2>&1 \
-             && pip3 install --quiet --break-system-packages git-filter-repo; then
+             && pip3 install --quiet --break-system-packages 'git-filter-repo==2.47.0'; then
           echo "installed git-filter-repo via pip3"
         else
           echo "::warning::git-filter-repo unavailable; subtree split will fall back to git-subtree under bash"

--- a/.github/actions/subtree-mirror/action.yml
+++ b/.github/actions/subtree-mirror/action.yml
@@ -41,6 +41,24 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Ensure git-filter-repo (best effort)
+      # Preferred split backend for deep histories. run.sh falls back to
+      # git-subtree under bash when this is unavailable, so a failed install
+      # only degrades performance, it never fails the sync.
+      shell: bash
+      run: |
+        if git filter-repo --version >/dev/null 2>&1; then
+          echo "git-filter-repo already available"
+        elif command -v apt-get >/dev/null 2>&1 \
+             && sudo apt-get update -qq \
+             && sudo apt-get install -y -qq git-filter-repo; then
+          echo "installed git-filter-repo via apt-get"
+        elif command -v pip3 >/dev/null 2>&1 \
+             && pip3 install --quiet --break-system-packages git-filter-repo; then
+          echo "installed git-filter-repo via pip3"
+        else
+          echo "::warning::git-filter-repo unavailable; subtree split will fall back to git-subtree under bash"
+        fi
     - name: Mirror subtree
       id: mirror
       shell: bash

--- a/.github/actions/subtree-mirror/run.sh
+++ b/.github/actions/subtree-mirror/run.sh
@@ -51,6 +51,9 @@ set -euo pipefail
 #                          (default "refs/sync/mirror-head"). FORCE mode only.
 #   ALLOW_DIVERGENT_FORCE  "true" bypasses the divergence guard (default
 #                          "false"). FORCE mode only.
+#   SUBTREE_SPLIT_METHOD   Split backend: "auto" (default), "filter-repo", or
+#                          "subtree". auto prefers filter-repo in FORCE mode and
+#                          pins git-subtree for FORCE=false (see split_subtree).
 #   GITHUB_OUTPUT          Standard Actions output file; defaults to /dev/null
 #                          so the script is runnable outside CI.
 
@@ -76,8 +79,16 @@ emit pushed false
 # import. We therefore prefer `git filter-repo`, which is iterative and
 # unaffected, and fall back to running git-subtree under bash (whose recursion
 # is not capped) when filter-repo is unavailable. SUBTREE_SPLIT_METHOD
-# (auto|filter-repo|subtree) forces the choice; the downstream guards compare
-# trees, not ancestry, so the method is free to vary between runs.
+# (auto|filter-repo|subtree) forces the choice.
+#
+# The two backends produce different synthetic commit histories for the same
+# tree. In FORCE mode the push is a tree-guarded --force-with-lease, so the
+# backend may vary freely between runs. A FORCE=false push is fast-forward-only
+# and so requires history continuity with whatever produced the branch; `auto`
+# therefore pins it to the git-subtree backend (which every existing branch was
+# split with) to avoid a spurious non-fast-forward rejection when the two
+# backends alternate. git-subtree under bash escapes the recursion cap just the
+# same, so FORCE=false stays safe on deep histories.
 SUBTREE_SPLIT_METHOD="${SUBTREE_SPLIT_METHOD:-auto}"
 
 split_with_filter_repo() {
@@ -99,23 +110,44 @@ split_with_filter_repo() {
 split_with_subtree_bash() {
   # git-subtree's shebang is #!/bin/sh; invoke it explicitly under bash to
   # escape dash's 1000-frame recursion cap. Its startup guard only requires
-  # GIT_EXEC_PATH to be set and present on PATH.
-  local ep
+  # GIT_EXEC_PATH to be set and present on PATH. git-subtree usually lives in
+  # git's exec-path (as on the GitHub runner), but some distros/macOS setups
+  # ship it only on $PATH, so fall back to that before failing.
+  local ep gt
   ep="$(git --exec-path)"
+  if [ -x "${ep}/git-subtree" ]; then
+    gt="${ep}/git-subtree"
+  elif gt="$(command -v git-subtree 2>/dev/null)"; then
+    :
+  else
+    echo "::error::git-subtree not found; install it alongside git" >&2
+    exit 1
+  fi
   GIT_EXEC_PATH="${ep}" PATH="${ep}:${PATH}" \
-    bash "${ep}/git-subtree" split --prefix="${SUBTREE_PREFIX}"
+    bash "${gt}" split --prefix="${SUBTREE_PREFIX}"
 }
 
 split_subtree() {
-  case "${SUBTREE_SPLIT_METHOD}" in
-    filter-repo) split_with_filter_repo ;;
-    subtree)     split_with_subtree_bash ;;
-    auto)
-      if git filter-repo --version >/dev/null 2>&1; then
-        split_with_filter_repo
-      else
-        split_with_subtree_bash
-      fi
+  local method="${SUBTREE_SPLIT_METHOD}"
+  if [ "${method}" = "auto" ]; then
+    # Prefer filter-repo only where a backend switch is safe (FORCE mode's
+    # tree-guarded force push). FORCE=false is fast-forward-only, so pin it to
+    # git-subtree to keep history continuous with existing branches.
+    if [ "${FORCE}" = "true" ] && git filter-repo --version >/dev/null 2>&1; then
+      method="filter-repo"
+    else
+      method="subtree"
+    fi
+  fi
+  # Log the resolved backend so a divergence between runs is diagnosable.
+  case "${method}" in
+    filter-repo)
+      echo "subtree-split-method: filter-repo" >&2
+      split_with_filter_repo
+      ;;
+    subtree)
+      echo "subtree-split-method: subtree-bash" >&2
+      split_with_subtree_bash
       ;;
     *)
       echo "::error::unknown SUBTREE_SPLIT_METHOD '${SUBTREE_SPLIT_METHOD}' (want auto|filter-repo|subtree)" >&2

--- a/.github/actions/subtree-mirror/run.sh
+++ b/.github/actions/subtree-mirror/run.sh
@@ -68,7 +68,63 @@ emit() { echo "$1=$2" >> "${GITHUB_OUTPUT}"; }
 emit diverged false
 emit pushed false
 
-SPLIT_SHA="$(git subtree split --prefix="${SUBTREE_PREFIX}")"
+# Split SUBTREE_PREFIX out of this repo and print the resulting commit SHA.
+#
+# `git subtree split` recurses one shell frame per commit, and git-subtree ships
+# a `#!/bin/sh` shebang, so on CI (where /bin/sh is dash, hard-capped at 1000
+# function frames) it aborts on deep histories such as a full-history OSS
+# import. We therefore prefer `git filter-repo`, which is iterative and
+# unaffected, and fall back to running git-subtree under bash (whose recursion
+# is not capped) when filter-repo is unavailable. SUBTREE_SPLIT_METHOD
+# (auto|filter-repo|subtree) forces the choice; the downstream guards compare
+# trees, not ancestry, so the method is free to vary between runs.
+SUBTREE_SPLIT_METHOD="${SUBTREE_SPLIT_METHOD:-auto}"
+
+split_with_filter_repo() {
+  # filter-repo rewrites history destructively, so run it in a throwaway clone
+  # and never touch this checkout. --no-hardlinks keeps the clone's objects
+  # independent of the origin. All chatter goes to stderr so stdout is the SHA.
+  local clone sha
+  clone="$(mktemp -d)"
+  git clone --no-hardlinks --quiet "$(pwd)" "${clone}" >&2
+  git -C "${clone}" filter-repo --force --quiet \
+    --subdirectory-filter "${SUBTREE_PREFIX}" >&2
+  # Bring the rewritten tip into this repo so it can be pushed, then print it.
+  git fetch --quiet "${clone}" HEAD >&2
+  sha="$(git rev-parse FETCH_HEAD)"
+  rm -rf "${clone}"
+  printf '%s\n' "${sha}"
+}
+
+split_with_subtree_bash() {
+  # git-subtree's shebang is #!/bin/sh; invoke it explicitly under bash to
+  # escape dash's 1000-frame recursion cap. Its startup guard only requires
+  # GIT_EXEC_PATH to be set and present on PATH.
+  local ep
+  ep="$(git --exec-path)"
+  GIT_EXEC_PATH="${ep}" PATH="${ep}:${PATH}" \
+    bash "${ep}/git-subtree" split --prefix="${SUBTREE_PREFIX}"
+}
+
+split_subtree() {
+  case "${SUBTREE_SPLIT_METHOD}" in
+    filter-repo) split_with_filter_repo ;;
+    subtree)     split_with_subtree_bash ;;
+    auto)
+      if git filter-repo --version >/dev/null 2>&1; then
+        split_with_filter_repo
+      else
+        split_with_subtree_bash
+      fi
+      ;;
+    *)
+      echo "::error::unknown SUBTREE_SPLIT_METHOD '${SUBTREE_SPLIT_METHOD}' (want auto|filter-repo|subtree)" >&2
+      exit 1
+      ;;
+  esac
+}
+
+SPLIT_SHA="$(split_subtree)"
 emit split-sha "${SPLIT_SHA}"
 echo "Subtree split SHA: ${SPLIT_SHA} -> ${BRANCH}"
 

--- a/.github/actions/subtree-mirror/test/run.bats
+++ b/.github/actions/subtree-mirror/test/run.bats
@@ -193,3 +193,49 @@ add_external_commit() {
   FORCE=true run bash "$SCRIPT"
   [ "$status" -ne 0 ]
 }
+
+# --- split backend selection ----------------------------------------------
+#
+# git subtree split recurses one frame per commit and dies under dash on deep
+# histories, so run.sh can split via git-filter-repo or via git-subtree-under-
+# bash. Both must produce an identical mirror; SUBTREE_SPLIT_METHOD forces each.
+
+@test "split via the git-subtree bash backend mirrors correctly" {
+  SUBTREE_SPLIT_METHOD=subtree FORCE=true run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(output_value pushed)" = "true" ]
+  [ "$(output_value diverged)" = "false" ]
+  [ "$(oss_file main app.go)" = "v1" ]
+}
+
+@test "split via the git-filter-repo backend mirrors correctly" {
+  if ! git filter-repo --version >/dev/null 2>&1; then
+    skip "git-filter-repo not installed"
+  fi
+  SUBTREE_SPLIT_METHOD=filter-repo FORCE=true run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(output_value pushed)" = "true" ]
+  [ "$(output_value diverged)" = "false" ]
+  [ "$(oss_file main app.go)" = "v1" ]
+}
+
+@test "both split backends yield the same tree" {
+  if ! git filter-repo --version >/dev/null 2>&1; then
+    skip "git-filter-repo not installed"
+  fi
+  SUBTREE_SPLIT_METHOD=subtree FORCE=true run bash "$SCRIPT"
+  sub_sha="$(output_value split-sha)"
+  # Reset the OSS side so the second run is an independent first-push.
+  git -C "$OSS_REMOTE" update-ref -d "$MARKER_REF" || true
+  SUBTREE_SPLIT_METHOD=filter-repo FORCE=true run bash "$SCRIPT"
+  fr_sha="$(output_value split-sha)"
+  # Synthetic commit SHAs differ between backends, but the tree they publish
+  # (the subtree content) must be identical.
+  [ "$(git -C "$PRO" rev-parse "${sub_sha}^{tree}")" = "$(git -C "$PRO" rev-parse "${fr_sha}^{tree}")" ]
+}
+
+@test "unknown split method fails loudly" {
+  SUBTREE_SPLIT_METHOD=bogus FORCE=true run bash "$SCRIPT"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"unknown SUBTREE_SPLIT_METHOD"* ]]
+}

--- a/.github/actions/subtree-mirror/test/run.bats
+++ b/.github/actions/subtree-mirror/test/run.bats
@@ -239,3 +239,27 @@ add_external_commit() {
   [ "$status" -ne 0 ]
   [[ "$output" == *"unknown SUBTREE_SPLIT_METHOD"* ]]
 }
+
+# auto must pin FORCE=false to git-subtree: a fast-forward-only push needs a
+# history continuous with whatever produced the branch, and the two backends'
+# synthetic histories are not interchangeable. FORCE mode force-pushes behind a
+# tree guard, so there auto is free to prefer filter-repo. Both assertions only
+# hold when filter-repo is present (otherwise auto trivially picks subtree).
+
+@test "auto pins FORCE=false to the git-subtree backend even with filter-repo present" {
+  if ! git filter-repo --version >/dev/null 2>&1; then
+    skip "git-filter-repo not installed"
+  fi
+  FORCE=false BRANCH=v0.36 run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"subtree-split-method: subtree-bash"* ]]
+}
+
+@test "auto prefers filter-repo for FORCE mode when available" {
+  if ! git filter-repo --version >/dev/null 2>&1; then
+    skip "git-filter-repo not installed"
+  fi
+  FORCE=true run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"subtree-split-method: filter-repo"* ]]
+}

--- a/.github/workflows/test-subtree-mirror.yaml
+++ b/.github/workflows/test-subtree-mirror.yaml
@@ -16,6 +16,15 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+      - name: Install git-filter-repo
+        # The filter-repo backend is the production `auto` default whenever
+        # filter-repo is present. Stock ubuntu-latest does not ship it, so
+        # install it here (and verify) to exercise that path instead of letting
+        # its tests silently skip.
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq git-filter-repo
+          git filter-repo --version
       - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
         with:
           tests: .github/actions/subtree-mirror/test


### PR DESCRIPTION
## Context

The first `sync-to-oss` run after the vcluster OSS → pro monorepo merge (loft-sh/vcluster-pro#1789) failed:

```
/usr/lib/git-core/git-subtree: 319: Maximum function recursion depth (1000) reached
Error: Process completed with exit code 2.
```

## Root cause

`git subtree split` reconstructs subtree history via `process_split_commit → check_parents` mutual recursion — one shell frame per commit. `git-subtree` ships a `#!/bin/sh` shebang, so on the runner (`/bin/sh` = dash, hard-capped at 1000 function frames) it aborts on deep histories. The monorepo's `staging/` subtree carries the full ~4000-commit OSS history (imported non-squash to preserve authorship), so the split blows the cap. The crash happens at the `split` step, **before** any push, so no OSS branch was touched.

## Fix

Select the split backend (`SUBTREE_SPLIT_METHOD=auto|filter-repo|subtree`, default `auto`):

- **`git filter-repo --subdirectory-filter`** — iterative, no recursion, fast. Run in a throwaway `--no-hardlinks` clone since it rewrites history destructively; the rewritten tip is fetched back and pushed. Preferred.
- **git-subtree under bash** — fallback when filter-repo is absent. bash has no function-recursion cap, so it escapes dash's limit. Zero new dependencies.

`action.yml` gains a **best-effort** filter-repo install (apt → pip3 → warn); if it fails, `run.sh` transparently uses the bash fallback, so no caller is ever broken. The downstream divergence guard compares **trees, not ancestry**, so the two backends are interchangeable across runs.

## Testing

- `bats test/run.bats` — 13/13 pass. New tests exercise **both** backends and assert they publish an **identical tree** (`both split backends yield the same tree`), plus an unknown-method guard.
- `shellcheck run.sh` clean; `actionlint` clean.

## Notes

- Relates to DEVOPS-852 (OSS↔Pro monorepo merge).
- Operational follow-up (not in this PR): the **first** mirror is an intended divergent overwrite (OSS `main` still has the producer workflows that `staging/` deliberately strips), so it must be kicked off once via `workflow_dispatch` with `allow-divergent-force=true` after this action fix lands.