### PR TITLE
fix(backport): commit legacy backports under the bot identity

### DIFF
--- a/.github/actions/backport-legacy-split/run.sh
+++ b/.github/actions/backport-legacy-split/run.sh
@@ -278,7 +278,14 @@ Applied with merge conflicts that need manual resolution."
   # Emit only on the commit path so a skipped/failed side keeps the default
   # <side>-conflicts=false (emitted up front) rather than a phantom true.
   emit "${side}-conflicts" "$conflicts"
-  git -C "$checkout" commit -q -m "$msg"
+  # $checkout is a fresh `git clone` of the target repo (see above), NOT the
+  # actions/checkout workspace -- so it inherits no user.name/user.email and an
+  # unqualified `git commit` dies with "empty ident name". Set the bot identity
+  # inline (both author and committer) rather than depending on ambient config.
+  git -C "$checkout" \
+    -c user.name="github-actions[bot]" \
+    -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
+    commit -q -m "$msg"
 
   # No open PR (checked before cloning), so nothing to protect: (re)create the
   # branch. Force keeps a re-run before the PR exists idempotent -- e.g. a

--- a/.github/actions/backport-legacy-split/test/run.bats
+++ b/.github/actions/backport-legacy-split/test/run.bats
@@ -538,3 +538,30 @@ short() { git -C "$MONO" rev-parse --short HEAD; }
   [ "$(output_value oss-pushed)" = "false" ]
   [ "$(output_value pro-pushed)" = "false" ]
 }
+
+# --- commit identity -------------------------------------------------------
+
+@test "commits under the bot identity when no ambient git identity is set" {
+  # Regression: the target checkout is a fresh clone that carries no
+  # user.name/user.email, so an unqualified `git commit` died with
+  # "empty ident name" in real CI. The rest of the suite masks this because
+  # setup() exports GIT_{AUTHOR,COMMITTER}_* -- here we strip them (and rely on
+  # the user-less GIT_CONFIG_GLOBAL) to reproduce the CI environment, and assert
+  # the commit still lands under the github-actions[bot] identity.
+  cd "$MONO"
+  printf 'line1\nCHANGED\nline3\n' > "$PFX/app.go"
+  git commit -qam "oss: change"
+  local br="backport/v0.35/$(short)"
+
+  run env -u GIT_AUTHOR_NAME -u GIT_AUTHOR_EMAIL \
+          -u GIT_COMMITTER_NAME -u GIT_COMMITTER_EMAIL \
+          bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(output_value oss-pushed)" = "true" ]
+
+  # Both author and committer must be the bot -- proving the identity came from
+  # run.sh's inline -c flags, not leftover ambient config.
+  [ "$(git -C "$OSS_REMOTE" show -s --format='%an' "$br")" = "github-actions[bot]" ]
+  [ "$(git -C "$OSS_REMOTE" show -s --format='%cn' "$br")" = "github-actions[bot]" ]
+  [ "$(git -C "$OSS_REMOTE" show -s --format='%ae' "$br")" = "41898282+github-actions[bot]@users.noreply.github.com" ]
+}


### PR DESCRIPTION
## Problem

Every legacy backport job in [vcluster-pro run 29839292903](https://github.com/loft-sh/vcluster-pro/actions/runs/29839292903) (v0.34 / v0.35 / v0.36) failed with:

```
Author identity unknown
fatal: empty ident name (for <runner@...>) not allowed
##[error]Process completed with exit code 128.
```

The `backport-legacy-split` action commits onto a **fresh `git clone`** of the target repo (not the `actions/checkout` workspace), so it inherits no `user.name` / `user.email`. The unqualified `git commit` then dies with exit 128, failing both the clean-apply and the conflict ("opening a conflicted PR for manual resolution") paths.

## Fix

Set the `github-actions[bot]` identity inline on the commit (author and committer) via `-c user.name` / `-c user.email`, rather than depending on ambient git config that a clone doesn't have.

## Test

The existing bats suite masked this because `setup()` exported `GIT_{AUTHOR,COMMITTER}_*` globally. Added a regression test that strips those env vars (reproducing the CI environment) and asserts the commit still lands under the bot identity. Verified the new test fails on the old code and passes on the fix; full suite (22 tests) + shellcheck green.

## Follow-up

`backport/v1` is SHA-pinned by consumers (e.g. `vcluster-pro/.github/workflows/backport.yaml@3348e817`). After this merges, re-point the `backport/v1` tag **and** bump the pinned SHA in vcluster-pro for the fix to take effect.