### PR TITLE
feat(backport): comment backport PR links on the source PR for legacy targets

### DIFF
--- a/.github/actions/backport-legacy-split/README.md
+++ b/.github/actions/backport-legacy-split/README.md
@@ -106,14 +106,17 @@ than pushing an empty backport.
 
 <!-- AUTO-DOC-OUTPUT:START - Do not remove or modify this section -->
 
-|     OUTPUT      |  TYPE  |                                 DESCRIPTION                                  |
-|-----------------|--------|------------------------------------------------------------------------------|
-| backport-branch | string |         The backport branch name pushed to <br>the target repo(s).           |
-|  oss-conflicts  | string |          true when the OSS half applied <br>with merge conflicts.            |
-|   oss-pushed    | string |              true when an OSS backport branch <br>was pushed.                |
-|  pro-conflicts  | string |          true when the pro half applied <br>with merge conflicts.            |
-|   pro-pushed    | string | true when a pro backport branch <br>was pushed (pro-only or mixed commits).  |
-|      route      | string |       Classification of the commit: pro-only | <br>oss-only | mixed.         |
+|     OUTPUT      |  TYPE  |                                                                               DESCRIPTION                                                                                |
+|-----------------|--------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| backport-branch | string |                                                       The backport branch name pushed to <br>the target repo(s).                                                         |
+|  comment-body   | string | Ready-to-post Markdown summarizing the backport PR <br>link(s) for this target; empty when <br>none were opened/found. Upsert as a <br>sticky comment on the source PR.  |
+|  oss-conflicts  | string |                                                        true when the OSS half applied <br>with merge conflicts.                                                          |
+|   oss-pr-url    | string |                                      URL of the OSS backport PR <br>opened this run (or the one already open); empty if <br>none.                                        |
+|   oss-pushed    | string |                                                            true when an OSS backport branch <br>was pushed.                                                              |
+|  pro-conflicts  | string |                                                        true when the pro half applied <br>with merge conflicts.                                                          |
+|   pro-pr-url    | string |                                      URL of the pro backport PR <br>opened this run (or the one already open); empty if <br>none.                                        |
+|   pro-pushed    | string |                                               true when a pro backport branch <br>was pushed (pro-only or mixed commits).                                                |
+|      route      | string |                                                     Classification of the commit: pro-only | <br>oss-only | mixed.                                                       |
 
 <!-- AUTO-DOC-OUTPUT:END -->
 

--- a/.github/actions/backport-legacy-split/action.yml
+++ b/.github/actions/backport-legacy-split/action.yml
@@ -49,6 +49,15 @@ outputs:
   pro-conflicts:
     description: "true when the pro half applied with merge conflicts."
     value: ${{ steps.backport.outputs.pro-conflicts }}
+  oss-pr-url:
+    description: "URL of the OSS backport PR opened this run (or the one already open); empty if none."
+    value: ${{ steps.backport.outputs.oss-pr-url }}
+  pro-pr-url:
+    description: "URL of the pro backport PR opened this run (or the one already open); empty if none."
+    value: ${{ steps.backport.outputs.pro-pr-url }}
+  comment-body:
+    description: "Ready-to-post Markdown summarizing the backport PR link(s) for this target; empty when none were opened/found. Upsert as a sticky comment on the source PR."
+    value: ${{ steps.backport.outputs.comment-body }}
 
 runs:
   using: "composite"

--- a/.github/actions/backport-legacy-split/run.sh
+++ b/.github/actions/backport-legacy-split/run.sh
@@ -112,6 +112,17 @@ emit oss-pushed false
 emit pro-pushed false
 emit oss-conflicts false
 emit pro-conflicts false
+emit oss-pr-url ""
+emit pro-pr-url ""
+
+# Accumulated across both sides so the summary comment (emitted at the very end)
+# can list every backport PR this run opened or found already open. backport_side
+# records into these as it goes; a plain key=value output can't carry the
+# multi-line comment body, so it's written with the heredoc form below.
+OSS_PR_URL=""; PRO_PR_URL=""
+OSS_CONFLICTS=false; PRO_CONFLICTS=false
+set_url()       { case "$1" in oss) OSS_PR_URL="$2" ;; pro) PRO_PR_URL="$2" ;; esac; }
+set_conflicts() { case "$1" in oss) OSS_CONFLICTS="$2" ;; pro) PRO_CONFLICTS="$2" ;; esac; }
 
 SHA="$(git rev-parse "$COMMIT")"
 SHORT="$(git rev-parse --short "$COMMIT")"
@@ -218,6 +229,9 @@ backport_side() {
     fi
     if [ -n "$existing" ]; then
       echo "${side}: PR #${existing} already open for ${BACKPORT_BRANCH} -> ${TARGET_BRANCH}; leaving branch and PR as-is (may hold manual conflict resolution)"
+      # Still surface the open PR's URL so a re-run's summary comment keeps
+      # listing it (advisory: a failed lookup just omits the link, never errors).
+      set_url "$side" "$(gh pr view "$existing" --repo "$slug" --json url --jq '.url' 2>/dev/null || true)"
       return 0
     fi
   fi
@@ -278,6 +292,7 @@ Applied with merge conflicts that need manual resolution."
   # Emit only on the commit path so a skipped/failed side keeps the default
   # <side>-conflicts=false (emitted up front) rather than a phantom true.
   emit "${side}-conflicts" "$conflicts"
+  set_conflicts "$side" "$conflicts"
   # $checkout is a fresh `git clone` of the target repo (see above), NOT the
   # actions/checkout workspace -- so it inherits no user.name/user.email and an
   # unqualified `git commit` dies with "empty ident name". Set the bot identity
@@ -320,7 +335,12 @@ Applied with merge conflicts that need manual resolution."
 > auto-merged. Resolve the conflict markers, then mark this PR ready for review."
       create_args+=(--draft)
     fi
-    gh pr create "${create_args[@]}" --body "$body"
+    # gh prints the new PR's URL on stdout; capture it (echo it back so the job
+    # log still shows it) and record it for the summary comment.
+    local pr_url
+    pr_url="$(gh pr create "${create_args[@]}" --body "$body")"
+    printf '%s\n' "$pr_url"
+    set_url "$side" "$pr_url"
   fi
 }
 
@@ -350,3 +370,49 @@ if [ "$route" = "pro-only" ] || [ "$route" = "mixed" ]; then
   git diff --binary "${DIFF_BASE}" "${DIFF_HEAD}" -- . ":(exclude)${SUBTREE_PREFIX}" > "${WORKDIR}/pro.patch"
   backport_side pro "$PRO_REMOTE" "${PRO_REPO:-}" "${WORKDIR}/pro.patch"
 fi
+
+# --- summary comment -------------------------------------------------------
+# sorenlouv posts a "backport PRs opened" comment on the source PR for the
+# monorepo era (>= v0.37); this legacy path opens PRs itself, so it must build
+# the equivalent. Emit a ready-to-post Markdown body (empty when nothing was
+# opened/found) that the caller upserts as a sticky comment, one per target.
+build_comment_body() {
+  local -a bullets=()
+  local any_conflict=false side url conflicts
+  for side in pro oss; do          # pro first, then oss (matches the PR order)
+    case "$side" in
+      pro) url="$PRO_PR_URL"; conflicts="$PRO_CONFLICTS" ;;
+      oss) url="$OSS_PR_URL"; conflicts="$OSS_CONFLICTS" ;;
+    esac
+    [ -n "$url" ] || continue
+    if [ "$conflicts" = true ]; then
+      bullets+=("- **${side}:** ${url} — :warning: merge conflicts, opened as a draft")
+      any_conflict=true
+    else
+      bullets+=("- **${side}:** ${url}")
+    fi
+  done
+  [ "${#bullets[@]}" -gt 0 ] || return 0   # nothing opened/found -> no comment
+
+  local icon=":white_check_mark:" note=""
+  if [ "$any_conflict" = true ]; then
+    icon=":warning:"; note=" — resolve the conflicts and mark the draft ready"
+  fi
+  # shellcheck disable=SC2016  # the backticks are literal Markdown, not a subshell
+  printf '%s Backported to `%s`%s\n\n' "$icon" "$TARGET_BRANCH" "$note"
+  printf '%s\n' "${bullets[@]}"
+}
+
+# GITHUB_OUTPUT can't carry newlines as key=value, so use the heredoc form. A
+# fixed delimiter is safe: the body is bot-generated Markdown that never contains
+# this token. Always emitted (even empty) so the caller reads it unconditionally.
+COMMENT_BODY="$(build_comment_body)"
+{
+  printf 'comment-body<<__BACKPORT_BODY_EOF__\n'
+  printf '%s\n' "$COMMENT_BODY"
+  printf '__BACKPORT_BODY_EOF__\n'
+} >> "$GITHUB_OUTPUT"
+
+# Final per-side URLs (override the empty defaults emitted up front).
+emit oss-pr-url "$OSS_PR_URL"
+emit pro-pr-url "$PRO_PR_URL"

--- a/.github/actions/backport-legacy-split/test/run.bats
+++ b/.github/actions/backport-legacy-split/test/run.bats
@@ -88,6 +88,16 @@ fi
 if [ "$1" = pr ] && [ "$2" = create ]; then
   printf '%s\n' "$@" >> "${GH_CREATE_LOG:?}"
   echo "https://github.com/x/y/pull/99"
+  exit 0
+fi
+# `gh pr view <n> --json url --jq .url` -- surface the existing PR's URL.
+if [ "$1" = pr ] && [ "$2" = view ]; then
+  echo "https://github.com/x/y/pull/$3"
+  exit 0
+fi
+if [ "$1" = api ]; then   # `gh api user --jq .login`
+  echo "loft-bot"
+  exit 0
 fi
 exit 0
 STUB
@@ -99,6 +109,12 @@ STUB
 }
 
 output_value() { grep "^$1=" "$GITHUB_OUTPUT" | tail -n1 | cut -d= -f2-; }
+
+# comment-body is emitted with the GITHUB_OUTPUT heredoc form (it's multi-line),
+# so output_value can't read it -- extract the block between the delimiters.
+comment_body() {
+  awk '/^comment-body<<__BACKPORT_BODY_EOF__$/{f=1;next} /^__BACKPORT_BODY_EOF__$/{f=0} f' "$GITHUB_OUTPUT"
+}
 
 # Content of <path> on <branch> in a bare remote.
 remote_file() { git -C "$1" show "$2:$3"; }
@@ -511,6 +527,91 @@ short() { git -C "$MONO" rev-parse --short HEAD; }
   [ "$(output_value oss-conflicts)" = "true" ]
   [ "$(output_value oss-pushed)" = "true" ]
   grep -Fxq -- --draft "$GH_CREATE_LOG"  # conflicted PR opened as draft
+}
+
+# --- summary comment (backport PR links back onto the source PR) -----------
+
+@test "comment: a clean backport emits the PR url and a success summary comment" {
+  install_fake_gh
+  cd "$MONO"
+  printf 'line1\nOSS\nline3\n' > "$PFX/app.go"
+  git commit -qam "oss: change"
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(output_value oss-pr-url)" = "https://github.com/x/y/pull/99" ]
+  [ "$(output_value pro-pr-url)" = "" ]
+
+  run comment_body
+  [[ "$output" == *':white_check_mark: Backported to `v0.35`'* ]]
+  [[ "$output" == *'- **oss:** https://github.com/x/y/pull/99'* ]]
+  # Clean apply -> no conflict warning in the body.
+  [[ "$output" != *':warning:'* ]]
+}
+
+@test "comment: a conflicted backport flags the draft in the summary comment" {
+  install_fake_gh
+  git clone -q --branch v0.35 --single-branch "$OSS_REMOTE" "$ROOT/ossdiv"
+  (
+    cd "$ROOT/ossdiv"
+    printf 'line1\nLEGACY\nline3\n' > app.go
+    git commit -qam "oss legacy: divergent" && git push -q origin v0.35
+  )
+  cd "$MONO"
+  printf 'line1\nOSS\nline3\n' > "$PFX/app.go"
+  git commit -qam "oss: change"
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+
+  run comment_body
+  [[ "$output" == *':warning: Backported to `v0.35`'* ]]
+  [[ "$output" == *'opened as a draft'* ]]
+}
+
+@test "comment: a mixed backport lists both the pro and oss PRs" {
+  install_fake_gh
+  cd "$MONO"
+  printf 'line1\nOSS\nline3\n' > "$PFX/app.go"
+  printf 'package main // pro\n' > main.go
+  git commit -qam "mixed: oss + pro"
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(output_value oss-pr-url)" = "https://github.com/x/y/pull/99" ]
+  [ "$(output_value pro-pr-url)" = "https://github.com/x/y/pull/99" ]
+
+  run comment_body
+  [[ "$output" == *'- **pro:** https://github.com/x/y/pull/99'* ]]
+  [[ "$output" == *'- **oss:** https://github.com/x/y/pull/99'* ]]
+}
+
+@test "comment: an already-open PR still appears in the summary comment" {
+  install_fake_gh
+  export GH_PRLIST=exists          # skip create; the existing PR is #42
+  cd "$MONO"
+  printf 'line1\nOSS\nline3\n' > "$PFX/app.go"
+  git commit -qam "oss: change"
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ ! -s "$GH_CREATE_LOG" ]                                   # nothing created
+  [ "$(output_value oss-pr-url)" = "https://github.com/x/y/pull/42" ]
+
+  run comment_body
+  [[ "$output" == *'- **oss:** https://github.com/x/y/pull/42'* ]]
+}
+
+@test "comment: nothing opened or found -> empty comment body" {
+  install_fake_gh
+  export GH_PRLIST=fail            # query fails -> side skipped, no PR, no url
+  cd "$MONO"
+  printf 'line1\nOSS\nline3\n' > "$PFX/app.go"
+  git commit -qam "oss: change"
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ -z "$(comment_body)" ]
 }
 
 # --- guards ----------------------------------------------------------------

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -177,6 +177,7 @@ jobs:
         uses: dev-hanz-ops/install-gh-cli-action@af38ce09b1ec248aeb08eea2b16bbecea9e059f8 # v0.2.1
 
       - name: Backport to ${{ matrix.target }}
+        id: backport
         uses: loft-sh/github-actions/.github/actions/backport-legacy-split@backport-legacy-split/v1 # zizmor: ignore[unpinned-uses] -- internal loft-sh/github-actions ref; reusable workflows check out the CALLER repo, so a local ./.github/actions path is not present here. @backport-legacy-split/v1 is the floating coordination tag kept aligned with backport/v1 (see DEVOPS-923 pin-drift class).
         with:
           subtree-prefix: ${{ inputs.subtree-prefix }}
@@ -190,3 +191,29 @@ jobs:
           # rebase-merged PR, not just the merge tip.
           pr-number: ${{ github.event.pull_request.number }}
           create-pr: 'true'
+
+      # sorenlouv posts a "backport PRs opened" comment on the source PR for the
+      # monorepo era; the legacy path opens its PRs itself, so restore the
+      # equivalent here. The action emits a ready-to-post body per target; upsert
+      # it as a sticky comment (one marker per target) so re-runs update in place
+      # instead of stacking duplicates.
+      - name: Resolve PAT login for the sticky-comment author match
+        id: pat
+        if: ${{ steps.backport.outputs.comment-body != '' }}
+        env:
+          # The comment is posted with the PAT (parity with sorenlouv/link-backport-prs;
+          # the caller only grants contents: read), so its author is the PAT's
+          # account, not github-actions[bot]. sticky-pr-comment matches on author to
+          # find its prior comment -- feed it the resolved login so re-runs update.
+          GH_TOKEN: ${{ secrets.gh-access-token }}
+        run: echo "login=$(gh api user --jq '.login')" >> "$GITHUB_OUTPUT"
+
+      - name: Comment backport links on the source PR
+        if: ${{ steps.backport.outputs.comment-body != '' }}
+        uses: loft-sh/github-actions/.github/actions/sticky-pr-comment@sticky-pr-comment/v1 # zizmor: ignore[unpinned-uses] -- internal loft-sh/github-actions ref; reusable workflows check out the CALLER repo, so a local ./.github/actions path is not present here. sticky-pr-comment is a general-purpose action carrying its own independent @sticky-pr-comment/v1 tag (not part of the backport coordination set).
+        with:
+          marker: "<!-- legacy-backport-${{ matrix.target }} -->"
+          body: ${{ steps.backport.outputs.comment-body }}
+          pr-number: ${{ github.event.pull_request.number }}
+          github-token: ${{ secrets.gh-access-token }}
+          expected-author: ${{ steps.pat.outputs.login }}


### PR DESCRIPTION
## Problem

After a backport, the source PR used to get a comment listing the backport PRs. That comment is now **missing for ≤ v0.36 (legacy) targets**.

Cause: it was never the identity fix — it's a gap in the legacy path. The **≥ v0.37** path uses `sorenlouv/backport-github-action`, which *natively* comments the opened backport PRs on the source PR. The **≤ v0.36** path (`backport-legacy-split`) opens its PRs itself via `gh pr create` and posted nothing back.

## Fix

- **`backport-legacy-split` action** now captures each opened (or already-open) PR URL, emits `oss-pr-url` / `pro-pr-url`, and builds a ready-to-post Markdown `comment-body` (flags conflicted drafts).
- **`backport.yaml` reusable workflow** upserts that body as a **per-target sticky comment** on the source PR via the existing `sticky-pr-comment` action. One marker per target (`<!-- legacy-backport-<target> -->`), so re-runs update in place instead of stacking duplicates.
- Posts with the PAT (`gh-access-token`) — parity with the sorenlouv / `link-backport-prs` steps, since the caller only grants `contents: read`. The PAT's login is resolved at runtime and passed as the sticky `expected-author` so upsert matches its own prior comment.

Example comment (one per release line):

> ✅ Backported to `v0.34`
> - **pro:** loft-sh/vcluster-pro#2050
> - **oss:** loft-sh/vcluster#4102

Conflicted halves are flagged (`⚠️ … opened as a draft`).

## Tests

Added bats coverage for URL emission and the summary comment across clean, conflicted, mixed, already-open, and empty cases (27 tests total). `shellcheck`, `actionlint`, `zizmor`, and `make check-docs` all green; action docs regenerated.

## Deploy note

Same coordination-tag lockstep as before: after merge, re-point `backport/v1` **and** `backport-legacy-split/v1` to the merge commit (they SHA-drift otherwise — the root cause of the earlier re-run failures).