### PR TITLE
feat(oss-commit-sync): per-commit diff-replay oss sync action replacing subtree-mirror

### DIFF
--- a/.github/actions/oss-commit-sync/README.md
+++ b/.github/actions/oss-commit-sync/README.md
@@ -1,0 +1,148 @@
+# oss-commit-sync
+
+Bidirectional per-commit sync between a monorepo subtree and a downstream OSS
+repository. Replaces `subtree-mirror` (snapshot mirroring via `git subtree
+split` + guarded force-push) with incremental diff replay:
+
+- Each synced commit is produced by 3-way applying the source commit's diff,
+  re-rooted between the subtree prefix and the OSS repo root. Author, date,
+  and message are preserved verbatim; the committer is the CI identity.
+- The two histories are linked by commit-message trailers, which are the only
+  sync state (no marker refs, no map files):
+  - `Monorepo-Commit: <sha>` on OSS commits created from monorepo commits
+  - `Oss-Commit: <sha>` on monorepo commits created from OSS commits
+- Cost is O(new commits) per run. `git subtree split` walked the full history
+  every time and timed out; this walks only the range since the last trailer.
+- Both branches are append-only. Nothing is ever force-pushed; every failure
+  mode fails closed before pushing.
+
+## Directions
+
+### `direction: export` (monorepo subtree → OSS branch)
+
+Replays every first-parent commit after the resume point that touches
+`subtree-prefix` onto the OSS branch tip. The resume point is the newest
+`Monorepo-Commit` trailer on the OSS branch. Commits carrying an `Oss-Commit`
+trailer originated on OSS and are skipped (loop guard).
+
+Safety mechanisms, in order:
+
+1. **Divergence guard** — every OSS commit we did not create must already be
+   absorbed into the monorepo (appear as an `Oss-Commit` trailer). Otherwise
+   the run fails closed with `diverged=true` and the caller dispatches the
+   import direction. Nothing is pushed.
+2. **Diff replay** — an absorbed external commit is never reverted by a
+   replayed company commit, because only that commit's own changes are
+   applied (snapshot projection would rewrite the whole tree).
+3. **Convergence assertion** — after replay, the OSS tip tree must equal the
+   monorepo staging tree, or the run fails without pushing. `align-tree: true`
+   instead appends one bot-authored snapshot commit that sets the OSS tree to
+   the staging tree: the append-only escape hatch (used at migration to drop
+   OSS-only producer workflows, or after manual reconciliation).
+
+New release lines: when the branch does not exist on OSS, it is created from
+the OSS commit corresponding to the monorepo branch point (found via trailers
+on the OSS default branch), then the branch-only commits are replayed.
+
+### `direction: import` (external OSS commits → PR branch)
+
+Replays every first-parent OSS commit after the resume point that we did not
+create onto a freshly rebuilt PR branch, re-rooted under `subtree-prefix`.
+The resume point is the newest `Oss-Commit` trailer on the base branch. The
+caller pushes the branch and opens/updates the sync PR.
+
+- `exclude-paths` drops OSS-only paths (producer workflows) from every
+  replayed diff. A commit whose diff becomes empty is skipped without a
+  marker commit; the skip is re-derived deterministically on every run, so
+  no `--allow-empty` commit needs to survive GitHub's rebase-merge.
+- A conflicting external commit fails the 3-way apply loudly; the run exits
+  non-zero with `conflict-sha` set and a clean worktree.
+- The checkout must be at the base branch (`branch` input) with full history.
+
+**The sync PR must be rebase-merged** (never squash), or per-commit
+authorship and the trailers are destroyed on the base branch. Have the
+automation enable auto-merge with rebase rather than trusting habit. If a
+maintainer needs to fix up a sync PR, they must add new commits (without an
+`Oss-Commit` trailer), never amend the replayed ones; amendments are caught
+later by the export convergence assertion.
+
+## Inputs
+
+| Input | Required | Default | Description |
+|---|---|---|---|
+| `direction` | yes | | `export` or `import` |
+| `subtree-prefix` | yes | | Subtree path, e.g. `staging/github.com/loft-sh/vcluster` |
+| `oss-repo` | yes | | Downstream repo as `owner/repo` |
+| `branch` | yes | | Branch to sync (same name both sides) |
+| `github-token` | yes | | Token with read (import) / write (export) access to the OSS repo |
+| `oss-default-branch` | no | `main` | Anchor source for new release-line branches (export) |
+| `seed-monorepo-commit` | no | | First-run resume point, paired with `seed-oss-commit` (export) |
+| `seed-oss-commit` | no | | First-run anchor (export) / resume point (import) |
+| `align-tree` | no | `false` | Append a snapshot alignment commit on tree drift (export) |
+| `exclude-paths` | no | | Newline-separated OSS-root-relative paths to drop (import) |
+| `pr-branch` | no | `automation/sync-from-oss-<branch>` | Local branch for replayed commits (import) |
+
+## Outputs
+
+| Output | Direction | Description |
+|---|---|---|
+| `pushed` | export | `true` when commits were pushed to the OSS branch |
+| `diverged` | export | `true` when unabsorbed external commits blocked the run |
+| `exported-count` | export | Commits created on the OSS branch |
+| `oss-tip` | export | OSS branch tip after the run |
+| `has-changes` | import | `true` when external commits were replayed |
+| `replayed-count` | import | External commits replayed |
+| `skipped-count` | import | Commits skipped as excluded-paths-only |
+| `conflict-sha` | import | OSS commit that failed the 3-way apply |
+| `pr-branch` | import | Branch holding the replayed commits |
+
+## Usage
+
+```yaml
+# Export: on push to main/v* touching the subtree.
+- uses: loft-sh/github-actions/.github/actions/oss-commit-sync@oss-commit-sync/v1
+  id: sync
+  with:
+    direction: export
+    subtree-prefix: staging/github.com/loft-sh/vcluster
+    oss-repo: loft-sh/vcluster
+    branch: ${{ github.ref_name }}
+    github-token: ${{ secrets.GH_ACCESS_TOKEN }}
+
+# Import: on cron / divergence dispatch; caller pushes + opens the PR.
+- uses: loft-sh/github-actions/.github/actions/oss-commit-sync@oss-commit-sync/v1
+  id: import
+  with:
+    direction: import
+    subtree-prefix: staging/github.com/loft-sh/vcluster
+    oss-repo: loft-sh/vcluster
+    branch: main
+    github-token: ${{ secrets.GH_ACCESS_TOKEN }}
+    exclude-paths: |
+      .github/workflows/release.yaml
+      .github/workflows/push-head-images.yaml
+```
+
+Requires `fetch-depth: 0` on the checkout: resume points and loop guards are
+discovered by walking first-parent history for trailers.
+
+## Migration from subtree-mirror
+
+1. Merge a monorepo commit carrying `Oss-Commit: <current oss tip>` (seeds
+   the import resume point).
+2. First export run: pass `seed-monorepo-commit` (the monorepo commit whose
+   staging tree matches that OSS tip) + `seed-oss-commit`, and
+   `align-tree: true` so the producer workflows still present on OSS are
+   deleted by the alignment commit. Every commit after that carries trailers
+   and neither seed nor alignment is needed again.
+
+## Testing
+
+```bash
+cd .github/actions/oss-commit-sync && bats test/
+```
+
+Fixtures are throwaway local repos; no network. The suite includes the
+interleaving scenarios that break snapshot-based mirroring (silent revert of
+external commits, revert/reapply churn, import reverting unexported company
+changes) as regression tests.

--- a/.github/actions/oss-commit-sync/action.yml
+++ b/.github/actions/oss-commit-sync/action.yml
@@ -1,0 +1,91 @@
+name: 'oss-commit-sync'
+description: "Bidirectional per-commit sync between a monorepo subtree and a downstream OSS repo. Replays each commit's diff (3-way, re-rooted) preserving author, date, and message; links histories with Monorepo-Commit / Oss-Commit trailers; append-only, never force-pushes."
+
+inputs:
+  direction:
+    description: "export (monorepo subtree -> OSS branch) or import (external OSS commits -> PR branch under the subtree)."
+    required: true
+  subtree-prefix:
+    description: "Path of the subtree within this repo, e.g. staging/github.com/loft-sh/vcluster. Requires a full-history checkout (fetch-depth: 0)."
+    required: true
+  oss-repo:
+    description: "Downstream OSS repository as owner/repo, e.g. loft-sh/vcluster."
+    required: true
+  branch:
+    description: "Branch to sync (same name on both repos, usually github.ref_name)."
+    required: true
+  github-token:
+    description: "Token with read (import) or write (export) access to the OSS repo. Used to build the remote URL; never logged."
+    required: true
+  oss-default-branch:
+    description: "OSS default branch used to anchor newly created release-line branches. Export only."
+    required: false
+    default: main
+  seed-monorepo-commit:
+    description: "Monorepo commit to resume from when the OSS branch has no Monorepo-Commit trailer yet (first export run). Must be paired with seed-oss-commit."
+    required: false
+    default: ""
+  seed-oss-commit:
+    description: "OSS commit anchor for the first run: paired with seed-monorepo-commit on export; the import resume point when the base branch has no Oss-Commit trailer yet."
+    required: false
+    default: ""
+  align-tree:
+    description: "Export only: when the post-replay OSS tree differs from the staging tree, append one snapshot alignment commit instead of failing. Append-only escape hatch; use for migration or after manual reconciliation."
+    required: false
+    default: "false"
+  exclude-paths:
+    description: "Import only: newline-separated paths (relative to the OSS repo root) dropped during replay, e.g. producer workflows that exist only on OSS."
+    required: false
+    default: ""
+  pr-branch:
+    description: "Import only: local branch the replayed commits are created on. Defaults to automation/sync-from-oss-<branch>."
+    required: false
+    default: ""
+
+outputs:
+  pushed:
+    description: "Export: true when commits were pushed to the OSS branch."
+    value: ${{ steps.sync.outputs.pushed }}
+  diverged:
+    description: "Export: true when OSS has external commits not yet absorbed and the run failed closed."
+    value: ${{ steps.sync.outputs.diverged }}
+  exported-count:
+    description: "Export: number of commits created on the OSS branch (including an alignment commit, if any)."
+    value: ${{ steps.sync.outputs.exported-count }}
+  oss-tip:
+    description: "Export: the OSS branch tip after the run."
+    value: ${{ steps.sync.outputs.oss-tip }}
+  has-changes:
+    description: "Import: true when at least one external commit was replayed onto the PR branch."
+    value: ${{ steps.sync.outputs.has-changes }}
+  replayed-count:
+    description: "Import: number of external commits replayed."
+    value: ${{ steps.sync.outputs.replayed-count }}
+  skipped-count:
+    description: "Import: number of external commits skipped because they touch only excluded paths."
+    value: ${{ steps.sync.outputs.skipped-count }}
+  conflict-sha:
+    description: "Import: the OSS commit that failed the 3-way apply, when the run failed on a conflict."
+    value: ${{ steps.sync.outputs.conflict-sha }}
+  pr-branch:
+    description: "Import: the local branch holding the replayed commits."
+    value: ${{ steps.sync.outputs.pr-branch }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Sync commits
+      id: sync
+      shell: bash
+      env:
+        DIRECTION: ${{ inputs.direction }}
+        SUBTREE_PREFIX: ${{ inputs.subtree-prefix }}
+        OSS_REMOTE: https://x-access-token:${{ inputs.github-token }}@github.com/${{ inputs.oss-repo }}.git
+        BRANCH: ${{ inputs.branch }}
+        OSS_DEFAULT_BRANCH: ${{ inputs.oss-default-branch }}
+        SEED_MONOREPO_COMMIT: ${{ inputs.seed-monorepo-commit }}
+        SEED_OSS_COMMIT: ${{ inputs.seed-oss-commit }}
+        ALIGN_TREE: ${{ inputs.align-tree }}
+        EXCLUDE_PATHS: ${{ inputs.exclude-paths }}
+        PR_BRANCH: ${{ inputs.pr-branch }}
+      run: ${{ github.action_path }}/run.sh

--- a/.github/actions/oss-commit-sync/export.sh
+++ b/.github/actions/oss-commit-sync/export.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Export monorepo commits touching SUBTREE_PREFIX to the OSS repository.
+#
+# Every first-parent monorepo commit after the resume point that touches the
+# subtree becomes its own OSS commit: the commit's diff is re-rooted with
+# --relative and 3-way applied on top of the OSS branch tip, preserving
+# author, date, and message, plus a "Monorepo-Commit: <sha>" trailer. Commits
+# carrying an "Oss-Commit:" trailer originated on OSS and are skipped (loop
+# guard). Pushes are plain fast-forwards; nothing is ever force-pushed.
+#
+# Resume point: the newest Monorepo-Commit trailer on the OSS branch. Diff
+# replay (not tree snapshots) is what makes interleaving safe: an external
+# OSS commit that is already absorbed into the subtree is never reverted by
+# a replayed company commit, because only the company commit's own changes
+# are applied.
+#
+# Divergence guard: before replaying, every OSS commit since the resume
+# anchor that we did not create must already be absorbed into the monorepo
+# (appear as an Oss-Commit trailer). Otherwise replaying could interleave
+# with unreviewed external work; we fail closed and the caller dispatches
+# the import direction.
+#
+# Convergence assertion: after replay, the OSS tip tree must equal the
+# monorepo staging tree. A mismatch fails the run; ALIGN_TREE=true instead
+# appends a bot-authored alignment commit that sets the OSS tree to the
+# staging tree (used once at migration to drop the producer workflows, and
+# as the append-only escape hatch that replaces force-pushing).
+#
+# New branches (fresh release lines): when BRANCH does not exist on OSS, the
+# anchor is discovered by walking the monorepo branch back to the newest
+# commit already present on the OSS default branch (via either trailer
+# direction), and the OSS branch is created from that commit.
+#
+# Required env: SUBTREE_PREFIX, OSS_REMOTE (pushable URL; tests use a local
+# path), BRANCH.
+# Optional env: OSS_DEFAULT_BRANCH (default main), SEED_MONOREPO_COMMIT +
+# SEED_OSS_COMMIT (first run on a pre-existing branch with no trailers),
+# ALIGN_TREE (default false), GITHUB_OUTPUT.
+#
+# Outputs: pushed, diverged, exported-count, oss-tip.
+
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SUBTREE_PREFIX="${SUBTREE_PREFIX:?SUBTREE_PREFIX is required}"
+OSS_REMOTE="${OSS_REMOTE:?OSS_REMOTE is required}"
+BRANCH="${BRANCH:?BRANCH is required}"
+OSS_DEFAULT_BRANCH="${OSS_DEFAULT_BRANCH:-main}"
+SEED_MONOREPO_COMMIT="${SEED_MONOREPO_COMMIT:-}"
+SEED_OSS_COMMIT="${SEED_OSS_COMMIT:-}"
+ALIGN_TREE="${ALIGN_TREE:-false}"
+GITHUB_OUTPUT="${GITHUB_OUTPUT:-/dev/null}"
+
+cd "$(git rev-parse --show-toplevel)"
+
+emit diverged false
+emit pushed false
+emit exported-count 0
+
+# --- locate the OSS branch tip and the resume point ------------------------
+
+# Probe branch existence; exit 2 means "absent", anything else non-zero is a
+# transport/auth failure that must not be mistaken for a first push.
+branch_absent=false
+ls_status=0
+git ls-remote --exit-code --heads "$OSS_REMOTE" "refs/heads/${BRANCH}" >/dev/null || ls_status=$?
+if [ "$ls_status" -eq 2 ]; then
+  branch_absent=true
+elif [ "$ls_status" -ne 0 ]; then
+  die "failed to query OSS branch ${BRANCH} (git ls-remote exit ${ls_status}); refusing to sync"
+fi
+
+if [ "$branch_absent" = "false" ]; then
+  git fetch --quiet "$OSS_REMOTE" "refs/heads/${BRANCH}"
+  OSS_TIP="$(git rev-parse FETCH_HEAD)"
+
+  entry="$(newest_trailer_entry "$OSS_TIP" "$MONOREPO_TRAILER")"
+  if [ -n "$entry" ]; then
+    OSS_ANCHOR="${entry%% *}"
+    RESUME="${entry#* }"
+  elif [ -n "$SEED_MONOREPO_COMMIT" ] && [ -n "$SEED_OSS_COMMIT" ]; then
+    OSS_ANCHOR="$SEED_OSS_COMMIT"
+    RESUME="$SEED_MONOREPO_COMMIT"
+  else
+    die "no ${MONOREPO_TRAILER} trailer found on OSS ${BRANCH} and no seed provided; set SEED_MONOREPO_COMMIT + SEED_OSS_COMMIT for the first run"
+  fi
+
+  git cat-file -e "${RESUME}^{commit}" \
+    || die "resume point ${RESUME} (from ${MONOREPO_TRAILER} trailer) is not a commit in this repo"
+  git merge-base --is-ancestor "$OSS_ANCHOR" "$OSS_TIP" \
+    || die "resume anchor ${OSS_ANCHOR} is not an ancestor of OSS ${BRANCH} tip"
+
+  # Divergence guard: every OSS commit we did not create must already be
+  # absorbed (present as an Oss-Commit trailer on our first-parent chain).
+  absorbed_file="$(mktemp)"
+  all_trailer_entries HEAD "$OSS_TRAILER" | awk '{print $2}' > "$absorbed_file"
+  unabsorbed=()
+  for s in $(git rev-list --first-parent "${OSS_ANCHOR}..${OSS_TIP}"); do
+    has_trailer "$s" "$MONOREPO_TRAILER" && continue
+    grep -qxF "$s" "$absorbed_file" || unabsorbed+=("$s")
+  done
+  rm -f "$absorbed_file"
+  if [ "${#unabsorbed[@]}" -gt 0 ]; then
+    emit diverged true
+    echo "::error::OSS ${BRANCH} has external commits not yet absorbed into ${SUBTREE_PREFIX}:"
+    printf '::error::  %s\n' "${unabsorbed[@]}"
+    echo "::error::Run the import direction (sync-from-oss) and merge its PR, then retry."
+    exit 1
+  fi
+else
+  # Fresh release line: anchor where the monorepo branch history was last
+  # known to OSS, via either trailer direction on the OSS default branch.
+  git fetch --quiet "$OSS_REMOTE" "refs/heads/${OSS_DEFAULT_BRANCH}"
+  DEFAULT_TIP="$(git rev-parse FETCH_HEAD)"
+
+  exported_map="$(mktemp)"
+  all_trailer_entries "$DEFAULT_TIP" "$MONOREPO_TRAILER" | awk '{print $2 "\t" $1}' > "$exported_map"
+
+  RESUME=""
+  OSS_TIP=""
+  while read -r m; do
+    oss_sha="$(awk -F'\t' -v k="$m" '$1 == k { print $2; exit }' "$exported_map")"
+    if [ -n "$oss_sha" ]; then
+      RESUME="$m"
+      OSS_TIP="$oss_sha"
+      break
+    fi
+    imported_from="$(trailer_value "$m" "$OSS_TRAILER")"
+    if [ -n "$imported_from" ] && git merge-base --is-ancestor "$imported_from" "$DEFAULT_TIP" 2>/dev/null; then
+      RESUME="$m"
+      OSS_TIP="$imported_from"
+      break
+    fi
+  done < <(git rev-list --first-parent HEAD)
+  rm -f "$exported_map"
+
+  [ -n "$RESUME" ] \
+    || die "cannot anchor new OSS branch ${BRANCH}: no commit on this branch is known to OSS ${OSS_DEFAULT_BRANCH}"
+  echo "OSS ${BRANCH} does not exist; creating it from ${OSS_TIP} (monorepo ${RESUME})"
+fi
+
+# --- replay -----------------------------------------------------------------
+
+WT="$(mktemp -d)/oss"
+git worktree add --detach --quiet "$WT" "$OSS_TIP"
+trap 'git worktree remove --force "$WT" 2>/dev/null || true' EXIT
+
+count=0
+while read -r M; do
+  [ -n "$M" ] || continue
+  ensure_not_merge "$M"
+  if has_trailer "$M" "$OSS_TRAILER"; then
+    echo "Skipping ${M} (originated on OSS: $(trailer_value "$M" "$OSS_TRAILER"))"
+    continue
+  fi
+  patch="$(git diff-tree --no-commit-id -p --binary -M --relative="$SUBTREE_PREFIX" "$M")"
+  if [ -z "$patch" ]; then
+    echo "Skipping ${M} (empty diff under ${SUBTREE_PREFIX})"
+    continue
+  fi
+  if ! printf '%s\n' "$patch" | git -C "$WT" apply --3way --whitespace=nowarn; then
+    git -C "$WT" reset --hard --quiet
+    git -C "$WT" clean -fdq
+    die "conflict replaying ${M} onto OSS ${BRANCH}; resolve by importing OSS first or inspect the commit"
+  fi
+  git -C "$WT" add -A
+  replay_commit "$M" "$MONOREPO_TRAILER" "$WT"
+  count=$((count + 1))
+  echo "Replayed ${M} -> $(git -C "$WT" rev-parse HEAD) ($(git log -1 --format=%s "$M"))"
+done < <(git rev-list --reverse --first-parent "${RESUME}..HEAD" -- "$SUBTREE_PREFIX")
+
+NEW_TIP="$(git -C "$WT" rev-parse HEAD)"
+
+# --- convergence assertion ---------------------------------------------------
+
+STAGING_TREE="$(git rev-parse "HEAD:${SUBTREE_PREFIX}")"
+OSS_TREE="$(git -C "$WT" rev-parse "HEAD^{tree}")"
+if [ "$STAGING_TREE" != "$OSS_TREE" ]; then
+  if [ "$ALIGN_TREE" = "true" ]; then
+    msgfile="$(mktemp)"
+    {
+      echo "chore: align OSS mirror with monorepo staging tree"
+      echo
+      echo "Snapshot alignment requested via align-tree; sets the OSS tree to the"
+      echo "monorepo subtree content in one append-only commit."
+      echo
+      echo "${MONOREPO_TRAILER}: $(git rev-parse HEAD)"
+    } > "$msgfile"
+    NEW_TIP="$(git commit-tree "$STAGING_TREE" -p "$NEW_TIP" -F "$msgfile")"
+    rm -f "$msgfile"
+    count=$((count + 1))
+    echo "Appended alignment commit ${NEW_TIP}"
+  else
+    echo "::error::OSS tree does not match the monorepo staging tree after replay:"
+    git --no-pager diff --stat "$OSS_TREE" "$STAGING_TREE" || true
+    echo "::error::Re-run with align-tree=true to append a snapshot alignment commit."
+    exit 1
+  fi
+fi
+
+# --- push (plain fast-forward; branch creation for new lines) ---------------
+
+if [ "$NEW_TIP" != "$OSS_TIP" ] || [ "$branch_absent" = "true" ]; then
+  git push --quiet "$OSS_REMOTE" "${NEW_TIP}:refs/heads/${BRANCH}"
+  emit pushed true
+  echo "Pushed ${NEW_TIP} to OSS ${BRANCH}"
+else
+  echo "Nothing to push; OSS ${BRANCH} is up to date"
+fi
+emit exported-count "$count"
+emit oss-tip "$NEW_TIP"

--- a/.github/actions/oss-commit-sync/import.sh
+++ b/.github/actions/oss-commit-sync/import.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Import external OSS commits into the monorepo subtree on a PR branch.
+#
+# Every first-parent OSS commit after the resume point that we did not create
+# (no "Monorepo-Commit:" trailer) is replayed under SUBTREE_PREFIX as its own
+# commit: the commit's diff (minus EXCLUDE_PATHS) is 3-way applied with
+# --directory, preserving author, date, and message, plus an
+# "Oss-Commit: <sha>" trailer. The caller pushes the PR branch and opens or
+# updates the sync PR; the PR must be rebase-merged so per-commit history and
+# trailers survive on the base branch.
+#
+# Resume point: the newest Oss-Commit trailer on the base branch. Commits
+# whose diff is empty after path exclusion (touched only excluded producer
+# workflows) are skipped without a marker commit: the skip decision is
+# deterministic from the commit itself, so re-walking them on the next run is
+# idempotent and free. This deliberately avoids --allow-empty marker commits,
+# whose survival across GitHub's rebase-merge is not guaranteed.
+#
+# Diff replay (not tree snapshots) means an external commit never reverts
+# monorepo changes that have not been exported yet: only the external
+# commit's own changes are applied. A genuine overlap fails the 3-way apply
+# loudly and cleanly.
+#
+# The repository MUST be checked out at the base branch (BRANCH) when this
+# script runs: the PR branch is rebuilt from HEAD, and the resume point is
+# read from HEAD's history.
+#
+# Required env: SUBTREE_PREFIX, OSS_REMOTE, BRANCH.
+# Optional env: SEED_OSS_COMMIT (first run, when the base branch has no
+# Oss-Commit trailer yet), EXCLUDE_PATHS (newline-separated paths relative to
+# the OSS repo root), PR_BRANCH (default automation/sync-from-oss-<branch>),
+# GITHUB_OUTPUT.
+#
+# Outputs: has-changes, replayed-count, skipped-count, conflict-sha,
+# pr-branch.
+
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SUBTREE_PREFIX="${SUBTREE_PREFIX:?SUBTREE_PREFIX is required}"
+OSS_REMOTE="${OSS_REMOTE:?OSS_REMOTE is required}"
+BRANCH="${BRANCH:?BRANCH is required}"
+SEED_OSS_COMMIT="${SEED_OSS_COMMIT:-}"
+EXCLUDE_PATHS="${EXCLUDE_PATHS:-}"
+PR_BRANCH="${PR_BRANCH:-automation/sync-from-oss-${BRANCH}}"
+GITHUB_OUTPUT="${GITHUB_OUTPUT:-/dev/null}"
+
+cd "$(git rev-parse --show-toplevel)"
+
+emit has-changes false
+emit replayed-count 0
+emit skipped-count 0
+emit conflict-sha ""
+emit pr-branch "$PR_BRANCH"
+
+git fetch --quiet "$OSS_REMOTE" "refs/heads/${BRANCH}" \
+  || die "failed to fetch OSS branch ${BRANCH}"
+OSS_TIP="$(git rev-parse FETCH_HEAD)"
+
+# --- resume point ------------------------------------------------------------
+
+entry="$(newest_trailer_entry HEAD "$OSS_TRAILER")"
+if [ -n "$entry" ]; then
+  RESUME="${entry#* }"
+elif [ -n "$SEED_OSS_COMMIT" ]; then
+  RESUME="$SEED_OSS_COMMIT"
+else
+  die "no ${OSS_TRAILER} trailer found on ${BRANCH} and no SEED_OSS_COMMIT provided for the first run"
+fi
+
+git cat-file -e "${RESUME}^{commit}" \
+  || die "resume point ${RESUME} is not a commit (bad trailer or seed?)"
+git merge-base --is-ancestor "$RESUME" "$OSS_TIP" \
+  || die "resume point ${RESUME} is not an ancestor of OSS ${BRANCH} tip; history may have been rewritten on OSS"
+
+# --- build exclude pathspecs ------------------------------------------------
+
+excludes=()
+while IFS= read -r p; do
+  [ -n "$p" ] && excludes+=(":(exclude)${p}")
+done <<< "$EXCLUDE_PATHS"
+
+# --- replay onto a fresh PR branch -------------------------------------------
+
+# The PR branch is rebuilt from the base tip every run: re-replaying the same
+# range yields the same content, and the caller's force-push updates any open
+# sync PR in place.
+git switch --quiet -C "$PR_BRANCH"
+
+replayed=0
+skipped=0
+while read -r E; do
+  [ -n "$E" ] || continue
+  ensure_not_merge "$E"
+  if has_trailer "$E" "$MONOREPO_TRAILER"; then
+    echo "Skipping ${E} (originated in the monorepo: $(trailer_value "$E" "$MONOREPO_TRAILER"))"
+    continue
+  fi
+  patch="$(git diff-tree --no-commit-id -p --binary -M "$E" -- . ${excludes[@]+"${excludes[@]}"})"
+  if [ -z "$patch" ]; then
+    skipped=$((skipped + 1))
+    echo "Skipping ${E} (touches only excluded paths)"
+    continue
+  fi
+  if ! printf '%s\n' "$patch" | git apply --3way --directory="$SUBTREE_PREFIX" --whitespace=nowarn; then
+    git reset --hard --quiet
+    git clean -fdq -- "$SUBTREE_PREFIX"
+    emit conflict-sha "$E"
+    die "conflict replaying OSS commit ${E} into ${SUBTREE_PREFIX}; resolve manually (export any pending monorepo changes first, then re-run)"
+  fi
+  git add -A -- "$SUBTREE_PREFIX"
+  replay_commit "$E" "$OSS_TRAILER" "."
+  replayed=$((replayed + 1))
+  echo "Replayed ${E} -> $(git rev-parse HEAD) ($(git log -1 --format=%s "$E"))"
+done < <(git rev-list --reverse --first-parent "${RESUME}..${OSS_TIP}")
+
+emit replayed-count "$replayed"
+emit skipped-count "$skipped"
+if [ "$replayed" -gt 0 ]; then
+  emit has-changes true
+  echo "Replayed ${replayed} external commit(s) onto ${PR_BRANCH} (${skipped} skipped)"
+else
+  echo "No external commits to import (${skipped} skipped)"
+fi

--- a/.github/actions/oss-commit-sync/lib.sh
+++ b/.github/actions/oss-commit-sync/lib.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Shared helpers for oss-commit-sync export.sh / import.sh.
+#
+# Both directions replay individual commits between a monorepo subtree and a
+# downstream OSS repository, preserving author, date, and message, and linking
+# the two histories with commit-message trailers:
+#
+#   Monorepo-Commit: <sha>   on OSS commits we created from monorepo commits
+#   Oss-Commit: <sha>        on monorepo commits we created from OSS commits
+#
+# Trailers are the only sync state; there is no marker ref, map file, or
+# external store. A commit that merely quotes a trailer string in its body is
+# never matched: git's %(trailers) parsing only recognizes a well-formed
+# trailer block, which is what interpret-trailers writes.
+
+# shellcheck disable=SC2034  # used by the sourcing scripts
+MONOREPO_TRAILER="Monorepo-Commit"
+# shellcheck disable=SC2034  # used by the sourcing scripts
+OSS_TRAILER="Oss-Commit"
+
+# Committer identity for replayed commits (author identity is preserved from
+# the source commit). Callers may override via the standard git env vars.
+export GIT_COMMITTER_NAME="${GIT_COMMITTER_NAME:-github-actions[bot]}"
+export GIT_COMMITTER_EMAIL="${GIT_COMMITTER_EMAIL:-41898282+github-actions[bot]@users.noreply.github.com}"
+
+emit() { echo "$1=$2" >> "${GITHUB_OUTPUT}"; }
+
+die() {
+  echo "::error::$1"
+  exit 1
+}
+
+# newest_trailer_entry <ref> <key>
+# Walk <ref> first-parent, newest first, and print "<commit-sha> <value>" for
+# the first commit carrying the trailer. Prints nothing when none is found.
+# With several same-key trailers on one commit the newest (last) value wins.
+newest_trailer_entry() {
+  local ref="$1" key="$2"
+  git log --first-parent --format="%H%x09%(trailers:key=${key},valueonly,separator=%x09)" "$ref" \
+    | awk -F'\t' 'NF >= 2 && $NF != "" { print $1 " " $NF; exit }'
+}
+
+# all_trailer_entries <ref> <key>
+# Like newest_trailer_entry but prints every "<commit-sha> <value>" pair on
+# the first-parent chain, newest first.
+all_trailer_entries() {
+  local ref="$1" key="$2"
+  git log --first-parent --format="%H%x09%(trailers:key=${key},valueonly,separator=%x09)" "$ref" \
+    | awk -F'\t' 'NF >= 2 && $NF != "" { print $1 " " $NF }'
+}
+
+# trailer_value <sha> <key>
+# Print the trailer value of a single commit (newest wins); empty when absent.
+trailer_value() {
+  git log -1 --format="%(trailers:key=$2,valueonly)" "$1" | sed '/^[[:space:]]*$/d' | tail -n1
+}
+
+has_trailer() { [ -n "$(trailer_value "$1" "$2")" ]; }
+
+# ensure_not_merge <sha>
+# The replay model requires linear history on both sides (both repos have
+# allow_merge_commit disabled). Fail loudly if a merge commit sneaks into the
+# replay range instead of guessing which parent's diff to take.
+ensure_not_merge() {
+  local sha="$1"
+  if [ "$(git rev-list --no-walk --count --merges "$sha")" -gt 0 ]; then
+    die "commit ${sha} is a merge commit; the sync requires linear history"
+  fi
+}
+
+# replay_commit <src-sha> <trailer-key> <git-dir>
+# Commit whatever is currently staged in <git-dir>, preserving <src-sha>'s
+# author name/email/date and full message, with "<trailer-key>: <src-sha>"
+# appended as a proper trailer. The committer stays the CI identity.
+replay_commit() {
+  local src="$1" key="$2" dir="$3" msgfile
+  msgfile=$(mktemp)
+  git log -1 --format=%B "$src" | git interpret-trailers --trailer "${key}: ${src}" > "$msgfile"
+  GIT_AUTHOR_NAME="$(git log -1 --format=%an "$src")" \
+  GIT_AUTHOR_EMAIL="$(git log -1 --format=%ae "$src")" \
+  GIT_AUTHOR_DATE="$(git log -1 --format=%aI "$src")" \
+    git -C "$dir" commit --quiet -F "$msgfile"
+  rm -f "$msgfile"
+}

--- a/.github/actions/oss-commit-sync/run.sh
+++ b/.github/actions/oss-commit-sync/run.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Entry point for the composite action: dispatch on DIRECTION.
+case "${DIRECTION:?DIRECTION is required (export|import)}" in
+  export) exec "$(dirname "${BASH_SOURCE[0]}")/export.sh" ;;
+  import) exec "$(dirname "${BASH_SOURCE[0]}")/import.sh" ;;
+  *)
+    echo "::error::unknown DIRECTION '${DIRECTION}' (want export or import)"
+    exit 1
+    ;;
+esac

--- a/.github/actions/oss-commit-sync/test/export.bats
+++ b/.github/actions/oss-commit-sync/test/export.bats
@@ -1,0 +1,202 @@
+#!/usr/bin/env bats
+# Tests for export.sh (monorepo subtree -> OSS).
+
+load helpers
+
+setup() {
+  setup_fixture
+}
+
+teardown() {
+  teardown_fixture
+}
+
+@test "basic export: one company commit becomes one OSS commit with authorship and trailer" {
+  C=$(company_commit pkg/app.go "l1-changed" "feat: company change")
+
+  run bash "$EXPORT"
+  [ "$status" -eq 0 ]
+  [ "$(output_value pushed)" = "true" ]
+  [ "$(output_value exported-count)" = "1" ]
+
+  [ "$(git -C "$OSS_REMOTE" log -1 --format=%s main)" = "feat: company change" ]
+  [ "$(git -C "$OSS_REMOTE" log -1 --format=%an main)" = "dev" ]
+  [ "$(git -C "$OSS_REMOTE" log -1 --format='%(trailers:key=Monorepo-Commit,valueonly)' main)" = "$C" ]
+  [ "$(oss_file pkg/app.go)" = "l1-changed" ]
+}
+
+@test "multiple commits export in order" {
+  company_commit pkg/a.go "a" "feat: first"
+  company_commit pkg/b.go "b" "feat: second"
+
+  run bash "$EXPORT"
+  [ "$status" -eq 0 ]
+  [ "$(output_value exported-count)" = "2" ]
+  [ "$(git -C "$OSS_REMOTE" log --format=%s -2 main | tac)" = "feat: first
+feat: second" ]
+}
+
+@test "no-op run: nothing new pushes nothing and succeeds" {
+  run bash "$EXPORT"
+  [ "$status" -eq 0 ]
+  [ "$(output_value pushed)" = "false" ]
+  [ "$(output_value exported-count)" = "0" ]
+}
+
+@test "commits outside the subtree are not exported" {
+  (cd "$MONO" && echo "pro-change" > pro.txt && git commit -qam "feat: pro only")
+
+  run bash "$EXPORT"
+  [ "$status" -eq 0 ]
+  [ "$(output_value pushed)" = "false" ]
+}
+
+@test "guard: unabsorbed external commit fails closed with diverged=true" {
+  external_commit ext.go "external" "feat: external contribution"
+  before=$(oss_tip)
+  company_commit pkg/app.go "l1-company" "feat: company change"
+
+  run bash "$EXPORT"
+  [ "$status" -ne 0 ]
+  [ "$(output_value diverged)" = "true" ]
+  # nothing was pushed, nothing destroyed
+  [ "$(oss_tip)" = "$before" ]
+  [ "$(oss_file ext.go)" = "external" ]
+}
+
+@test "export after absorption: skips imported commit, keeps external content, trees converge" {
+  E=$(external_commit ext.go "external" "feat: external contribution")
+  absorb_external
+  C=$(company_commit pkg/app.go "l1-company" "feat: company change")
+
+  run bash "$EXPORT"
+  [ "$status" -eq 0 ]
+  [ "$(output_value pushed)" = "true" ]
+  # only the company commit was replayed; the absorbed one was skipped
+  [ "$(output_value exported-count)" = "1" ]
+  [ "$(oss_file ext.go)" = "external" ]
+  [ "$(oss_file pkg/app.go)" = "l1-company" ]
+  # convergence: OSS tree == staging tree
+  [ "$(git -C "$OSS_REMOTE" rev-parse 'main^{tree}')" = "$(git -C "$MONO" rev-parse "HEAD:$PFX")" ]
+}
+
+@test "interleaving (C1, absorb E, C2): no revert/reapply churn on OSS" {
+  # C1 lands before the external commit is absorbed.
+  C1=$(company_commit pkg/c1.go "c1" "feat: c1")
+  E=$(external_commit ext.go "external" "feat: external contribution")
+  absorb_external
+  C2=$(company_commit pkg/c2.go "c2" "feat: c2")
+
+  run bash "$EXPORT"
+  [ "$status" -eq 0 ]
+  [ "$(output_value exported-count)" = "2" ]
+  # THE regression test vs snapshot projection: the intermediate OSS commit
+  # (C1's replay) must NOT revert the external file.
+  c1_replay=$(git -C "$OSS_REMOTE" rev-parse main~1)
+  run git -C "$OSS_REMOTE" show "$c1_replay:ext.go"
+  [ "$status" -eq 0 ]
+  [ "$output" = "external" ]
+  # final tree converges
+  [ "$(git -C "$OSS_REMOTE" rev-parse 'main^{tree}')" = "$(git -C "$MONO" rev-parse "HEAD:$PFX")" ]
+}
+
+@test "seeding: OSS branch without trailers requires and uses the seed pair" {
+  # Rebuild the OSS remote without a trailer on the seed commit.
+  rm -rf "$OSS_REMOTE" "$ROOT/ossseed"
+  git init -q --bare "$OSS_REMOTE"
+  git init -q "$ROOT/ossseed"
+  (
+    cd "$ROOT/ossseed"
+    git checkout -q -b main
+    mkdir -p pkg && printf 'l1\nl2\nl3\n' > pkg/app.go
+    git add . && git commit -qm "pre-migration oss"
+    git push -q "$OSS_REMOTE" main
+  )
+  seed_oss=$(oss_tip)
+  company_commit pkg/app.go "l1-post-seed" "feat: post-seed change"
+
+  run bash "$EXPORT"
+  [ "$status" -ne 0 ]  # no trailer, no seed -> refuse
+
+  SEED_MONOREPO_COMMIT="$M0" SEED_OSS_COMMIT="$seed_oss" run bash "$EXPORT"
+  [ "$status" -eq 0 ]
+  [ "$(output_value exported-count)" = "1" ]
+  [ "$(oss_file pkg/app.go)" = "l1-post-seed" ]
+}
+
+@test "align-tree: tree drift fails without it, converges append-only with it" {
+  # Simulate migration state: OSS still carries a producer workflow that the
+  # staging tree does not have.
+  git clone -q "$OSS_REMOTE" "$ROOT/drift"
+  (
+    cd "$ROOT/drift"
+    mkdir -p .github/workflows
+    echo "producer" > .github/workflows/release.yaml
+    git add . && git commit -qm "chore: producer workflow (oss-only)
+
+Monorepo-Commit: $M0"
+    git push -q origin main
+  )
+  before=$(oss_tip)
+
+  run bash "$EXPORT"
+  [ "$status" -ne 0 ]  # assertion catches the drift
+  [ "$(oss_tip)" = "$before" ]
+
+  ALIGN_TREE=true run bash "$EXPORT"
+  [ "$status" -eq 0 ]
+  # append-only: previous tip is still the parent chain, file is gone
+  git -C "$OSS_REMOTE" merge-base --is-ancestor "$before" main
+  run oss_file .github/workflows/release.yaml
+  [ "$status" -ne 0 ]
+  [ "$(git -C "$OSS_REMOTE" rev-parse 'main^{tree}')" = "$(git -C "$MONO" rev-parse "HEAD:$PFX")" ]
+}
+
+@test "merge commit in the export range fails closed" {
+  (
+    cd "$MONO"
+    git switch -qc feature
+    company_commit pkg/f.go "f" "feat: on branch" >/dev/null
+    git switch -q main
+    company_commit pkg/g.go "g" "feat: on main" >/dev/null
+    git merge -q --no-ff --no-edit feature
+  )
+
+  run bash "$EXPORT"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"merge commit"* ]]
+}
+
+@test "new release branch: created on OSS anchored at the exported branch point" {
+  C=$(company_commit pkg/app.go "l1-v2" "feat: pre-branch change")
+  bash "$EXPORT"  # main is synced through C
+
+  (
+    cd "$MONO"
+    git switch -qc v0.99
+    company_commit pkg/rel.go "rel" "fix: release-line only" >/dev/null
+  )
+
+  BRANCH=v0.99 run bash "$EXPORT"
+  [ "$status" -eq 0 ]
+  [ "$(output_value pushed)" = "true" ]
+  # branch exists, contains the release commit, and its parent is main's tip
+  [ "$(git -C "$OSS_REMOTE" log -1 --format=%s v0.99)" = "fix: release-line only" ]
+  [ "$(git -C "$OSS_REMOTE" rev-parse v0.99~1)" = "$(git -C "$OSS_REMOTE" rev-parse main)" ]
+  [ "$(git -C "$OSS_REMOTE" rev-parse 'v0.99^{tree}')" = "$(git -C "$MONO" rev-parse "v0.99:$PFX")" ]
+}
+
+@test "existing release branch: append is fast-forward" {
+  bash "$EXPORT"
+  (cd "$MONO" && git switch -qc v0.99)
+  BRANCH=v0.99 bash "$EXPORT"
+  before=$(git -C "$OSS_REMOTE" rev-parse v0.99)
+
+  (cd "$MONO" && git switch -q v0.99)
+  company_commit pkg/rel.go "rel-2" "fix: backport" >/dev/null
+
+  BRANCH=v0.99 run bash "$EXPORT"
+  [ "$status" -eq 0 ]
+  git -C "$OSS_REMOTE" merge-base --is-ancestor "$before" v0.99
+  [ "$(git -C "$OSS_REMOTE" log -1 --format=%s v0.99)" = "fix: backport" ]
+}

--- a/.github/actions/oss-commit-sync/test/helpers.bash
+++ b/.github/actions/oss-commit-sync/test/helpers.bash
@@ -1,0 +1,121 @@
+# Shared fixture for export.bats / import.bats.
+#
+# Builds a "mono" monorepo (subtree prefix + pro-only file) and a bare "oss"
+# remote whose seed commit carries the Monorepo-Commit trailer anchor, i.e.
+# the state right after a completed migration. All pushes go to the local
+# bare repo, never the network.
+
+setup_fixture() {
+  ROOT=$(mktemp -d)
+  export ROOT
+  export GIT_AUTHOR_NAME=dev GIT_AUTHOR_EMAIL=dev@company.example
+  export GIT_COMMITTER_NAME=dev GIT_COMMITTER_EMAIL=dev@company.example
+  export GIT_CONFIG_GLOBAL="$ROOT/gitconfig"
+  git config --file "$GIT_CONFIG_GLOBAL" init.defaultBranch main
+  git config --file "$GIT_CONFIG_GLOBAL" protocol.file.allow always
+
+  EXPORT="$BATS_TEST_DIRNAME/../export.sh"
+  IMPORT="$BATS_TEST_DIRNAME/../import.sh"
+  PFX="staging/github.com/loft-sh/vcluster"
+
+  # Monorepo seed.
+  MONO="$ROOT/mono"
+  export MONO
+  git init -q "$MONO"
+  cd "$MONO"
+  git checkout -q -b main
+  mkdir -p "$PFX/pkg"
+  printf 'l1\nl2\nl3\n' > "$PFX/pkg/app.go"
+  echo "pro-only" > pro.txt
+  git add . && git commit -qm "seed monorepo"
+  M0=$(git rev-parse HEAD)
+  export M0
+
+  # Bare OSS remote: same content at the root, trailer-anchored to M0.
+  OSS_REMOTE="$ROOT/oss.git"
+  export OSS_REMOTE
+  git init -q --bare "$OSS_REMOTE"
+  git init -q "$ROOT/ossseed"
+  (
+    cd "$ROOT/ossseed"
+    git checkout -q -b main
+    mkdir -p pkg
+    printf 'l1\nl2\nl3\n' > pkg/app.go
+    git add . && git commit -qm "seed oss
+
+Monorepo-Commit: $M0"
+    git push -q "$OSS_REMOTE" main
+  )
+  O0=$(git -C "$OSS_REMOTE" rev-parse main)
+  export O0
+
+  # Migration state: monorepo main records that OSS is pulled up to O0
+  # (the doc's "seed the from-oss marker" step).
+  cd "$MONO"
+  git commit -q --allow-empty -m "chore: seed sync state
+
+Oss-Commit: $O0"
+  export SUBTREE_PREFIX="$PFX"
+  export BRANCH=main
+  export GITHUB_OUTPUT="$ROOT/output"
+  : > "$GITHUB_OUTPUT"
+}
+
+teardown_fixture() {
+  rm -rf "$ROOT"
+}
+
+output_value() {
+  grep "^$1=" "$GITHUB_OUTPUT" | tail -n1 | cut -d= -f2-
+}
+
+# company_commit <file-under-prefix> <content> <subject>
+company_commit() {
+  (
+    cd "$MONO"
+    mkdir -p "$(dirname "$PFX/$1")"
+    printf '%s\n' "$2" > "$PFX/$1"
+    git add . && git commit -qm "$3"
+  )
+  git -C "$MONO" rev-parse HEAD
+}
+
+# external_commit <file> <content> <subject> — a contributor PR merged on OSS.
+external_commit() {
+  local clone="$ROOT/ext-$RANDOM"
+  git clone -q "$OSS_REMOTE" "$clone"
+  (
+    cd "$clone"
+    git checkout -q main
+    mkdir -p "$(dirname "$1")"
+    printf '%s\n' "$2" > "$1"
+    git add .
+    GIT_AUTHOR_NAME=alice GIT_AUTHOR_EMAIL=alice@contributor.example \
+      git commit -qm "$3"
+    git push -q origin main
+  )
+  git -C "$OSS_REMOTE" rev-parse main
+}
+
+# absorb_external — run the real import + simulate a rebase-merge (FF) of the
+# sync PR, i.e. the state after a from-oss PR landed on main.
+absorb_external() {
+  (
+    cd "$MONO"
+    bash "$IMPORT" >/dev/null
+    git switch -q main
+    git merge -q --ff-only "automation/sync-from-oss-main"
+  )
+}
+
+oss_log_subjects() {
+  git -C "$OSS_REMOTE" log --format=%s main
+}
+
+oss_file() {
+  git -C "$OSS_REMOTE" show "main:$1"
+}
+
+oss_tip() {
+  git -C "$OSS_REMOTE" rev-parse main
+}

--- a/.github/actions/oss-commit-sync/test/import.bats
+++ b/.github/actions/oss-commit-sync/test/import.bats
@@ -1,0 +1,163 @@
+#!/usr/bin/env bats
+# Tests for import.sh (external OSS commits -> monorepo subtree PR branch).
+
+load helpers
+
+setup() {
+  setup_fixture
+}
+
+teardown() {
+  teardown_fixture
+}
+
+@test "basic import: external commit replayed under the prefix with authorship and trailer" {
+  E=$(external_commit ext.go "external" "feat: external contribution")
+
+  run bash "$IMPORT"
+  [ "$status" -eq 0 ]
+  [ "$(output_value has-changes)" = "true" ]
+  [ "$(output_value replayed-count)" = "1" ]
+  [ "$(output_value pr-branch)" = "automation/sync-from-oss-main" ]
+
+  cd "$MONO"
+  git switch -q automation/sync-from-oss-main
+  [ "$(git log -1 --format=%s)" = "feat: external contribution" ]
+  [ "$(git log -1 --format=%an)" = "alice" ]
+  [ "$(git log -1 --format='%(trailers:key=Oss-Commit,valueonly)')" = "$E" ]
+  [ "$(cat "$PFX/ext.go")" = "external" ]
+  # pro files untouched
+  [ "$(cat pro.txt)" = "pro-only" ]
+}
+
+@test "import skips commits we exported (loop guard)" {
+  company_commit pkg/app.go "l1-company" "feat: company change" >/dev/null
+  bash "$EXPORT"
+
+  run bash "$IMPORT"
+  [ "$status" -eq 0 ]
+  [ "$(output_value has-changes)" = "false" ]
+  [ "$(output_value replayed-count)" = "0" ]
+}
+
+@test "exclusion: producer workflow edits are dropped from a mixed commit" {
+  external_commit .github/workflows/release.yaml "producer-edit" "chore: producer only" >/dev/null
+  # A genuinely mixed commit: excluded workflow + real code in one commit.
+  git clone -q "$OSS_REMOTE" "$ROOT/mixed"
+  (
+    cd "$ROOT/mixed"
+    echo "producer-edit-2" > .github/workflows/release.yaml
+    echo "external" > ext.go
+    git add . && git commit -qm "feat: mixed with code"
+    git push -q origin main
+  )
+
+  EXCLUDE_PATHS=".github/workflows/release.yaml" run bash "$IMPORT"
+  [ "$status" -eq 0 ]
+  # producer-only commit skipped without a marker; mixed commit replayed
+  # with the workflow path stripped
+  [ "$(output_value replayed-count)" = "1" ]
+  [ "$(output_value skipped-count)" = "1" ]
+
+  cd "$MONO"
+  git switch -q automation/sync-from-oss-main
+  [ ! -e "$PFX/.github/workflows/release.yaml" ]
+  [ "$(cat "$PFX/ext.go")" = "external" ]
+}
+
+@test "excluded-only commits are idempotently re-skipped" {
+  external_commit .github/workflows/release.yaml "producer-edit" "chore: producer only" >/dev/null
+
+  EXCLUDE_PATHS=".github/workflows/release.yaml" run bash "$IMPORT"
+  [ "$status" -eq 0 ]
+  [ "$(output_value has-changes)" = "false" ]
+  [ "$(output_value skipped-count)" = "1" ]
+
+  EXCLUDE_PATHS=".github/workflows/release.yaml" run bash "$IMPORT"
+  [ "$status" -eq 0 ]
+  [ "$(output_value has-changes)" = "false" ]
+  [ "$(output_value skipped-count)" = "1" ]
+}
+
+@test "resume: after absorption only new externals are replayed" {
+  external_commit ext.go "external" "feat: first external" >/dev/null
+  absorb_external
+  E2=$(external_commit ext2.go "external-2" "feat: second external")
+
+  run bash "$IMPORT"
+  [ "$status" -eq 0 ]
+  [ "$(output_value replayed-count)" = "1" ]
+  cd "$MONO"
+  git switch -q automation/sync-from-oss-main
+  [ "$(git log -1 --format='%(trailers:key=Oss-Commit,valueonly)')" = "$E2" ]
+}
+
+@test "unexported company change survives an import (no snapshot revert)" {
+  # Company commit not yet exported + external commit on a different file.
+  company_commit pkg/company.go "company" "feat: unexported company change" >/dev/null
+  external_commit ext.go "external" "feat: external contribution" >/dev/null
+
+  run bash "$IMPORT"
+  [ "$status" -eq 0 ]
+  [ "$(output_value replayed-count)" = "1" ]
+  cd "$MONO"
+  git switch -q automation/sync-from-oss-main
+  # THE regression test vs snapshot projection: both changes present.
+  [ "$(cat "$PFX/pkg/company.go")" = "company" ]
+  [ "$(cat "$PFX/ext.go")" = "external" ]
+}
+
+@test "conflict: overlapping change fails closed with conflict-sha and a clean tree" {
+  company_commit pkg/app.go "company-version" "feat: company edit" >/dev/null
+  E=$(external_commit pkg/app.go "external-version" "fix: conflicting external edit")
+
+  run bash "$IMPORT"
+  [ "$status" -ne 0 ]
+  [ "$(output_value conflict-sha)" = "$E" ]
+  cd "$MONO"
+  [ -z "$(git status --porcelain)" ]
+}
+
+@test "re-run rebuilds the PR branch idempotently" {
+  external_commit ext.go "external" "feat: external contribution" >/dev/null
+
+  bash "$IMPORT"
+  first_tree=$(cd "$MONO" && git rev-parse "automation/sync-from-oss-main^{tree}")
+  # A real re-run starts from a fresh checkout of the base branch.
+  git -C "$MONO" switch -q main
+  run bash "$IMPORT"
+  [ "$status" -eq 0 ]
+  [ "$(output_value replayed-count)" = "1" ]
+  [ "$(cd "$MONO" && git rev-parse "automation/sync-from-oss-main^{tree}")" = "$first_tree" ]
+}
+
+@test "seed: first run without trailers uses SEED_OSS_COMMIT" {
+  # Strip the trailer state: reset main to before the seed-state commit, so
+  # no Oss-Commit trailer exists anywhere on the branch.
+  git -C "$MONO" reset -q --hard "$M0"
+  external_commit ext.go "external" "feat: external contribution" >/dev/null
+
+  run bash "$IMPORT"
+  [ "$status" -ne 0 ]  # no trailer, no seed -> refuse
+
+  SEED_OSS_COMMIT="$O0" run bash "$IMPORT"
+  [ "$status" -eq 0 ]
+  [ "$(output_value replayed-count)" = "1" ]
+}
+
+@test "merge commit on OSS fails closed" {
+  git clone -q "$OSS_REMOTE" "$ROOT/mergesrc"
+  (
+    cd "$ROOT/mergesrc"
+    git switch -qc feature
+    echo "f" > f.go && git add . && git commit -qm "feat: on branch"
+    git switch -q main
+    echo "m" > m.go && git add . && git commit -qm "feat: on main"
+    git merge -q --no-ff --no-edit feature
+    git push -q origin main
+  )
+
+  run bash "$IMPORT"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"merge commit"* ]]
+}

--- a/README.md
+++ b/README.md
@@ -384,6 +384,47 @@ Mirrors a monorepo subtree to a downstream OSS repository. Fast-forward-only for
 
 See [subtree-mirror README](./.github/actions/subtree-mirror/README.md) for detailed documentation.
 
+### OSS Commit Sync Action
+
+Successor to Subtree Mirror. Bidirectional per-commit sync between a monorepo subtree and a downstream OSS repository: replays each commit's diff (3-way, re-rooted) preserving author, date, and message, and links the two histories with `Monorepo-Commit` / `Oss-Commit` trailers as the only sync state. Incremental (O(new commits), no `git subtree split`), append-only (never force-pushes), fails closed on divergence and conflicts.
+
+**Location:** `.github/actions/oss-commit-sync`
+
+**Usage:**
+
+```yaml
+- uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+  with:
+    fetch-depth: 0
+    persist-credentials: false
+
+# monorepo -> OSS (on push touching the subtree)
+- id: sync
+  uses: loft-sh/github-actions/.github/actions/oss-commit-sync@oss-commit-sync/v1
+  with:
+    direction: export
+    subtree-prefix: staging/github.com/loft-sh/vcluster
+    oss-repo: loft-sh/vcluster
+    branch: ${{ github.ref_name }}
+    github-token: ${{ secrets.GH_ACCESS_TOKEN }}
+
+# OSS -> monorepo PR branch (on cron / divergence dispatch)
+- id: import
+  uses: loft-sh/github-actions/.github/actions/oss-commit-sync@oss-commit-sync/v1
+  with:
+    direction: import
+    subtree-prefix: staging/github.com/loft-sh/vcluster
+    oss-repo: loft-sh/vcluster
+    branch: main
+    github-token: ${{ secrets.GH_ACCESS_TOKEN }}
+```
+
+**Key inputs:** `direction` (`export`/`import`), `subtree-prefix`, `oss-repo`, `branch`, `github-token`; `align-tree` (export escape hatch: append one snapshot alignment commit on tree drift), `exclude-paths` (import: OSS-only paths dropped during replay), `seed-monorepo-commit`/`seed-oss-commit` (first run only).
+
+**Key outputs:** export: `pushed`, `diverged`, `exported-count`, `oss-tip`; import: `has-changes`, `replayed-count`, `skipped-count`, `conflict-sha`, `pr-branch`.
+
+See [oss-commit-sync README](./.github/actions/oss-commit-sync/README.md) for the full contract, safety mechanisms, and migration steps.
+
 ## Available Reusable Workflows
 
 ### Validate Renovate Config


### PR DESCRIPTION
## Summary

- Adds `oss-commit-sync`: bidirectional per-commit sync between a monorepo subtree (`staging/github.com/loft-sh/vcluster`) and the downstream OSS repo, replacing `subtree-mirror`. Each synced commit 3-way applies the source commit's own diff, re-rooted between the prefix and the OSS root, preserving **author, date, and message** verbatim.
- Sync state is self-describing `Monorepo-Commit:` / `Oss-Commit:` commit trailers; no marker refs or map files. Runs cost O(new commits); `git subtree split` walked the full history and timed out at 2 minutes on `vcluster-pro`.
- Both directions are append-only and fail closed: the export refuses to run while OSS holds unabsorbed external commits (`diverged=true` dispatches the back-sync), conflicts abort with a clean tree, and a post-export tree-equality assertion guarantees the mirror is exact. `align-tree` appends a single snapshot alignment commit as the append-only escape hatch (replaces `allow-divergent-force`; also performs the one-time migration deletion of the 7 producer workflows still on OSS).
- Import drops OSS-only producer-workflow paths from every replayed diff (kills the modify/delete conflict class, e.g. loft-sh/vcluster#4072) and skips excluded-only commits deterministically instead of emitting `--allow-empty` markers.
- New release lines self-anchor: when the branch is absent on OSS it is created from the OSS commit matching the monorepo branch point, found via trailers.

Design doc: `vcluster-pro/docs/oss-monorepo-sync-redesign.md` (see "Implementation decisions" for why diff replay instead of tree snapshots: snapshot projection has four interleaving holes that silently lose data, all reproduced as regression tests here).

Caller PR in `vcluster-pro` follows; after merge this needs the `oss-commit-sync/v1` tag.

## Test plan

- `bats test/` — 22 tests against throwaway local fixture repos (no network), covering: authorship/trailer preservation both directions, loop guards, divergence fail-closed, the four snapshot-interleaving regression scenarios (silent revert of external commits, revert/reapply churn, import reverting unexported company changes), path exclusion + idempotent empty skips, conflict fail-closed with clean tree, seeding, new/existing release branches, merge-commit rejection, and idempotent PR-branch rebuilds.
- `shellcheck` clean on all scripts; `actionlint` clean on the rewired caller workflows.
- Primitive behavior (`format-patch` pathspec commit-selection trap, `apply --3way --directory` staging/conflict semantics) verified in standalone experiments before implementation.

Closes DEVOPS-1121