### PR TITLE
feat(release-notification): attribute the human who triggered a release

### DIFF
--- a/.github/actions/release-notification/README.md
+++ b/.github/actions/release-notification/README.md
@@ -6,18 +6,19 @@ Sends a Slack notification when a new release is published.
 
 <!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
 
-|     INPUT     |  TYPE  | REQUIRED |           DEFAULT            |                                           DESCRIPTION                                           |
-|---------------|--------|----------|------------------------------|-------------------------------------------------------------------------------------------------|
-|  base_branch  | string |  false   |                              | Source branch from which the release <br>was cut (auto-detected from git history when omitted)  |
-|    changes    | string |  false   | `"See changelog link below"` |                                         Release changes                                         |
-|   is_draft    | string |  false   |          `"false"`           |                                    Is this a draft release?                                     |
-| is_prerelease | string |  false   |          `"false"`           |                                     Is this a pre-release?                                      |
-| previous_tag  | string |  false   |                              |                          Previous release tag for changelog comparison                          |
-|    product    | string |   true   |                              |                          Product name (vCluster or vCluster Platform)                           |
-|    status     | string |  false   |         `"success"`          |                  Release status: success, failure, cancelled, or <br>skipped                    |
-|  target_repo  | string |   true   |                              |                                        Target repository                                        |
-|    version    | string |   true   |                              |                                         Release version                                         |
-|  webhook_url  | string |   true   |                              |                                        Slack Webhook URL                                        |
+|     INPUT     |  TYPE  | REQUIRED |           DEFAULT            |                                                                                                        DESCRIPTION                                                                                                        |
+|---------------|--------|----------|------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|  base_branch  | string |  false   |                              |                                                              Source branch from which the release <br>was cut (auto-detected from git history when omitted)                                                               |
+|    changes    | string |  false   | `"See changelog link below"` |                                                                                                      Release changes                                                                                                      |
+|   is_draft    | string |  false   |          `"false"`           |                                                                                                 Is this a draft release?                                                                                                  |
+| is_prerelease | string |  false   |          `"false"`           |                                                                                                  Is this a pre-release?                                                                                                   |
+| previous_tag  | string |  false   |                              |                                                                                       Previous release tag for changelog comparison                                                                                       |
+|    product    | string |   true   |                              |                                                                                       Product name (vCluster or vCluster Platform)                                                                                        |
+|    status     | string |  false   |         `"success"`          |                                                                               Release status: success, failure, cancelled, or <br>skipped                                                                                 |
+|  target_repo  | string |   true   |                              |                                                                                                     Target repository                                                                                                     |
+| triggered_by  | string |  false   |   `"${{ github.actor }}"`    | Who triggered the release (shown in the Slack banner). Defaults <br>to github.actor; callers that dispatch the <br>release via a bot PAT should <br>pass the human actor so the <br>banner does not read as the <br>bot.  |
+|    version    | string |   true   |                              |                                                                                                      Release version                                                                                                      |
+|  webhook_url  | string |   true   |                              |                                                                                                     Slack Webhook URL                                                                                                     |
 
 <!-- AUTO-DOC-INPUT:END -->
 

--- a/.github/actions/release-notification/action.yml
+++ b/.github/actions/release-notification/action.yml
@@ -40,6 +40,10 @@ inputs:
   webhook_url:
     description: 'Slack Webhook URL'
     required: true
+  triggered_by:
+    description: 'Who triggered the release (shown in the Slack banner). Defaults to github.actor; callers that dispatch the release via a bot PAT should pass the human actor so the banner does not read as the bot.'
+    required: false
+    default: ${{ github.actor }}
 
 runs:
   using: "composite"
@@ -86,7 +90,7 @@ runs:
                 - type: mrkdwn
                   text: "*Repository:*\n${{ inputs.target_repo }}"
                 - type: mrkdwn
-                  text: "*Released by:*\n${{ github.actor }}"
+                  text: "*Released by:*\n${{ inputs.triggered_by }}"
             - type: section
               fields:
                 - type: mrkdwn
@@ -135,6 +139,6 @@ runs:
             - type: section
               fields:
                 - type: mrkdwn
-                  text: "*Triggered by:*\n${{ github.actor }}"
+                  text: "*Triggered by:*\n${{ inputs.triggered_by }}"
                 - type: mrkdwn
                   text: "*Run:*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View details>"

--- a/.github/actions/vcluster-release/action.yml
+++ b/.github/actions/vcluster-release/action.yml
@@ -41,6 +41,11 @@ runs:
         INPUT_VERSION: ${{ inputs.version }}
         INPUT_SOURCE_BRANCH: ${{ inputs.source-branch }}
         INPUT_DRY_RUN: ${{ inputs.dry-run }}
+        # The human who invoked cut-release (this composite runs in that
+        # workflow_dispatch context). Forwarded to the monorepo-era release.yaml
+        # so the Slack banner attributes the person, not the bot PAT that runs
+        # the dispatched build.
+        TRIGGERED_BY: ${{ github.actor }}
       run: ${{ github.action_path }}/src/vcluster-release.sh
 branding:
   icon: 'tag'

--- a/.github/actions/vcluster-release/src/vcluster-release.sh
+++ b/.github/actions/vcluster-release/src/vcluster-release.sh
@@ -36,6 +36,12 @@ CUTOVER="${CUTOVER:-v0.37}"
 OSS_REPO="${OSS_REPO:-loft-sh/vcluster}"
 PRO_REPO="${PRO_REPO:-loft-sh/vcluster-pro}"
 WORKFLOW="${WORKFLOW:-release.yaml}"
+# The human who invoked cut-release. Forwarded to the monorepo-era release.yaml
+# (-f triggered_by=...) so the Slack banner attributes the person, not the bot
+# PAT that dispatches the build. Only passed on paths whose release.yaml declares
+# the input (monorepo + feature-prerelease); legacy release.yaml's don't have it,
+# and gh workflow run rejects undeclared inputs, so legacy dispatches omit it.
+TRIGGERED_BY="${TRIGGERED_BY:-}"
 
 # ---------------------------------------------------------------------------
 # Pure helpers (no network) - the routing brain, exhaustively unit-tested.
@@ -240,11 +246,16 @@ create_tag() {
 # tagged commit's version of the workflow (verified in sandbox).
 dispatch() {
   local repo="$1" tag="$2"
+  shift 2
+  # Optional trailing args are extra `gh workflow run` flags (e.g.
+  # -f triggered_by=<actor>). Callers on legacy paths pass none, so those
+  # dispatches are byte-for-byte unchanged.
+  local extra=("$@")
   if [[ "${DRY_RUN:-true}" == "true" ]]; then
-    echo "[dry-run] gh workflow run ${WORKFLOW} --repo ${repo} --ref ${tag}"
+    echo "[dry-run] gh workflow run ${WORKFLOW} --repo ${repo} --ref ${tag} ${extra[*]}"
     return 0
   fi
-  gh workflow run "${WORKFLOW}" --repo "${repo}" --ref "${tag}"
+  gh workflow run "${WORKFLOW}" --repo "${repo}" --ref "${tag}" "${extra[@]}"
   echo "dispatched ${WORKFLOW} in ${repo} at ${tag}"
 }
 
@@ -285,7 +296,9 @@ cut_monorepo() {
   require_branch "$PRO_REPO" "$target"
   guard_not_released "$PRO_REPO" "$version"
   create_tag "$PRO_REPO" "$target" "$version"
-  dispatch "$PRO_REPO" "$version"
+  local dispatch_args=()
+  [[ -n "${TRIGGERED_BY}" ]] && dispatch_args=(-f "triggered_by=${TRIGGERED_BY}")
+  dispatch "$PRO_REPO" "$version" "${dispatch_args[@]}"
 }
 
 # cut_feature_prerelease <version> <feature-branch> - -next / -next.internal are
@@ -297,7 +310,9 @@ cut_feature_prerelease() {
   require_branch "$PRO_REPO" "$feature"
   guard_not_released "$PRO_REPO" "$version"
   create_tag "$PRO_REPO" "$feature" "$version"
-  dispatch "$PRO_REPO" "$version"
+  local dispatch_args=()
+  [[ -n "${TRIGGERED_BY}" ]] && dispatch_args=(-f "triggered_by=${TRIGGERED_BY}")
+  dispatch "$PRO_REPO" "$version" "${dispatch_args[@]}"
 }
 
 main() {

--- a/.github/actions/vcluster-release/test/vcluster-release.bats
+++ b/.github/actions/vcluster-release/test/vcluster-release.bats
@@ -466,6 +466,27 @@ EOF
   [[ "$output" == *"feature-branch prerelease (source my-feature)"* ]]
 }
 
+@test "TRIGGERED_BY: forwarded as -f triggered_by on the feature-prerelease dispatch" {
+  export GH_STUB_BRANCHES="loft-sh/vcluster-pro:my-feature"
+  TRIGGERED_BY="alice" INPUT_VERSION="v0.40.0-next.1" INPUT_SOURCE_BRANCH="my-feature" INPUT_DRY_RUN="true" run main
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"gh workflow run release.yaml --repo loft-sh/vcluster-pro --ref v0.40.0-next.1 -f triggered_by=alice"* ]]
+}
+
+@test "TRIGGERED_BY: forwarded on the monorepo dispatch too" {
+  export GH_STUB_BRANCHES="loft-sh/vcluster-pro:v0.40"
+  TRIGGERED_BY="bob" INPUT_VERSION="v0.40.1" INPUT_DRY_RUN="true" run main
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"--repo loft-sh/vcluster-pro --ref v0.40.1 -f triggered_by=bob"* ]]
+}
+
+@test "TRIGGERED_BY: never passed on legacy dispatches (release.yaml lacks the input)" {
+  export GH_STUB_BRANCHES="loft-sh/vcluster:v0.35 loft-sh/vcluster-pro:v0.35"
+  TRIGGERED_BY="carol" INPUT_VERSION="v0.35.4" INPUT_DRY_RUN="true" run main
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"triggered_by"* ]]
+}
+
 @test "next: a missing source-branch is a hard error" {
   INPUT_VERSION="v0.40.0-next.1" INPUT_DRY_RUN="true" run main
   [ "$status" -ne 0 ]

--- a/.github/workflows/notify-release.yaml
+++ b/.github/workflows/notify-release.yaml
@@ -35,6 +35,11 @@ on:
         required: false
         type: boolean
         default: false
+      triggered_by:
+        description: 'Human who triggered the release; forwarded to the Slack banner. Leave empty to fall back to github.actor (the run actor, which is the bot PAT when the release was dispatched cross-workflow).'
+        required: false
+        type: string
+        default: ''
     secrets:
       SLACK_WEBHOOK_URL_PRODUCT_RELEASES:
         description: 'Slack incoming webhook URL for #product-releases'
@@ -89,4 +94,8 @@ jobs:
           target_repo: ${{ inputs.target_repo }}
           product: ${{ inputs.product }}
           status: ${{ inputs.status }}
+          # Forward the human actor when the caller supplies one; otherwise fall
+          # back to github.actor (the composite's own default) for callers that
+          # don't pass it, keeping existing behavior unchanged.
+          triggered_by: ${{ inputs.triggered_by || github.actor }}
           webhook_url: ${{ secrets.SLACK_WEBHOOK_URL_PRODUCT_RELEASES }} # zizmor: ignore[secrets-outside-env] -- webhook URL passed via workflow_call

--- a/docs/workflows/notify-release.md
+++ b/docs/workflows/notify-release.md
@@ -6,15 +6,16 @@ Sends a Slack notification to #product-releases when a new version is published.
 
 <!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
 
-|      INPUT      |  TYPE   | REQUIRED |   DEFAULT   |                                   DESCRIPTION                                   |
-|-----------------|---------|----------|-------------|---------------------------------------------------------------------------------|
-|     dry-run     | boolean |  false   |   `false`   |    Validate inputs and workflow structure without <br>sending notifications     |
-|  previous_tag   | string  |  false   |             |  The previous tag for changelog comparison <br>(required when status=success)   |
-|     product     | string  |   true   |             |                 Product name (e.g. vCluster, vCluster Platform)                 |
-|       ref       | string  |  false   |             |                The git ref to checkout (defaults to github.ref)                 |
-| release_version | string  |   true   |             |                      The release version tag (e.g. v1.2.3)                      |
-|     status      | string  |  false   | `"success"` | Release status: success, failure, cancelled, or <br>skipped (default: success)  |
-|   target_repo   | string  |   true   |             |                    Target repository (e.g. loft-sh/vcluster)                    |
+|      INPUT      |  TYPE   | REQUIRED |   DEFAULT   |                                                                                               DESCRIPTION                                                                                               |
+|-----------------|---------|----------|-------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|     dry-run     | boolean |  false   |   `false`   |                                                                Validate inputs and workflow structure without <br>sending notifications                                                                 |
+|  previous_tag   | string  |  false   |             |                                                              The previous tag for changelog comparison <br>(required when status=success)                                                               |
+|     product     | string  |   true   |             |                                                                             Product name (e.g. vCluster, vCluster Platform)                                                                             |
+|       ref       | string  |  false   |             |                                                                            The git ref to checkout (defaults to github.ref)                                                                             |
+| release_version | string  |   true   |             |                                                                                  The release version tag (e.g. v1.2.3)                                                                                  |
+|     status      | string  |  false   | `"success"` |                                                             Release status: success, failure, cancelled, or <br>skipped (default: success)                                                              |
+|   target_repo   | string  |   true   |             |                                                                                Target repository (e.g. loft-sh/vcluster)                                                                                |
+|  triggered_by   | string  |  false   |             | Human who triggered the release; forwarded <br>to the Slack banner. Leave empty <br>to fall back to github.actor (the run actor, which is the bot PAT when the release was dispatched cross-workflow).  |
 
 <!-- AUTO-DOC-INPUT:END -->
 


### PR DESCRIPTION
## Problem

The #product-releases Slack banner shows **Triggered by / Released by: `${{ github.actor }}`**, which resolves to **loft-bot** whenever the release build is dispatched cross-workflow via the `GH_ACCESS_TOKEN` PAT (the single-release-dispatcher model, DEVOPS-1050). The human who cut the release is known at `cut-release` time but is lost across the `gh workflow run` dispatch hop.

## Change

Fully **additive and backward-compatible** — a new **optional** input that **falls back to `github.actor`**, so any caller that doesn't pass it renders exactly as today (loft-enterprise unaffected). No version bump; the existing `release-notification/v2` / `vcluster-release/v1` tags are just re-pointed on merge as usual.

- **`release-notification`**: optional `triggered_by` input, `default: ${{ github.actor }}`; used for both `Released by` (success) and `Triggered by` (failure) banners.
- **`notify-release.yaml`**: `triggered_by` passthrough, forwards `${{ inputs.triggered_by || github.actor }}`.
- **`vcluster-release`**: forwards the dispatcher's `github.actor` as `-f triggered_by=<actor>` **only on the monorepo + feature-prerelease dispatch paths**. Legacy `v0.31`–`v0.36` `release.yaml`s don't declare the input and `gh workflow run` rejects undeclared inputs, so legacy dispatches are byte-for-byte unchanged.

## Tests

`bats` 56 pass (+3: actor forwarded on monorepo + feature-prerelease; never on legacy). `shellcheck` + `actionlint` clean.

## Consumer

The vcluster-pro `release.yaml` side (a `triggered_by` `workflow_dispatch` input forwarded to both notify jobs) lands in the DEVOPS-1013 vcluster-pro PR.

Part of DEVOPS-1013.