### PR TITLE
fix(oss-commit-sync): default author identity for the alignment commit

### DIFF
--- a/.github/actions/oss-commit-sync/lib.sh
+++ b/.github/actions/oss-commit-sync/lib.sh
@@ -22,6 +22,12 @@ OSS_TRAILER="Oss-Commit"
 # the source commit). Callers may override via the standard git env vars.
 export GIT_COMMITTER_NAME="${GIT_COMMITTER_NAME:-github-actions[bot]}"
 export GIT_COMMITTER_EMAIL="${GIT_COMMITTER_EMAIL:-41898282+github-actions[bot]@users.noreply.github.com}"
+# Author defaults matter for the one commit not covered by replay_commit's
+# per-commit author env: the export alignment commit (git commit-tree). On a
+# bare CI runner with no user.name configured, git refuses to invent an
+# author ("empty ident name"), so default the author to the bot identity.
+export GIT_AUTHOR_NAME="${GIT_AUTHOR_NAME:-$GIT_COMMITTER_NAME}"
+export GIT_AUTHOR_EMAIL="${GIT_AUTHOR_EMAIL:-$GIT_COMMITTER_EMAIL}"
 
 emit() { echo "$1=$2" >> "${GITHUB_OUTPUT}"; }
 

--- a/.github/actions/oss-commit-sync/test/export.bats
+++ b/.github/actions/oss-commit-sync/test/export.bats
@@ -283,8 +283,13 @@ Monorepo-Commit: $M0"
   )
   seed_oss=$(oss_tip)
 
+  # Run with NO git identity in the environment, like a bare CI runner: the
+  # alignment commit-tree must not depend on the fixture's exported idents
+  # (rehearsal caught "empty ident name" here).
   SEED_MONOREPO_COMMIT="$M0" SEED_OSS_COMMIT="$seed_oss" \
-    EXCLUDE_PATHS=".github/workflows/release.yaml" ALIGN_TREE=true run bash "$EXPORT"
+    EXCLUDE_PATHS=".github/workflows/release.yaml" ALIGN_TREE=true \
+    run env -u GIT_AUTHOR_NAME -u GIT_AUTHOR_EMAIL -u GIT_COMMITTER_NAME -u GIT_COMMITTER_EMAIL \
+    bash "$EXPORT"
   [ "$status" -eq 0 ]
   [ "$(output_value pushed)" = "true" ]
   # the alignment commit deleted the excluded leftover and seeded the trailer

--- a/.github/actions/oss-commit-sync/test/helpers.bash
+++ b/.github/actions/oss-commit-sync/test/helpers.bash
@@ -13,6 +13,9 @@ setup_fixture() {
   export GIT_CONFIG_GLOBAL="$ROOT/gitconfig"
   git config --file "$GIT_CONFIG_GLOBAL" init.defaultBranch main
   git config --file "$GIT_CONFIG_GLOBAL" protocol.file.allow always
+  # CI runners have no GECOS name, so git cannot invent an ident there; make
+  # local runs equally strict so missing-ident regressions bite everywhere.
+  git config --file "$GIT_CONFIG_GLOBAL" user.useConfigOnly true
 
   EXPORT="$BATS_TEST_DIRNAME/../export.sh"
   IMPORT="$BATS_TEST_DIRNAME/../import.sh"


### PR DESCRIPTION
## Summary

- Second live-rehearsal catch: the migration re-run on a real runner died with `fatal: empty ident name`. The alignment `git commit-tree` is the only commit not covered by `replay_commit`'s per-commit author env, and bare CI runners have no GECOS name for git to auto-invent an ident from. `lib.sh` now defaults `GIT_AUTHOR_NAME`/`GIT_AUTHOR_EMAIL` to the bot committer identity.
- The bats fixtures masked this by exporting all four ident vars globally. They now set `user.useConfigOnly=true` (runner-equivalent strictness) and the migration test invokes the export with all ident vars unset; verified the test fails without the fix and passes with it.

## Test plan

- 28/28 bats; the migration test reproduces the runner failure exactly (red without fix, green with).
- Will re-run the live migration rehearsal after merge + re-pointing `oss-commit-sync/v1`, then the multi-commit scenario batch.

References DEVOPS-1121