### PR TITLE
docs(release): document advancing the vN coordination tag to ship shared-action fixes

### DIFF
--- a/.claude/skills/github-actions-dev/SKILL.md
+++ b/.claude/skills/github-actions-dev/SKILL.md
@@ -68,7 +68,15 @@ git tag -f <action-name>/v1
 git push origin <action-name>/v1 --force
 ```
 
-Exception: `release-notification` uses legacy repo-wide `v1` tag.
+Advancing this tag IS the release. Callers pin the tag, not `main`, so a fix merged
+to a shared action ships only when you move its tag to the merged commit. Skip this
+and the fix strands on `main` while callers keep running the old code (pin drift:
+DEVOPS-1126, DEVOPS-923).
+
+`release-notification` uses the action-scoped `release-notification/v2` tag as a
+coordination tag: the `notify-release.yaml` wrapper and its inner composite both
+resolve at `@release-notification/v2`, so advancing that one tag moves them together.
+(A legacy repo-wide `v1` tag predates this; callers no longer use it.)
 
 Referenced as:
 ```yaml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,19 @@ Never-hard-fail enforcement for advisory workflows (approval, notifications):
 
 Actions use per-action tags (e.g. `semver-validation/v1`, `linear-release-sync/v1`).
 
+### Shipping a fix to a shared action: advance the tag, or it strands on main
+
+Callers pin a floating coordination tag (`<action-name>/vN`, e.g. `release-notification/v2`), not `main`. Merging a fix to a shared action does NOT ship it. The fix reaches callers only when you advance that tag to the merged commit. Skip this and the fix strands on `main` while every caller keeps running the old code pinned at the tag (pin drift: DEVOPS-1126, DEVOPS-923).
+
+So after merging any change to a shared action, advance its tag as part of the release:
+
+```bash
+git tag -f <action-name>/v2 origin/main   # the merged commit
+git push origin <action-name>/v2 --force
+```
+
+For `release-notification`, the `notify-release.yaml` wrapper and its inner composite both resolve at `@release-notification/v2` (see PR #147), so advancing that one tag moves the wrapper and composite together.
+
 ### YAML-only / Node.js actions (semver-validation, release-notification, etc.)
 - Update code and commit changes
 - Tag the release: `git tag -f <action-name>/v1`


### PR DESCRIPTION
## Summary

Documents the release rule that DEVOPS-1126 turned on: a fix merged to a shared action does not ship until its floating `<action-name>/vN` coordination tag is advanced to the merged commit. Callers pin the tag, not `main`.

This is the recurrence-prevention piece of DEVOPS-1126 (acceptance criterion 4). The emoji fix itself is already live: `release-notification/v2` was advanced to `0293eae` during the PR #186 release, and that commit carries both PR #146 (failure header `emoji: true`) and PR #147 (wrapper and composite resolve at the same `@release-notification/v2` tag). All three callers pin `@release-notification/v2`, so they pick up the fix on their next release run.

## Key Changes

- `CLAUDE.md`: new Release Process subsection stating that advancing the coordination tag is how a shared-action fix reaches callers, with the tag-advance commands and the `release-notification` wrapper/composite alignment (PR #147).
- `.claude/skills/github-actions-dev/SKILL.md`: same lesson in the in-repo skill, and corrects a stale note. The skill claimed `release-notification` used a legacy repo-wide `v1` tag; callers actually pin the action-scoped `release-notification/v2`, and no caller references `@v1`.

## Why

The emoji fix sat correct on `main` for two months while every production release kept rendering the literal `:rotating_light:` shortcode, and roughly 23 agent attempts re-edited code that was already right. The gap was pin drift, not code: the coordination tag was never advanced after the fix merged. The release docs described the tag force-push mechanic but never stated the lesson, so the drift recurred unnoticed.

## Dependencies

None. Docs-only.

## TODO

- [ ] Live verification of the 🚨 banner (acceptance criteria 2 and 3) is a separate step, pending a decision on how to post a failure banner without spamming #product-releases. Tracked on DEVOPS-1126.

References DEVOPS-1126
