### PR TITLE
fix(release-notification): render failure emoji with unicode, not slack shortcode

### DIFF
--- a/.github/actions/release-notification/action.yml
+++ b/.github/actions/release-notification/action.yml
@@ -110,10 +110,16 @@ runs:
       env:
         STATUS: ${{ inputs.status }}
       run: |
+        # Use literal Unicode emoji, not Slack :shortcode: codes. The failure
+        # banner's leading emoji sits in a Block Kit `header`, and a header's
+        # plain_text does NOT render :shortcodes: even with `emoji: true` (Slack
+        # only renders shortcodes in mrkdwn/section text). A raw Unicode char
+        # renders in a header regardless. This is the actual fix for DEVOPS-1126;
+        # flipping the header's `emoji` flag (PR #146) never could have worked.
         case "$STATUS" in
-          failure)   echo "emoji=:rotating_light:" >> "$GITHUB_OUTPUT"; echo "label=Failed" >> "$GITHUB_OUTPUT" ;;
-          cancelled) echo "emoji=:warning:" >> "$GITHUB_OUTPUT"; echo "label=Cancelled" >> "$GITHUB_OUTPUT" ;;
-          skipped)   echo "emoji=:fast_forward:" >> "$GITHUB_OUTPUT"; echo "label=Skipped" >> "$GITHUB_OUTPUT" ;;
+          failure)   printf 'emoji=%s\n' '🚨' >> "$GITHUB_OUTPUT"; echo "label=Failed" >> "$GITHUB_OUTPUT" ;;
+          cancelled) printf 'emoji=%s\n' '⚠️' >> "$GITHUB_OUTPUT"; echo "label=Cancelled" >> "$GITHUB_OUTPUT" ;;
+          skipped)   printf 'emoji=%s\n' '⏩' >> "$GITHUB_OUTPUT"; echo "label=Skipped" >> "$GITHUB_OUTPUT" ;;
         esac
     - name: Post release failure notification
       if: inputs.status != 'success'


### PR DESCRIPTION
## Summary

The real fix for DEVOPS-1126. The "Release Pipeline Failed" Slack banner rendered `:rotating_light:` as literal text, and it still did on 2026-07-21 (vCluster Platform v4.12.0-alpha.1) even after the tag was advanced to the post-#186 code that carries `emoji: true` on the failure header.

Root cause: the leading emoji sits in a Block Kit `header` block, and a header's `plain_text` does not render `:shortcode:` emoji, with or without the `emoji` flag. Slack expands shortcodes only in `mrkdwn` / section text; its own docs say a header needs the emoji "in a separate component". So PR #146 (flipping the header `emoji: false` to `true`) could never have worked, which is why ~23 prior attempts built on that premise all failed.

Fix: emit the actual Unicode character (🚨 / ⚠️ / ⏩) from the `Resolve status text` step instead of the shortcode. A raw Unicode emoji renders in a header regardless of the flag, and also renders in the top-level fallback `text`.

## Key Changes

- `.github/actions/release-notification/action.yml`: `Resolve status text` now outputs Unicode emoji, not Slack shortcodes. No layout change, no `workflow_call` interface change, callers unaffected.

## Why this one is different

Earlier attempts (including PR #146) treated the `emoji` flag as the bug. The screenshot from the 2026-07-21 failure banner proves otherwise: that run executed the newer code (it shows the `Triggered by` field added in #186) with `emoji: true` on the header, and the shortcode still rendered literally. The variable was never the flag; it was the shortcode in a header block.

## Dependencies / ship step

This does not reach production on merge alone. Callers pin `release-notification/v2`, so after merge the `release-notification/v2` coordination tag must be advanced to the merged commit (see the release-process docs note in PR #189). Then verify with a real failure banner.

## TODO

- [ ] Merge
- [ ] Advance `release-notification/v2` to the merged commit
- [ ] Verify a live failure banner renders 🚨 (a real failed release, or a `status: failure` notify dispatch)

Closes DEVOPS-1126
