### PR TITLE
test(oss-commit-sync): pin squash-merge self-healing; drop auto-merge advice

### DIFF
--- a/.github/actions/oss-commit-sync/README.md
+++ b/.github/actions/oss-commit-sync/README.md
@@ -68,10 +68,17 @@ caller pushes the branch and opens/updates the sync PR.
   non-zero with `conflict-sha` set and a clean worktree.
 - The checkout must be at the base branch (`branch` input) with full history.
 
-**The sync PR must be rebase-merged** (never squash), or per-commit
-authorship and the trailers are destroyed on the base branch. Have the
-automation enable auto-merge with rebase rather than trusting habit. If a
-maintainer needs to fix up a sync PR, they must add new commits (without an
+**Merge the sync PR with rebase, never squash.** Squashing destroys the
+per-commit authorship of external contributions on the base branch, which is
+the whole point of the replay. It does NOT corrupt the sync, though: OSS
+history is append-only and already holds the real commits, and the state
+self-heals — squashed-away trailers make the externals look unabsorbed, but
+the export guard classifies them as benign (content present) and the next
+import re-skips them as no-ops (regression-tested in
+`test/squash-tolerance.bats`). The damage is limited to monorepo blame and
+contributor credit, so treat rebase-merge as review policy rather than
+wiring auto-merge (which some compliance postures disallow). If a maintainer
+needs to fix up a sync PR, they must add new commits (without an
 `Oss-Commit` trailer), never amend the replayed ones; amendments are caught
 later by the export convergence assertion.
 

--- a/.github/actions/oss-commit-sync/test/export.bats
+++ b/.github/actions/oss-commit-sync/test/export.bats
@@ -266,9 +266,11 @@ Monorepo-Commit: $M0"
 
 @test "migration: align-tree removes excluded-path leftovers and seeds the trailer" {
   # Pre-migration OSS carries a producer workflow that staging does not have,
-  # the exclude list covers it, and OSS has no trailers yet. Reproduces the
-  # rehearsal finding: with an exclude-aware align, the migration run was a
-  # green no-op that seeded nothing.
+  # the exclude list covers it, and OSS has no trailers yet. align-tree must
+  # act on this state even though the only drift is in excluded paths: if
+  # the exclude-aware assertion also gated the alignment, this run would be
+  # a green no-op that deletes nothing and seeds no trailer, leaving every
+  # subsequent export unable to find a resume point.
   rm -rf "$OSS_REMOTE" "$ROOT/ossseed"
   git init -q --bare "$OSS_REMOTE"
   git init -q "$ROOT/ossseed"
@@ -283,9 +285,10 @@ Monorepo-Commit: $M0"
   )
   seed_oss=$(oss_tip)
 
-  # Run with NO git identity in the environment, like a bare CI runner: the
-  # alignment commit-tree must not depend on the fixture's exported idents
-  # (rehearsal caught "empty ident name" here).
+  # Run with NO git identity in the environment. CI runners have no GECOS
+  # name for git to derive an ident from, so the alignment commit-tree dies
+  # with "empty ident name" unless the action supplies author defaults; the
+  # fixture's exported idents must not mask that.
   SEED_MONOREPO_COMMIT="$M0" SEED_OSS_COMMIT="$seed_oss" \
     EXCLUDE_PATHS=".github/workflows/release.yaml" ALIGN_TREE=true \
     run env -u GIT_AUTHOR_NAME -u GIT_AUTHOR_EMAIL -u GIT_COMMITTER_NAME -u GIT_COMMITTER_EMAIL \

--- a/.github/actions/oss-commit-sync/test/squash-tolerance.bats
+++ b/.github/actions/oss-commit-sync/test/squash-tolerance.bats
@@ -1,0 +1,92 @@
+#!/usr/bin/env bats
+# A squash-merged sync PR is a policy violation (it destroys per-commit
+# authorship of external contributions on the monorepo base branch), but it
+# must NOT corrupt the sync: OSS history is append-only and already holds the
+# real commits, and the trailer state self-heals through the benign guard and
+# the no-op skips. These tests pin that down for both squash variants.
+
+load helpers
+
+setup() {
+  setup_fixture
+}
+
+teardown() {
+  teardown_fixture
+}
+
+# Simulate the GitHub "Squash and merge" button: one commit on the base with
+# the PR branch's combined diff and a caller-provided message.
+squash_merge_pr_branch() {
+  local msg="$1"
+  (
+    cd "$MONO"
+    git switch -q main
+    git merge --squash -q "automation/sync-from-oss-main"
+    git commit -qm "$msg"
+  )
+}
+
+@test "squash WITHOUT trailers self-heals: export benign+no-op, import re-skips" {
+  external_commit ext1.go "one" "feat: alice first"
+  external_commit ext2.go "two" "feat: alice second"
+  bash "$IMPORT"
+
+  # Worst case: the squash message loses the Oss-Commit trailers entirely.
+  squash_merge_pr_branch "chore: sync from oss (#42)"
+
+  # Export: the externals look unabsorbed (no trailers on main), but their
+  # content is in staging, so the benign guard passes; the squash commit
+  # itself has no Oss-Commit trailer, so it enters the replay range and must
+  # be skipped as a no-op instead of duplicating content or failing.
+  run bash "$EXPORT"
+  [ "$status" -eq 0 ]
+  [ "$(output_value diverged)" = "false" ]
+  [ "$(output_value exported-count)" = "0" ]
+  [ "$(output_value pushed)" = "false" ]
+  # OSS keeps the real authorship untouched (append-only mirror)
+  [ "$(git -C "$OSS_REMOTE" log -1 --format=%an 'main^')" = "alice" ]
+
+  # Import: resume falls back before the squash, re-walks both externals,
+  # and skips each as a no-op; no duplicate replay commits.
+  git -C "$MONO" switch -q main
+  run bash "$IMPORT"
+  [ "$status" -eq 0 ]
+  [ "$(output_value has-changes)" = "false" ]
+  [ "$(output_value replayed-count)" = "0" ]
+
+  # And normal operation continues: the next company commit exports cleanly.
+  company_commit pkg/app.go "after-squash" "feat: company after squash" >/dev/null
+  run bash "$EXPORT"
+  [ "$status" -eq 0 ]
+  [ "$(output_value exported-count)" = "1" ]
+  [ "$(git -C "$OSS_REMOTE" rev-parse 'main^{tree}')" = "$(git -C "$MONO" rev-parse "HEAD:$PFX")" ]
+}
+
+@test "squash WITH trailers in the body: resume takes the newest trailer" {
+  E1=$(external_commit ext1.go "one" "feat: alice first")
+  E2=$(external_commit ext2.go "two" "feat: alice second")
+  bash "$IMPORT"
+
+  # GitHub's default squash message concatenates the commit messages, so
+  # both Oss-Commit trailers land in one commit body; the newest must win.
+  squash_merge_pr_branch "chore: sync from oss (#42)
+
+feat: alice first
+
+Oss-Commit: $E1
+
+feat: alice second
+
+Oss-Commit: $E2"
+
+  git -C "$MONO" switch -q main
+  run bash "$IMPORT"
+  [ "$status" -eq 0 ]
+  [ "$(output_value has-changes)" = "false" ]
+
+  run bash "$EXPORT"
+  [ "$status" -eq 0 ]
+  [ "$(output_value diverged)" = "false" ]
+  [ "$(output_value exported-count)" = "0" ]
+}


### PR DESCRIPTION
## Summary

- The caller workflows do not enable auto-merge on sync PRs: SOC2 change management requires a human-executed merge, so rebase-merge is review policy. This PR pins down why a wrong merge method cannot corrupt the sync: the diff-replay design is squash-tolerant. OSS history is append-only and already holds the external commits with their real authors, and the trailer state self-heals — squashed-away trailers make externals look unabsorbed, the export guard classifies them as benign (content already in staging), and the next import re-skips them as no-ops. A squash costs per-commit external authorship on the monorepo base branch, never sync correctness.
- Two new bats tests cover both squash variants: trailers lost entirely (export benign + no-op skip, import re-skip, normal operation continues, OSS authorship untouched) and trailers concatenated in the squash body (newest trailer wins for resume).
- README documents the merge policy and the squash consequences; test comments state their invariants directly. No behavior changes to the action itself.

## Test plan

- 30/30 bats (2 new). `make check-docs` clean.

References DEVOPS-1121