### PR TITLE
fix(oss-commit-sync): don't close git-log pipe early in newest_trailer_entry (exit 141 on large repos)

### DIFF
--- a/.github/actions/oss-commit-sync/lib.sh
+++ b/.github/actions/oss-commit-sync/lib.sh
@@ -40,10 +40,17 @@ die() {
 # Walk <ref> first-parent, newest first, and print "<commit-sha> <value>" for
 # the first commit carrying the trailer. Prints nothing when none is found.
 # With several same-key trailers on one commit the newest (last) value wins.
+#
+# The awk consumer must NOT `exit` on the first match: closing the pipe early
+# while `git log` is still writing a large history makes git receive SIGPIPE,
+# and under `set -o pipefail` that surfaces as exit 141 (git's SIGPIPE
+# handling is build-dependent, so this only bites on big repos on some
+# runners). Instead it reads the whole first-parent stream and keeps only the
+# first (newest) match. The first-parent log is bounded and cheap to stream.
 newest_trailer_entry() {
   local ref="$1" key="$2"
   git log --first-parent --format="%H%x09%(trailers:key=${key},valueonly,separator=%x09)" "$ref" \
-    | awk -F'\t' 'NF >= 2 && $NF != "" { print $1 " " $NF; exit }'
+    | awk -F'\t' 'found { next } NF >= 2 && $NF != "" { print $1 " " $NF; found = 1 }'
 }
 
 # all_trailer_entries <ref> <key>

--- a/.github/actions/oss-commit-sync/test/trailer-helpers.bats
+++ b/.github/actions/oss-commit-sync/test/trailer-helpers.bats
@@ -1,0 +1,51 @@
+#!/usr/bin/env bats
+# Unit tests for lib.sh trailer helpers, incl. the large-history SIGPIPE
+# regression: newest_trailer_entry must not close the git-log pipe early
+# (exit 141 under pipefail on big repos, build-dependent).
+
+setup() {
+  ROOT=$(mktemp -d); export ROOT
+  export GIT_AUTHOR_NAME=t GIT_AUTHOR_EMAIL=t@t GIT_COMMITTER_NAME=t GIT_COMMITTER_EMAIL=t@t
+  export GIT_CONFIG_GLOBAL="$ROOT/gc"
+  git config --file "$GIT_CONFIG_GLOBAL" init.defaultBranch main
+  # shellcheck disable=SC1090
+  source "$BATS_TEST_DIRNAME/../lib.sh"
+  git init -q "$ROOT/r"; cd "$ROOT/r"
+}
+teardown() { rm -rf "$ROOT"; }
+
+@test "newest_trailer_entry returns the newest match" {
+  git commit -q --allow-empty -m "old
+
+Monorepo-Commit: oldsha"
+  git commit -q --allow-empty -m "new
+
+Monorepo-Commit: newsha"
+  run newest_trailer_entry HEAD Monorepo-Commit
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | awk '{print $2}')" = "newsha" ]
+}
+
+@test "newest_trailer_entry is empty when no trailer present" {
+  git commit -q --allow-empty -m "no trailer here"
+  run newest_trailer_entry HEAD Monorepo-Commit
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "newest_trailer_entry survives a large history under pipefail (SIGPIPE regression)" {
+  # Fabricate ~2500 commits cheaply; newest carries the trailer so a naive
+  # early-exit consumer would close the pipe after line 1 while git streams
+  # the rest (>64KB) -> SIGPIPE -> 141 under pipefail.
+  et=$(git mktree </dev/null)
+  prev=$(git commit-tree "$et" -m root)
+  for i in $(seq 1 2500); do prev=$(git commit-tree "$et" -p "$prev" -m "c$i"); done
+  head=$(git commit-tree "$et" -p "$prev" -m "newest
+
+Monorepo-Commit: TARGETSHA")
+  git update-ref refs/heads/main "$head"
+  set -o pipefail
+  run newest_trailer_entry main Monorepo-Commit
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | awk '{print $2}')" = "TARGETSHA" ]
+}


### PR DESCRIPTION
## Summary

- `newest_trailer_entry` piped a full-history `git log` into an `awk` that `exit`ed on the first match. On a large repo `git` is still writing when the pipe closes, so it receives SIGPIPE, and under `set -o pipefail` the pipeline surfaces as **exit 141** — failing every resume-point lookup (export and import).
- Git's SIGPIPE handling is build/version-dependent, so this only manifested against the **real `loft-sh/vcluster` history on the CI runner** — not in the bats suite or the small-history rehearsal repos. The seeded migration path skips `newest_trailer_entry`, which is why the one-time migration landed correctly while the first seedless steady-state export failed.
- Fix: read the whole first-parent stream and keep the first (newest) match instead of exiting early. The first-parent log is bounded and cheap to stream.

## Test plan

- New `test/trailer-helpers.bats`: correctness (newest match / empty) plus a SIGPIPE regression that fabricates ~2500 commits via `commit-tree` and asserts `newest_trailer_entry` succeeds under `pipefail`. 33/33 bats green; shellcheck clean.
- Found by the real production migration: the seeded `sync-to-oss` migration converged the mirror and seeded the trailer; the follow-up seedless export exposed this.

References DEVOPS-1121