### PR TITLE
feat(oss-commit-sync): actionable push-rejection error + document bypass prerequisites

### DIFF
--- a/.github/actions/oss-commit-sync/README.md
+++ b/.github/actions/oss-commit-sync/README.md
@@ -16,6 +16,41 @@ split` + guarded force-push) with incremental diff replay:
 - Both branches are append-only. Nothing is ever force-pushed; every failure
   mode fails closed before pushing.
 
+## Prerequisites
+
+The export pushes **directly** to the OSS default branch (the mirror is
+maintained by automation, not by per-change PRs). On a protected public repo
+that means the sync identity must be able to bypass **every** protection
+targeting that branch — and there are usually two independent systems, both
+of which must be satisfied:
+
+1. **Repository and organization rulesets** — the identity must be a bypass
+   actor on each ruleset that enforces `pull_request` on the branch. A
+   **team** bypass actor only takes effect if that team has access to the
+   repo; a team on the bypass list without repo access is silently inert. A
+   **classic PAT** does not reliably inherit team bypass in all setups — if a
+   team bypass won't apply, use a `RepositoryRole` bypass or a GitHub App
+   (`Integration`) bypass actor.
+2. **Legacy branch protection** (if still present alongside rulesets) — the
+   identity must be in both the "restrict who can push" allowlist and the
+   "allow specified actors to bypass required pull requests" list. Editing
+   `bypass_pull_request_allowances` via the API is **replace** semantics:
+   read the current list and append, or you will drop existing actors.
+
+There is no reliable pre-push check for this: server-side rulesets are not
+evaluated on `git push --dry-run`, and a token with write access can still be
+blocked. The only authoritative validation is an actual push plus the repo's
+**Rules → Rule Insights** view, which shows, per ruleset, whether the actor
+bypassed. When the push is rejected, this action fails with an actionable
+error and sets `push-rejected=true`.
+
+**Change-management note:** because the OSS repo is a downstream mirror of a
+source-of-truth monorepo (every commit is reviewed upstream before it is
+republished here), a scoped automation identity bypassing PR on the mirror is
+a documentable control exception, not an unreviewed production change. Record
+it as such (identity scoped, token rotated, mechanism deterministic and
+trailer-audited) if the mirror repo is in scope for change-management review.
+
 ## Directions
 
 ### `direction: export` (monorepo subtree → OSS branch)
@@ -106,17 +141,18 @@ later by the export convergence assertion.
 
 <!-- AUTO-DOC-OUTPUT:START - Do not remove or modify this section -->
 
-|     OUTPUT     |  TYPE  |                                            DESCRIPTION                                            |
-|----------------|--------|---------------------------------------------------------------------------------------------------|
-|  conflict-sha  | string |  Import: the OSS commit that failed <br>the 3-way apply, when the run <br>failed on a conflict.   |
-|    diverged    | string |  Export: true when OSS has external <br>commits not yet absorbed and the <br>run failed closed.   |
-| exported-count | string | Export: number of commits created on <br>the OSS branch (including an alignment commit, if any).  |
-|  has-changes   | string |     Import: true when at least one <br>external commit was replayed onto the <br>PR branch.       |
-|    oss-tip     | string |                          Export: the OSS branch tip after <br>the run.                            |
-|   pr-branch    | string |                    Import: the local branch holding the <br>replayed commits.                     |
-|     pushed     | string |                   Export: true when commits were pushed <br>to the OSS branch.                    |
-| replayed-count | string |                           Import: number of external commits replayed.                            |
-| skipped-count  | string |      Import: number of external commits skipped <br>because they touch only excluded paths.       |
+|     OUTPUT     |  TYPE  |                                                                  DESCRIPTION                                                                   |
+|----------------|--------|------------------------------------------------------------------------------------------------------------------------------------------------|
+|  conflict-sha  | string |                        Import: the OSS commit that failed <br>the 3-way apply, when the run <br>failed on a conflict.                          |
+|    diverged    | string |                        Export: true when OSS has external <br>commits not yet absorbed and the <br>run failed closed.                          |
+| exported-count | string |                       Export: number of commits created on <br>the OSS branch (including an alignment commit, if any).                         |
+|  has-changes   | string |                            Import: true when at least one <br>external commit was replayed onto the <br>PR branch.                             |
+|    oss-tip     | string |                                                 Export: the OSS branch tip after <br>the run.                                                  |
+|   pr-branch    | string |                                          Import: the local branch holding the <br>replayed commits.                                            |
+| push-rejected  | string | Export: true when the push to <br>the OSS branch was rejected by <br>branch protection / a ruleset (the sync identity is not a bypass actor).  |
+|     pushed     | string |                                         Export: true when commits were pushed <br>to the OSS branch.                                           |
+| replayed-count | string |                                                  Import: number of external commits replayed.                                                  |
+| skipped-count  | string |                            Import: number of external commits skipped <br>because they touch only excluded paths.                              |
 
 <!-- AUTO-DOC-OUTPUT:END -->
 

--- a/.github/actions/oss-commit-sync/action.yml
+++ b/.github/actions/oss-commit-sync/action.yml
@@ -49,6 +49,9 @@ outputs:
   diverged:
     description: "Export: true when OSS has external commits not yet absorbed and the run failed closed."
     value: ${{ steps.sync.outputs.diverged }}
+  push-rejected:
+    description: "Export: true when the push to the OSS branch was rejected by branch protection / a ruleset (the sync identity is not a bypass actor)."
+    value: ${{ steps.sync.outputs.push-rejected }}
   exported-count:
     description: "Export: number of commits created on the OSS branch (including an alignment commit, if any)."
     value: ${{ steps.sync.outputs.exported-count }}

--- a/.github/actions/oss-commit-sync/export.sh
+++ b/.github/actions/oss-commit-sync/export.sh
@@ -41,7 +41,7 @@ set -euo pipefail
 # paths that are never mirrored; the guard and the convergence assertion
 # ignore them), GITHUB_OUTPUT.
 #
-# Outputs: pushed, diverged, exported-count, oss-tip.
+# Outputs: pushed, diverged, push-rejected, exported-count, oss-tip.
 
 source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
@@ -91,6 +91,7 @@ external_is_benign() {
 
 emit diverged false
 emit pushed false
+emit push-rejected false
 emit exported-count 0
 
 # --- locate the OSS branch tip and the resume point ------------------------
@@ -264,9 +265,19 @@ fi
 # --- push (plain fast-forward; branch creation for new lines) ---------------
 
 if [ "$NEW_TIP" != "$OSS_TIP" ] || [ "$branch_absent" = "true" ]; then
-  git_scrubbed push --quiet "$OSS_REMOTE" "${NEW_TIP}:refs/heads/${BRANCH}"
-  emit pushed true
-  echo "Pushed ${NEW_TIP} to OSS ${BRANCH}"
+  # A true pre-push permission check isn't possible: server-side rulesets are
+  # not evaluated on --dry-run, and a token with write access can still be
+  # blocked by branch protection. So the fail-fast is here: on a rejection,
+  # translate git's raw error into an actionable one instead of leaving a bare
+  # GH013 in the log.
+  if git_scrubbed push --quiet "$OSS_REMOTE" "${NEW_TIP}:refs/heads/${BRANCH}"; then
+    emit pushed true
+    echo "Pushed ${NEW_TIP} to OSS ${BRANCH}"
+  else
+    emit push-rejected true
+    echo "::error::Push to OSS ${BRANCH} was rejected. If this is a branch-protection / ruleset rejection (GH013, 'must be made through a pull request', or 'not authorized to push'), the sync identity is not a bypass actor. It must bypass EVERY protection targeting ${BRANCH}: all repository/organization rulesets (require-PR bypass) AND legacy branch protection (require-PR bypass + push allowlist). Team bypass actors only apply if the team has access to the repo. See the oss-commit-sync README 'Prerequisites'."
+    exit 1
+  fi
 else
   echo "Nothing to push; OSS ${BRANCH} is up to date"
 fi


### PR DESCRIPTION
## Summary

Follow-ups from taking the sync live against `loft-sh/vcluster`:

- **Actionable push rejection.** When the export's direct push to the OSS branch is rejected by branch protection / a ruleset, the action now emits a clear error naming what the sync identity must bypass, and sets `push-rejected=true` — instead of leaving a bare `GH013` git error in the log. A genuine pre-push check isn't possible (server-side rulesets aren't evaluated on `git push --dry-run`, and write access doesn't imply bypass), so the translated rejection is the fail-fast.
- **Prerequisites documentation.** New README section: the identity must bypass **every** protection targeting the OSS default branch across **both** systems (rulesets *and* legacy branch protection); a team bypass actor is inert unless the team has repo access; a classic PAT may need a `RepositoryRole` or GitHub App (`Integration`) bypass instead of team bypass; `bypass_pull_request_allowances` is replace-semantics (read-modify-write). Plus a change-management note framing the mirror bypass as a documentable control exception (mirror is downstream of a reviewed source of truth).

These are exactly the setup facts the rehearsal couldn't surface (throwaway repos had no protection), rediscovered the hard way during the live migration.

## Test plan

- `shellcheck` clean; `make check-docs` clean (regenerated Inputs/Outputs incl. new `push-rejected` output); 33/33 bats green (push-path behavior unchanged).

References DEVOPS-1121