### PR TITLE
feat(link-backport-prs): warn with a remedy on every fixable skip

### DIFF
--- a/.github/actions/link-backport-prs/README.md
+++ b/.github/actions/link-backport-prs/README.md
@@ -12,7 +12,9 @@ When a merged source PR carries `backport-to-<branch>` labels, the [sorenlouv ba
 
 The match is by title prefix, not milestone: the `[X.Y] Copy of ...` sub-issues created for a backport family do not reliably carry a patch milestone, so the title is the dependable key.
 
-It is advisory and idempotent: it never fails the backport job (every error is a warning and it exits 0), it skips entirely when no `linear-token` is provided, and re-runs do not add duplicate `Fixes` lines.
+It is advisory and idempotent: it never fails the backport job (every problem is a warning and it exits 0) and re-runs do not add duplicate `Fixes` lines.
+
+Every skip that a human can fix is loud. When a source PR carries backport labels but linking hits a dead end, the action emits a GitHub `::warning::` annotation and a job-summary line naming the remedy. This covers an empty `linear-token` (fix the repository secret), an unresolved parent Linear issue (attach the PR to its issue), a release line with no matching `[X.Y]` sub-issue (create or rename the sub-issue), and a backport PR that sorenlouv never opened (backport it manually after the conflict). A source PR with no backport labels stays a plain notice, since there is nothing to fix. The step always publishes a `linked-count` output, 0 when it skips.
 
 ## Usage
 
@@ -45,22 +47,26 @@ The `github-token` must be the same PAT that created the backport PRs (a PAT, no
 
 <!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
 
-|    INPUT     |  TYPE  | REQUIRED |     DEFAULT      |                                                                                                                                  DESCRIPTION                                                                                                                                  |
-|--------------|--------|----------|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-|   dry-run    | string |  false   |    `"false"`     |                                                                                                                   Log intended edits without applying them                                                                                                                    |
-| github-token | string |   true   |                  |                                                                             GitHub token with permission to read <br>and edit pull requests (must be the same PAT that created the backport PRs)                                                                              |
-| label-prefix | string |  false   | `"backport-to-"` |                                                                                                              Prefix of the backport labels on <br>the source PR                                                                                                               |
-| linear-token | string |  false   |                  | Linear API token for resolving the <br>issue family. Optional by design: this <br>is an advisory step, so when <br>empty the action no-ops and exits <br>0 instead of failing, letting callers <br>adopt the shared backport workflow before <br>a Linear token is wired up.  |
-|  repo-name   | string |   true   |                  |                                                                                                                          The name of the repository                                                                                                                           |
-|  repo-owner  | string |   true   |                  |                                                                                                                          The owner of the repository                                                                                                                          |
-|  source-pr   | string |   true   |                  |                                                                                                        The merged source pull request number <br>that was backported                                                                                                          |
+|    INPUT     |  TYPE  | REQUIRED |     DEFAULT      |                                                                                                                                                                  DESCRIPTION                                                                                                                                                                  |
+|--------------|--------|----------|------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|   dry-run    | string |  false   |    `"false"`     |                                                                                                                                                   Log intended edits without applying them                                                                                                                                                    |
+| github-token | string |   true   |                  |                                                                                                             GitHub token with permission to read <br>and edit pull requests (must be the same PAT that created the backport PRs)                                                                                                              |
+| label-prefix | string |  false   | `"backport-to-"` |                                                                                                                                              Prefix of the backport labels on <br>the source PR                                                                                                                                               |
+| linear-token | string |  false   |                  | Linear API token for resolving the <br>issue family. Optional: the step always <br>exits 0, so callers can adopt <br>the backport workflow before a token <br>is wired up. When it is <br>empty but the source PR carries <br>backport labels, the step emits a <br>warning naming the missing secret instead <br>of silently doing nothing.  |
+|  repo-name   | string |   true   |                  |                                                                                                                                                          The name of the repository                                                                                                                                                           |
+|  repo-owner  | string |   true   |                  |                                                                                                                                                          The owner of the repository                                                                                                                                                          |
+|  source-pr   | string |   true   |                  |                                                                                                                                        The merged source pull request number <br>that was backported                                                                                                                                          |
 
 <!-- AUTO-DOC-INPUT:END -->
 
 ## Outputs
 
 <!-- AUTO-DOC-OUTPUT:START - Do not remove or modify this section -->
-No outputs.
+
+|    OUTPUT    |  TYPE  |                                   DESCRIPTION                                    |
+|--------------|--------|----------------------------------------------------------------------------------|
+| linked-count | string | Number of backport PRs linked to <br>a Linear sub-issue (0 when the step skips)  |
+
 <!-- AUTO-DOC-OUTPUT:END -->
 
 ## Development
@@ -75,4 +81,4 @@ Run the unit tests:
 make test-link-backport-prs
 ```
 
-The tests cover the pure matching logic: release-line extraction from a target branch, title-prefix matching (`[0.34]` and `[v0.34]`), sub-issue selection within an issue family, idempotency of the `Fixes` line, and identifier extraction fallback.
+The tests cover the pure matching logic (release-line extraction from a target branch, title-prefix matching for `[0.34]` and `[v0.34]`, sub-issue selection within an issue family, idempotency of the `Fixes` line, and identifier extraction fallback), plus the remedy-warning rendering and the `linked-count` / job-summary writers.

--- a/.github/actions/link-backport-prs/action.yml
+++ b/.github/actions/link-backport-prs/action.yml
@@ -15,7 +15,7 @@ inputs:
     description: 'GitHub token with permission to read and edit pull requests (must be the same PAT that created the backport PRs)'
     required: true
   linear-token:
-    description: 'Linear API token for resolving the issue family. Optional by design: this is an advisory step, so when empty the action no-ops and exits 0 instead of failing, letting callers adopt the shared backport workflow before a Linear token is wired up.'
+    description: 'Linear API token for resolving the issue family. Optional: the step always exits 0, so callers can adopt the backport workflow before a token is wired up. When it is empty but the source PR carries backport labels, the step emits a warning naming the missing secret instead of silently doing nothing.'
     required: false
     default: ''
   label-prefix:
@@ -27,6 +27,11 @@ inputs:
     required: false
     default: 'false'
 
+outputs:
+  linked-count:
+    description: 'Number of backport PRs linked to a Linear sub-issue (0 when the step skips)'
+    value: ${{ steps.link.outputs.linked-count }}
+
 runs:
   using: 'composite'
   steps:
@@ -36,6 +41,7 @@ runs:
         go-version-file: ${{ github.action_path }}/src/go.mod
 
     - name: Build and run Link Backport PRs
+      id: link
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}

--- a/.github/actions/link-backport-prs/src/main.go
+++ b/.github/actions/link-backport-prs/src/main.go
@@ -52,9 +52,14 @@ type issueFamily struct {
 }
 
 func main() {
+	// Workflow commands (::notice::, ::warning::) are only parsed when they
+	// start the line, so drop log's default date/time prefix; otherwise the
+	// annotations never surface in the run.
+	log.SetFlags(0)
 	if err := run(); err != nil {
 		// Advisory tool: surface the problem but never fail the backport job.
 		warnf("link-backport-prs: %v", err)
+		writeLinkedCount(0)
 	}
 }
 
@@ -75,13 +80,6 @@ func run() error {
 		return fmt.Errorf("GITHUB_TOKEN is required")
 	}
 
-	linearToken := os.Getenv("LINEAR_TOKEN")
-	if linearToken == "" {
-		// No Linear token wired up by the caller: nothing to do, not an error.
-		noticef("LINEAR_TOKEN not provided, skipping Linear sub-issue linking")
-		return nil
-	}
-
 	ctx := context.Background()
 	gh, err := github.NewClient(github.WithAuthToken(githubToken))
 	if err != nil {
@@ -93,15 +91,36 @@ func run() error {
 		return fmt.Errorf("get source PR #%d: %w", *sourcePR, err)
 	}
 
+	// A source PR without backport labels has nothing to link and nothing to
+	// fix, so it stays a plain notice.
 	targets := backportTargets(src.Labels, *labelPrefix)
 	if len(targets) == 0 {
 		noticef("source PR #%d has no %s* labels, nothing to link", *sourcePR, *labelPrefix)
+		writeLinkedCount(0)
+		return nil
+	}
+
+	// Backport labels are present, so every skip from here on hides a link that
+	// should have happened. The empty-token case is the silent no-op from the
+	// production rollout (DEVOPS-1060): a missing or misnamed secret looked
+	// identical to the feature being off. Make it loud, with the fix.
+	linearToken := os.Getenv("LINEAR_TOKEN")
+	if linearToken == "" {
+		remedyWarning{
+			problem: fmt.Sprintf("source PR #%d carries %d backport label(s) but linear-token is empty, so no backport PR was linked to its Linear sub-issue", *sourcePR, len(targets)),
+			remedy:  "set the backport workflow's linear-token secret to a valid Linear API token (verify the caller's `secrets: linear-token:` maps to an existing repository secret)",
+		}.emit()
+		writeLinkedCount(0)
 		return nil
 	}
 
 	family := resolveFamily(linearToken, src)
 	if family == nil {
-		warnf("could not resolve a Linear issue for source PR #%d (no attachment, no identifier in branch/body)", *sourcePR)
+		remedyWarning{
+			problem: fmt.Sprintf("could not resolve a Linear issue for source PR #%d (no attachment, and no TEAM-123 identifier in its branch or body), so its %d backport target(s) were not linked", *sourcePR, len(targets)),
+			remedy:  "attach the source PR to its Linear issue, or include the issue identifier in the PR branch name or body",
+		}.emit()
+		writeLinkedCount(0)
 		return nil
 	}
 	candidates := familyCandidates(*family)
@@ -117,7 +136,10 @@ func run() error {
 
 		sub, ok := matchSubIssue(candidates, version)
 		if !ok {
-			warnf("no sub-issue with a [%s] title prefix found under %s for backport to %s", version, family.Identifier, target)
+			remedyWarning{
+				problem: fmt.Sprintf("no sub-issue with a [%s] title prefix found under %s for backport to %s", version, family.Identifier, target),
+				remedy:  fmt.Sprintf("create or rename a sub-issue under %s so its title starts with [%s]", family.Identifier, version),
+			}.emit()
 			continue
 		}
 
@@ -128,7 +150,10 @@ func run() error {
 			continue
 		}
 		if bp == nil {
-			warnf("no backport PR found for %s (base %s); sorenlouv may have skipped it (conflict/no commits)", headBranch, target)
+			remedyWarning{
+				problem: fmt.Sprintf("no backport PR found for %s (base %s); sorenlouv likely skipped it after a merge conflict or empty diff", headBranch, target),
+				remedy:  fmt.Sprintf("backport to %s manually and add 'Fixes %s' to that PR's body", target, sub.Identifier),
+			}.emit()
 			continue
 		}
 
@@ -153,12 +178,7 @@ func run() error {
 	}
 
 	noticef("link-backport-prs: linked %d of %d backport target(s)", linked, len(targets))
-	if out := os.Getenv("GITHUB_OUTPUT"); out != "" {
-		if f, err := os.OpenFile(out, os.O_APPEND|os.O_WRONLY, 0o644); err == nil {
-			fmt.Fprintf(f, "linked-count=%d\n", linked)
-			f.Close()
-		}
-	}
+	writeLinkedCount(linked)
 	return nil
 }
 
@@ -404,10 +424,61 @@ func linearGraphQL(token, query string, variables map[string]any, out any) error
 	return json.Unmarshal(body, out)
 }
 
+// remedyWarning is a skip a human can fix. It renders to both a ::warning::
+// annotation (surfaced in the run's annotations) and a job-summary bullet, so a
+// skipped link is impossible to miss and always states how to fix it. Emitting
+// one never fails the job: the step stays advisory.
+type remedyWarning struct {
+	problem string // what was skipped and why
+	remedy  string // the concrete action that makes the link happen
+}
+
+func (w remedyWarning) annotation() string {
+	return fmt.Sprintf("%s. Remedy: %s", w.problem, w.remedy)
+}
+
+func (w remedyWarning) summaryLine() string {
+	return fmt.Sprintf("- ⚠️ %s\n  - **Remedy:** %s", w.problem, w.remedy)
+}
+
+func (w remedyWarning) emit() {
+	warnf("%s", w.annotation())
+	summaryf("%s", w.summaryLine())
+}
+
 func noticef(format string, args ...any) {
 	log.Printf("::notice::"+format, args...)
 }
 
 func warnf(format string, args ...any) {
 	log.Printf("::warning::"+format, args...)
+}
+
+// summaryf appends a markdown line to the GitHub job summary. Advisory: when
+// $GITHUB_STEP_SUMMARY is unset (local runs) or unwritable, it is a no-op.
+func summaryf(format string, args ...any) {
+	appendToEnvFile("GITHUB_STEP_SUMMARY", fmt.Sprintf(format, args...))
+}
+
+// writeLinkedCount publishes the linked-count step output declared in
+// action.yml. It is written on every exit path (0 when the step skips) so
+// callers always read a number.
+func writeLinkedCount(n int) {
+	appendToEnvFile("GITHUB_OUTPUT", fmt.Sprintf("linked-count=%d", n))
+}
+
+// appendToEnvFile appends one line to the file named by envVar, if that
+// variable is set. Backs both $GITHUB_OUTPUT and $GITHUB_STEP_SUMMARY; write
+// failures are ignored so the advisory step never fails the backport job.
+func appendToEnvFile(envVar, line string) {
+	path := os.Getenv(envVar)
+	if path == "" {
+		return
+	}
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0o644)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	fmt.Fprintln(f, line)
 }

--- a/.github/actions/link-backport-prs/src/main_test.go
+++ b/.github/actions/link-backport-prs/src/main_test.go
@@ -1,6 +1,11 @@
 package main
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
 
 func TestVersionFromBranch(t *testing.T) {
 	cases := map[string]string{
@@ -164,4 +169,94 @@ func TestBackportTargetsFromNames(t *testing.T) {
 			t.Fatalf("got %v, want %v", got, want)
 		}
 	}
+}
+
+func TestRemedyWarningRendering(t *testing.T) {
+	w := remedyWarning{problem: "no backport PR found for X", remedy: "backport X manually"}
+
+	// The annotation is a single line so GitHub renders it as one ::warning::.
+	got := w.annotation()
+	want := "no backport PR found for X. Remedy: backport X manually"
+	if got != want {
+		t.Errorf("annotation() = %q, want %q", got, want)
+	}
+	if strings.Contains(got, "\n") {
+		t.Errorf("annotation() must be single-line, got %q", got)
+	}
+
+	// The summary line is a markdown bullet naming the remedy.
+	line := w.summaryLine()
+	if !strings.HasPrefix(line, "- ") {
+		t.Errorf("summaryLine() should be a markdown bullet, got %q", line)
+	}
+	if !strings.Contains(line, w.problem) || !strings.Contains(line, w.remedy) {
+		t.Errorf("summaryLine() should name both problem and remedy, got %q", line)
+	}
+	if !strings.Contains(line, "Remedy:") {
+		t.Errorf("summaryLine() should label the remedy, got %q", line)
+	}
+}
+
+func TestWriteLinkedCount(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "output")
+	if err := os.WriteFile(path, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GITHUB_OUTPUT", path)
+
+	writeLinkedCount(3)
+
+	got := readFile(t, path)
+	if got != "linked-count=3\n" {
+		t.Errorf("GITHUB_OUTPUT = %q, want %q", got, "linked-count=3\n")
+	}
+}
+
+func TestWriteLinkedCountZeroOnSkip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "output")
+	if err := os.WriteFile(path, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GITHUB_OUTPUT", path)
+
+	// A skip path publishes 0 so callers always read a number.
+	writeLinkedCount(0)
+
+	if got := readFile(t, path); got != "linked-count=0\n" {
+		t.Errorf("GITHUB_OUTPUT = %q, want %q", got, "linked-count=0\n")
+	}
+}
+
+func TestSummaryfAppends(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "summary")
+	if err := os.WriteFile(path, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GITHUB_STEP_SUMMARY", path)
+
+	summaryf("- first")
+	summaryf("- second")
+
+	if got := readFile(t, path); got != "- first\n- second\n" {
+		t.Errorf("GITHUB_STEP_SUMMARY = %q, want %q", got, "- first\n- second\n")
+	}
+}
+
+func TestAppendToEnvFileUnsetIsNoop(t *testing.T) {
+	// When the variable is unset (a local run, no Actions environment), writing
+	// must be a harmless no-op, never a panic or error.
+	t.Setenv("GITHUB_OUTPUT", "")
+	if err := os.Unsetenv("GITHUB_OUTPUT"); err != nil {
+		t.Fatal(err)
+	}
+	writeLinkedCount(1) // must not panic
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(b)
 }


### PR DESCRIPTION
## Summary

The `link-backport-prs` step exited 0 with only a `::notice::` on every skip path, so a misconfiguration was indistinguishable from the feature being off. After the DEVOPS-1060 rollout the callers referenced a secret name that did not exist, `LINEAR_TOKEN` resolved empty, and every backport PR was created without its `Fixes` line with nothing to surface it. This makes every skip that has a remedy loud.

## Key Changes

- Warn with a remedy on fixable skips. When the source PR carries backport labels, the action now emits a `::warning::` annotation plus a `$GITHUB_STEP_SUMMARY` line naming the fix for each remediable skip:
  - empty `linear-token`: set the backport workflow's `linear-token` secret (the DEVOPS-1060 failure mode)
  - unresolved parent Linear issue: attach the PR to its issue
  - no `[X.Y]` sub-issue for a target: create or rename the sub-issue
  - missing backport PR: backport manually after the conflict
- A source PR with no backport labels stays a plain notice, since there is nothing to fix.
- The empty-token check now runs after the labels are read, so it can tell "feature off" (no labels) from "misconfigured" (labels present, empty token).
- `log.SetFlags(0)` so the `::notice::` / `::warning::` workflow commands start the line and actually render as annotations. The default date/time prefix was pushing them off line-start, so they never surfaced as annotations before.
- Declared `linked-count` as an action output (the Go program already wrote it to `$GITHUB_OUTPUT`), and now publish it on every exit path, 0 when the step skips.
- Still advisory: `main()` never exits non-zero, so the backport job never fails.
- Unit tests, README prose, and the auto-doc input/output tables updated.

## Testing

- `make test-link-backport-prs` (14 tests, all pass), covering the new remedy-warning rendering and the `linked-count` / job-summary writers alongside the existing matching logic.
- `zizmor .github/actions/link-backport-prs/`: no findings.
- `make generate-docs` run; the README auto-doc blocks are in sync.

## Dependencies

None. The action already shipped (#157). The caller secret-name fixes (loft-sh/vcluster#4084, loft-sh/vcluster-pro#2021, loft-sh/loft-enterprise#7491) are independent and need not land first.

## TODO

- [ ] After merge, advance the floating `link-backport-prs/v1` coordination tag (kept aligned with `backport/v1`, see DEVOPS-923) so callers pick up the change.

Closes DEVOPS-1139
