### PR TITLE
fix(backport): readable pr title/body for legacy split backports

### DIFF
--- a/.github/actions/backport-legacy-split/README.md
+++ b/.github/actions/backport-legacy-split/README.md
@@ -85,6 +85,21 @@ or renamed on the legacy branch, so its preimage isn't in the target index),
 nothing is staged and the run **fails loudly** with an actionable error rather
 than pushing an empty backport.
 
+## PR title and body
+
+The opened PR reads like its source rather than a bare SHA:
+
+- **Title** — `[<target>] <commit subject> (<side>)`, e.g.
+  `[v0.36] fix: CRD sync race (#3993) (pro)`. The subject is the monorepo
+  merge/squash commit subject, taken verbatim.
+- **Body** — references the source (the PR when `pr-number` is set,
+  fully-qualified as `owner/repo#N` so the reference links from the OSS repo too;
+  otherwise the monorepo commit SHA) and lists the backported commit under a
+  `### Backported Commits:` heading.
+
+Linear linking is intentionally **not** put in the body — see the Linear note
+below.
+
 ## Inputs
 
 <!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->

--- a/.github/actions/backport-legacy-split/run.sh
+++ b/.github/actions/backport-legacy-split/run.sh
@@ -129,6 +129,30 @@ SHORT="$(git rev-parse --short "$COMMIT")"
 BACKPORT_BRANCH="backport/${TARGET_BRANCH}/${SHORT}"
 emit backport-branch "$BACKPORT_BRANCH"
 
+# Human-readable PR metadata, sourced from the monorepo commit itself (CWD is a
+# full-history monorepo checkout). Computed once -- side-independent.
+#   SUBJECT    The merge/squash commit subject, reused verbatim in the PR title so
+#              a legacy backport reads like its source ("[v0.36] fix: ... (#1234)")
+#              instead of a bare SHA.
+#   SOURCE_REPO owner/repo of the monorepo (the repo the source PR lives in), parsed
+#              from origin. Used to fully-qualify the PR reference (owner/repo#N) so
+#              it links correctly even on the OSS half, whose target repo differs
+#              from the monorepo. Empty (e.g. tests, no origin) -> bare "#N".
+#
+# Linear linking is deliberately NOT done here: link-backport-prs owns it (resolve
+# the source PR's parent issue -> match the per-release-line "[X.Y] Copy of ..."
+# sub-issue -> append "Fixes <sub-issue>"). A "resolves <PARENT-KEY>" here would
+# both duplicate that and close the WRONG issue (the parent, not the line's
+# sub-issue). See the README note on the legacy-linking gap.
+SUBJECT="$(git log -1 --format=%s "$SHA")"
+SOURCE_REPO="$( { git config --get remote.origin.url 2>/dev/null || true; } \
+  | sed -E 's#^git@[^:]+:##; s#^https?://[^/]+/##; s#\.git$##' )"
+SRC_PR_REF=""
+if [ -n "${PR_NUMBER:-}" ]; then
+  SRC_PR_REF="#${PR_NUMBER}"
+  [ -n "$SOURCE_REPO" ] && SRC_PR_REF="${SOURCE_REPO}#${PR_NUMBER}"
+fi
+
 # --- diff range ------------------------------------------------------------
 # We backport what the PR changed. Deriving that from the merge commit alone is
 # unreliable: COMMIT^ is the base only for a squash/merge-commit; a rebase-merge
@@ -319,9 +343,21 @@ Applied with merge conflicts that need manual resolution."
   echo "${side}: pushed ${BACKPORT_BRANCH} -> ${slug:-the target repo}"
 
   if [ "$CREATE_PR" = "true" ]; then
-    local title body
-    title="[${TARGET_BRANCH}] backport ${SHORT} (${side})"
-    body="Automated backport of \`${SHA}\` (${side} half) onto \`${TARGET_BRANCH}\`."
+    local title body origin
+    # Read like the source commit: "[v0.36] fix: ... (#1234) (pro)" -- the subject
+    # verbatim, the target line, and the side (which repo/half this PR is).
+    title="[${TARGET_BRANCH}] ${SUBJECT} (${side})"
+    # Reference the source by PR when known (fully-qualified so it links from the
+    # OSS repo too), else by the immutable monorepo commit.
+    if [ -n "$SRC_PR_REF" ]; then
+      origin="${SRC_PR_REF}"
+    else
+      origin="commit \`${SHA}\`"
+    fi
+    body="Backport of ${origin} to \`${TARGET_BRANCH}\` (${side} half).
+
+### Backported Commits:
+- ${SHORT} ${SUBJECT}"
     local -a create_args=(--repo "$slug" --head "$BACKPORT_BRANCH" --base "$TARGET_BRANCH" --title "$title")
     if [ "$conflicts" = true ]; then
       # Open as a DRAFT so it cannot be auto-merged: the committed conflict

--- a/.github/actions/backport-legacy-split/test/run.bats
+++ b/.github/actions/backport-legacy-split/test/run.bats
@@ -476,6 +476,39 @@ short() { git -C "$MONO" rev-parse --short HEAD; }
   [[ "$body" == *"fix: the thing (#1234)"* ]]
 }
 
+@test "create-pr: PR reference is fully-qualified as owner/repo#N from origin" {
+  install_fake_gh
+  cd "$MONO"
+  # A PR head fetched via PR_NUMBER, plus a real GitHub-style origin so the
+  # SOURCE_REPO parser has a URL to strip to owner/repo. insteadOf rewrites the
+  # actual fetch to a local bare repo (hermetic), while `git config --get
+  # remote.origin.url` still returns the unrewritten https URL the parser reads.
+  git checkout -q -b prhead
+  printf 'line1\nOSS\nline3\n' > "$PFX/app.go"; git commit -qam c1
+  local prhead; prhead="$(git rev-parse HEAD)"
+  git checkout -q main
+  printf 'line1\nOSS\nline3\n' > "$PFX/app.go"; git commit -qam "squash (#1)"
+  local mergec; mergec="$(git rev-parse HEAD)"
+
+  local origin="$ROOT/origin-src.git"
+  git init -q --bare "$origin"
+  git push -q "$origin" main
+  git push -q "$origin" "$prhead:refs/pull/1/head"
+  git remote add origin "https://github.com/loft-sh/vcluster-pro.git"
+  git config "url.$origin.insteadOf" "https://github.com/loft-sh/vcluster-pro.git"
+
+  COMMIT="$mergec" PR_NUMBER=1 run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(output_value oss-pushed)" = "true" ]
+
+  # Body references the source PR fully-qualified (owner/repo#N), so it links
+  # from the OSS repo too -- not a bare "#1" (which would resolve wrongly there)
+  # nor the local origin path.
+  local body; body="$(create_body)"
+  [[ "$body" == *"Backport of loft-sh/vcluster-pro#1 to \`v0.35\` (oss half)."* ]]
+  [[ "$body" != *"Backport of #1 "* ]]
+}
+
 @test "create-pr: an existing open PR is detected and the side is skipped" {
   install_fake_gh
   export GH_PRLIST=exists

--- a/.github/actions/backport-legacy-split/test/run.bats
+++ b/.github/actions/backport-legacy-split/test/run.bats
@@ -110,6 +110,12 @@ STUB
 
 output_value() { grep "^$1=" "$GITHUB_OUTPUT" | tail -n1 | cut -d= -f2-; }
 
+# The fake `gh` logs each argv token on its own line. A single-line flag's value
+# is the token right after it; --body is passed last and spans multiple lines, so
+# its value is everything after the "--body" line to EOF (one create call/test).
+create_arg()  { grep -A1 -Fx -- "$1" "$GH_CREATE_LOG" | tail -n1; }
+create_body() { awk 'f{print} /^--body$/{f=1}' "$GH_CREATE_LOG"; }
+
 # comment-body is emitted with the GITHUB_OUTPUT heredoc form (it's multi-line),
 # so output_value can't read it -- extract the block between the delimiters.
 comment_body() {
@@ -446,6 +452,28 @@ short() { git -C "$MONO" rev-parse --short HEAD; }
   grep -q '^create$' "$GH_CREATE_LOG"
   run grep -Fxq -- --draft "$GH_CREATE_LOG"
   [ "$status" -ne 0 ]                   # clean PR is NOT a draft
+}
+
+@test "create-pr: title and body carry the commit subject, not a bare SHA" {
+  install_fake_gh
+  cd "$MONO"
+  printf 'line1\nOSS\nline3\n' > "$PFX/app.go"
+  git commit -qam "fix: the thing (#1234)"
+  local sha; sha="$(git -C "$MONO" rev-parse HEAD)"
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+
+  # Title reads like the source: "[<target>] <subject> (<side>)" -- subject
+  # verbatim, NOT the old "backport <short-sha>".
+  [ "$(create_arg --title)" = "[v0.35] fix: the thing (#1234) (oss)" ]
+  [[ "$(create_arg --title)" != *"backport ${sha:0:7}"* ]]
+
+  # Body references the source commit and lists it under a readable heading.
+  local body; body="$(create_body)"
+  [[ "$body" == *"Backport of commit \`$sha\` to \`v0.35\` (oss half)."* ]]
+  [[ "$body" == *"### Backported Commits:"* ]]
+  [[ "$body" == *"fix: the thing (#1234)"* ]]
 }
 
 @test "create-pr: an existing open PR is detected and the side is skipped" {


### PR DESCRIPTION
## Summary
- `backport-legacy-split` hardcoded the PR title/body from the bare SHA (`[v0.36] backport 0be5f924e (pro)`), losing the readable form the old sorenlouv path produced (compare loft-sh/vcluster#4001 vs loft-sh/vcluster-pro#2043).
- Title now reads like its source: `[<target>] <commit subject> (<side>)`, taken verbatim from the monorepo commit.
- Body references the source (PR fully-qualified as `owner/repo#N` so it links from the OSS repo too, else the monorepo SHA) and lists the backported commit under `### Backported Commits:`.
- Linear linking is deliberately left out of the body: `link-backport-prs` owns it and closes the per-release-line sub-issue, whereas a `resolves` here would close the parent issue.
- One fix covers both halves (oss + pro), so the OSS-repo legacy PRs benefit too once the tag is advanced.

## Test plan
- Added a bats test asserting the title carries the commit subject (not a bare SHA) and the body references the source commit + lists it; full suite passes (`make test-backport-legacy-split`, 28/28).
- `make generate-docs` clean (no auto-doc drift); README documents the new title/body format.

## Follow-up (not in this PR)
- Legacy cross-repo backport PRs still get no Linear linking: `link-backport-prs` is repo-scoped to the caller and keyed on sorenlouv's `backport/<target>/pr-<sourcePR>` branch naming, so it can't see these `backport/<target>/<short-sha>` PRs in the OSS/pro repos. Tracked as the DEVOPS-1051 legacy-linking gap.
- Ship reminder: advance the `backport-legacy-split/v1` tag (resolves via `backport/v1`) to the merged commit or the fix strands on main.

Closes DEVOPS-1151