### PR TITLE
fix(vcluster-release): normalize and validate the version before tagging

### DIFF
--- a/.github/actions/vcluster-release/action.yml
+++ b/.github/actions/vcluster-release/action.yml
@@ -30,10 +30,14 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Validate version
-      uses: loft-sh/github-actions/.github/actions/semver-validation@6b5890feaccd82f7c0999ccf10a425cd0844dee0 # semver-validation/v1
-      with:
-        version: ${{ inputs.version }}
+    # Version validation lives in the script (validate_version), not here. This
+    # step used to call semver-validation with no `id:` and no gate, so its
+    # result was discarded and a malformed version went on to be tagged
+    # (DEVOPS-798). It also could not be ordered correctly: running before the
+    # script, it saw the RAW input and would reject a recoverable paste such as
+    # "V0.37.1" that normalize_version repairs. In-script validation runs after
+    # normalization, is stricter than semver (the leading v and a patch
+    # component are required), and is covered by the bats suite.
     - name: Cut release
       shell: bash
       env:

--- a/.github/actions/vcluster-release/src/vcluster-release.sh
+++ b/.github/actions/vcluster-release/src/vcluster-release.sh
@@ -47,6 +47,26 @@ TRIGGERED_BY="${TRIGGERED_BY:-}"
 # Pure helpers (no network) - the routing brain, exhaustively unit-tested.
 # ---------------------------------------------------------------------------
 
+# normalize_version <raw> -> canonical vX.Y.Z[-suffix]
+# Operators paste versions from Linear, Slack and release notes, where the
+# leading v is inconsistent and a stray space survives a copy. The routing
+# helpers below already tolerate both spellings (parse_major_minor strips an
+# optional v), but the raw string is used VERBATIM as the tag name and as the
+# double-cut probe key - so an un-normalized "0.37.1" would create a v-less tag
+# AND sail past guard_not_released, which probes for "v0.37.1" and gets a 404.
+# That silently re-releases an already-shipped version, and the resulting tag can
+# never be promoted (promote-release requires ^v[0-9]+\.[0-9]+\.[0-9]+$) nor be
+# resolved by the Go module proxy, which requires the v. Normalizing here, before
+# anything reads the value, makes both spellings land on the same canonical tag.
+normalize_version() {
+  local v="$1"
+  v="${v#"${v%%[![:space:]]*}"}"    # strip leading whitespace
+  v="${v%"${v##*[![:space:]]}"}"    # strip trailing whitespace
+  [[ "$v" == V* ]] && v="v${v#V}"   # accept a capitalized V
+  [[ "$v" == v* ]] || v="v${v}"     # supply the leading v when missing
+  printf '%s\n' "$v"
+}
+
 # parse_major_minor <version> -> "MAJOR MINOR"
 # Accepts v-prefixed or bare, with or without patch/prerelease:
 #   v0.35.4-rc.1 -> "0 35", v1.0 -> "1 0". Fails loudly on garbage.
@@ -316,7 +336,14 @@ cut_feature_prerelease() {
 }
 
 main() {
-  local version="${INPUT_VERSION:?INPUT_VERSION is required}" era line raw_dry_run
+  local raw_version="${INPUT_VERSION:?INPUT_VERSION is required}" version era line raw_dry_run
+  # Canonicalize before ANY consumer sees it: the tag name, the double-cut probe
+  # and every routing decision must all agree on one spelling. Echo the rewrite
+  # so the run log shows exactly which tag is about to be created.
+  version="$(normalize_version "$raw_version")"
+  if [[ "$version" != "$raw_version" ]]; then
+    echo "::notice::normalized version '${raw_version}' -> '${version}'"
+  fi
   # Fail closed: only an explicit, unambiguous "false" cuts for real. Any other
   # value (empty, typo, "yes", "1", wrong case, stray whitespace) stays in
   # dry-run, so a misconfigured caller can never accidentally fire a real

--- a/.github/actions/vcluster-release/src/vcluster-release.sh
+++ b/.github/actions/vcluster-release/src/vcluster-release.sh
@@ -67,6 +67,28 @@ normalize_version() {
   printf '%s\n' "$v"
 }
 
+# validate_version <version> - hard-fail anything that is not our tag shape.
+# Runs AFTER normalize_version, so a recoverable paste (missing v, capitalized V,
+# stray whitespace) has already been repaired and only genuinely malformed input
+# reaches here. Deliberately STRICTER than semver, because the value is used
+# verbatim as a git tag and every downstream consumer assumes vMAJOR.MINOR.PATCH:
+#   vX.Y     would create a tag colliding with the vX.Y release BRANCH, leaving an
+#            ambiguous ref that git resolves with a warning.
+#   vX.Y.Z.N is not semver at all.
+#   0.37.1   bare semver is valid to node-semver but cannot be promoted
+#            (promote-release matches ^v[0-9]+\.[0-9]+\.[0-9]+$) nor resolved by
+#            the Go module proxy; normalize_version has already fixed it by here.
+# Build metadata (+meta) is rejected too: no consumer in the pipeline handles it.
+# The prerelease body is only shape-checked here - classify_suffix decides which
+# suffixes are actually routable, and is fail-closed on unknown ones.
+validate_version() {
+  local v="$1"
+  if [[ ! "$v" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+    echo "::error::version '${v}' is not a valid release version. Expected vMAJOR.MINOR.PATCH with an optional prerelease suffix, e.g. v0.37.1, v0.37.0-rc.1, v0.37.0-next.internal.3." >&2
+    return 1
+  fi
+}
+
 # parse_major_minor <version> -> "MAJOR MINOR"
 # Accepts v-prefixed or bare, with or without patch/prerelease:
 #   v0.35.4-rc.1 -> "0 35", v1.0 -> "1 0". Fails loudly on garbage.
@@ -344,6 +366,11 @@ main() {
   if [[ "$version" != "$raw_version" ]]; then
     echo "::notice::normalized version '${raw_version}' -> '${version}'"
   fi
+  # Gate on the canonical value, before any branch is read or tag created. This
+  # is the single validation point for EVERY release line: legacy cuts fan out
+  # from here too, so their branch-local release.yaml never sees a malformed
+  # version even though it carries no gate of its own.
+  validate_version "$version" || exit 1
   # Fail closed: only an explicit, unambiguous "false" cuts for real. Any other
   # value (empty, typo, "yes", "1", wrong case, stray whitespace) stays in
   # dry-run, so a misconfigured caller can never accidentally fire a real

--- a/.github/actions/vcluster-release/test/vcluster-release.bats
+++ b/.github/actions/vcluster-release/test/vcluster-release.bats
@@ -124,6 +124,82 @@ EOF
   [ "$output" = "v0.37.0-preview.1" ]
 }
 
+# ---- validate_version (pure) ----
+
+@test "validate_version: accepts every shape we actually cut" {
+  for v in v0.37.1 v1.2.3 v0.37.0-rc.1 v0.37.0-alpha.1 v0.37.0-beta.1 \
+           v0.37.0-next.1 v0.37.0-next.internal.3 v0.36.10-rc.11 ; do
+    run validate_version "$v"
+    [ "$status" -eq 0 ] || { echo "rejected a legitimate version: $v"; false; }
+  done
+}
+
+@test "validate_version: rejects a truncated vX.Y (would collide with the release branch)" {
+  run validate_version "v0.37"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"is not a valid release version"* ]]
+}
+
+@test "validate_version: rejects a four-part version" {
+  run validate_version "v0.37.1.2"
+  [ "$status" -ne 0 ]
+}
+
+@test "validate_version: rejects a bare version (normalize_version runs first)" {
+  run validate_version "0.37.1"
+  [ "$status" -ne 0 ]
+}
+
+@test "validate_version: rejects build metadata, which no consumer handles" {
+  run validate_version "v0.37.1+build.5"
+  [ "$status" -ne 0 ]
+}
+
+@test "validate_version: rejects garbage and non-numeric components" {
+  for v in abc v0.37.x vx.y.z "" v0.37.1- ; do
+    run validate_version "$v"
+    [ "$status" -ne 0 ] || { echo "accepted garbage: '$v'"; false; }
+  done
+}
+
+# ---- main: validation gates before anything is read or mutated ----
+
+@test "main: a truncated version is rejected before any branch read or tag" {
+  INPUT_VERSION="v0.37" INPUT_DRY_RUN="true" run main
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"is not a valid release version"* ]]
+  [[ "$output" != *"refs/tags/"* ]]
+  [[ "$output" != *"Routing"* ]]
+}
+
+@test "main: a four-part version is rejected" {
+  INPUT_VERSION="v0.37.1.2" INPUT_DRY_RUN="true" run main
+  [ "$status" -ne 0 ]
+  [[ "$output" != *"refs/tags/"* ]]
+}
+
+@test "main: validation runs on the NORMALIZED value, not the raw input" {
+  # "V0.37.1" is invalid as typed; normalization repairs it, so it must be
+  # accepted - the gate must not fire on the raw string.
+  export GH_STUB_BRANCHES="loft-sh/vcluster-pro:v0.37"
+  INPUT_VERSION="V0.37.1" INPUT_DRY_RUN="true" run main
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"normalized version 'V0.37.1' -> 'v0.37.1'"* ]]
+  [[ "$output" == *"ref=refs/tags/v0.37.1"* ]]
+}
+
+@test "main: a bare truncated version still fails after normalization" {
+  INPUT_VERSION="0.37" INPUT_DRY_RUN="true" run main
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"is not a valid release version"* ]]
+}
+
+@test "main: a legacy-line version is validated too (one gate for every era)" {
+  INPUT_VERSION="v0.36" INPUT_DRY_RUN="true" run main
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"is not a valid release version"* ]]
+}
+
 # ---- main: a bare version routes and tags identically to the v-prefixed one ----
 
 @test "main: bare version is normalized before tagging and dispatch" {

--- a/.github/actions/vcluster-release/test/vcluster-release.bats
+++ b/.github/actions/vcluster-release/test/vcluster-release.bats
@@ -86,6 +86,82 @@ EOF
   chmod +x "${STUB_DIR}/gh"
 }
 
+# ---- normalize_version (pure) ----
+
+@test "normalize_version: bare version gains the leading v" {
+  run normalize_version "0.37.1"
+  [ "$status" -eq 0 ]
+  [ "$output" = "v0.37.1" ]
+}
+
+@test "normalize_version: already-canonical version is untouched" {
+  run normalize_version "v0.37.1"
+  [ "$output" = "v0.37.1" ]
+}
+
+@test "normalize_version: prerelease suffixes survive normalization" {
+  run normalize_version "0.37.0-rc.1"
+  [ "$output" = "v0.37.0-rc.1" ]
+  run normalize_version "0.37.0-next.internal.3"
+  [ "$output" = "v0.37.0-next.internal.3" ]
+}
+
+@test "normalize_version: capitalized V is accepted" {
+  run normalize_version "V0.37.1"
+  [ "$output" = "v0.37.1" ]
+}
+
+@test "normalize_version: surrounding whitespace from a paste is stripped" {
+  run normalize_version "  v0.37.1  "
+  [ "$output" = "v0.37.1" ]
+  run normalize_version "	0.37.1 "
+  [ "$output" = "v0.37.1" ]
+}
+
+@test "normalize_version: does not eat a v inside the version" {
+  # only a LEADING v is structural; nothing else may be rewritten
+  run normalize_version "0.37.0-preview.1"
+  [ "$output" = "v0.37.0-preview.1" ]
+}
+
+# ---- main: a bare version routes and tags identically to the v-prefixed one ----
+
+@test "main: bare version is normalized before tagging and dispatch" {
+  export GH_STUB_BRANCHES="loft-sh/vcluster-pro:v0.37"
+  INPUT_VERSION="0.37.1" INPUT_DRY_RUN="true" run main
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"normalized version '0.37.1' -> 'v0.37.1'"* ]]
+  [[ "$output" == *"ref=refs/tags/v0.37.1"* ]]
+  [[ "$output" != *"refs/tags/0.37.1 "* ]]
+  [[ "$output" == *"gh workflow run release.yaml --repo loft-sh/vcluster-pro --ref v0.37.1"* ]]
+}
+
+@test "main: a bare version does NOT bypass the double-cut guard" {
+  # The regression this normalization exists to prevent: probing for "0.37.1"
+  # 404s while "v0.37.1" is already shipped, silently re-releasing it.
+  export GH_STUB_BRANCHES="loft-sh/vcluster-pro:v0.37"
+  export GH_STUB_RELEASES="loft-sh/vcluster-pro:v0.37.1"
+  INPUT_VERSION="0.37.1" INPUT_DRY_RUN="true" run main
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"release v0.37.1 already exists"* ]]
+}
+
+@test "main: bare legacy version tags both repos with the v-prefixed tag" {
+  export GH_STUB_BRANCHES="loft-sh/vcluster:v0.36 loft-sh/vcluster-pro:v0.36"
+  INPUT_VERSION="0.36.5" INPUT_DRY_RUN="true" run main
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"ref=refs/tags/v0.36.5 -f sha=<v0.36 head>"* ]]
+  [[ "$output" == *"--repo loft-sh/vcluster --ref v0.36.5"* ]]
+  [[ "$output" == *"--repo loft-sh/vcluster-pro --ref v0.36.5"* ]]
+}
+
+@test "main: a canonical version logs no normalization notice" {
+  export GH_STUB_BRANCHES="loft-sh/vcluster-pro:v0.37"
+  INPUT_VERSION="v0.37.1" INPUT_DRY_RUN="true" run main
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"normalized version"* ]]
+}
+
 # ---- parse_major_minor (pure) ----
 
 @test "parse_major_minor: v-prefixed patch+prerelease -> major minor" {


### PR DESCRIPTION
## Summary

Two commits, one root cause: the `version` input is used **verbatim** as the tag name and as the double-cut probe key, and nothing repaired or checked it.

### 1. Normalize (`normalize_version`)

A paste that omits the leading `v` (`0.37.1`) created a v-less tag *and* sailed past `guard_not_released`, which probes for `v0.37.1` and gets a 404 — **silently re-releasing an already-shipped version**.

Nothing failed loudly. The routing helpers already tolerated both spellings (`parse_major_minor` starts with `v="${1#v}"`), so era, line and suffix all classified correctly; the build went green and the artifacts looked right. The damage surfaced only later:

- the tag **can never be promoted** — `promote-release` requires `^v[0-9]+\.[0-9]+\.[0-9]+$`, so unchecking *Pre-release* just errors
- the **Go module proxy ignores it** — Go requires the `v` prefix
- `is_latest_stable()` filters on the same pattern, so it is invisible to future promotion decisions

Also covers the two adjacent paste hazards with the same root cause: a capitalized `V` and surrounding whitespace. The rewrite is echoed as a `::notice::`.

### 2. Validate (`validate_version`) — DEVOPS-798 item 1

`action.yml` ran a `Validate version` step with **no `id:` and no gate**, so `semver-validation`'s `is_valid` was discarded and a malformed version went on to be tagged and dispatched. That step is removed and replaced with in-script validation, for two reasons:

- **it could not be gated in place and still be correct.** Running before the script, it saw the *raw* input — so gating it would reject `V0.37.1`, which normalization repairs. Validation has to run *after* normalization.
- **it is stricter than semver on purpose.** The value becomes a git tag, so the leading `v` and a patch component are required. Bare `0.37.1` is valid semver but unpromotable; `v0.37` would create a tag colliding with the `v0.37` release **branch**, leaving an ambiguous ref; `v0.37.1.2` is not semver at all.

The prerelease body is only shape-checked — `classify_suffix` still decides which suffixes are routable, and stays fail-closed on unknown ones.

## Why this removes the backport work

This is **the single validation point for every release line**. Legacy (`<= v0.36`) cuts fan out from this same action on `main`, so their branch-local `release.yaml` never sees a malformed version even though it carries no gate of its own.

The alternative was backporting a gate to **ten branches** — `vcluster-pro` `v0.32`–`v0.36` and `loft-sh/vcluster` `v0.32`–`v0.36`, all of which have the same ungated `publish`-job semver step. Those would have to be hand-authored, since a cherry-pick cannot cross the monorepo/legacy layout boundary (the DEVOPS-1083 backports hit exactly this and the tooling committed conflict markers while GitHub still reported the PRs mergeable).

Residual gap: the direct re-dispatch path (`gh workflow run release.yaml --ref $TAG`, the documented recovery route) bypasses this action — but it requires an already-existing tag, which this validated on creation.

## Test plan

- `bats .github/actions/vcluster-release/test/vcluster-release.bats` — **77 pass, 0 fail** (56 existing + 21 new)
- `shellcheck` clean on `src/vcluster-release.sh`; `zizmor` clean on `action.yml`
- Traced the pre-fix behaviour against the deployed `vcluster-release/v1` with a stubbed `gh`, confirming a bare version was accepted, tagged v-lessly, and bypassed the double-cut guard

New coverage worth calling out:

- a bare version **does not** bypass the double-cut guard (the regression this exists to prevent)
- validation runs on the **normalized** value — `V0.37.1` is accepted, not rejected
- `v0.37` and `v0.37.1.2` are rejected **before** any branch read or tag creation (asserted by the absence of `refs/tags/` and `Routing` in the output)
- a legacy-line version is validated on the same path, proving the one-gate-for-every-era claim
- a bare legacy version tags *both* repos v-prefixed

## Deployment note

Inert until `vcluster-release/v1` is re-pointed. Doing so also ships the unreleased `TRIGGERED_BY` work already on `main` (Slack banner attributing the human instead of the bot PAT) — worth a deliberate decision rather than a surprise.

Closes DEVOPS-798