### PR TITLE
fix(backport-legacy-split): make the backport subject a conventional commit

### DIFF
--- a/.github/actions/backport-legacy-split/README.md
+++ b/.github/actions/backport-legacy-split/README.md
@@ -89,9 +89,17 @@ than pushing an empty backport.
 
 The opened PR reads like its source rather than a bare SHA:
 
-- **Title** — `[<target>] <commit subject> (<side>)`, e.g.
-  `[v0.36] fix: CRD sync race (#3993) (pro)`. The subject is the monorepo
-  merge/squash commit subject, taken verbatim.
+- **Title** — `<commit subject> (backport <target> <side>)`, e.g.
+  `fix: CRD sync race (#3993) (backport v0.36 pro)`. The subject is the monorepo
+  merge/squash commit subject, taken verbatim, and it leads so the result is a
+  valid conventional commit.
+- **Commit subject** — the same string as the title. This matters because the
+  target repos set `squash_merge_commit_title=COMMIT_OR_PR_TITLE`, so GitHub
+  takes the **commit** subject whenever the PR has a single commit, which is the
+  normal case here (one commit per side). The PR title only wins once a second
+  commit exists, e.g. a pushed conflict resolution. Both are kept identical so
+  either path lands a conventional subject on the release branch, which also
+  keeps the goreleaser changelog filters (`^docs:`, `^test:`, …) working.
 - **Body** — references the source (the PR when `pr-number` is set,
   fully-qualified as `owner/repo#N` so the reference links from the OSS repo too;
   otherwise the monorepo commit SHA) and lists the backported commit under a

--- a/.github/actions/backport-legacy-split/run.sh
+++ b/.github/actions/backport-legacy-split/run.sh
@@ -131,9 +131,10 @@ emit backport-branch "$BACKPORT_BRANCH"
 
 # Human-readable PR metadata, sourced from the monorepo commit itself (CWD is a
 # full-history monorepo checkout). Computed once -- side-independent.
-#   SUBJECT    The merge/squash commit subject, reused verbatim in the PR title so
-#              a legacy backport reads like its source ("[v0.36] fix: ... (#1234)")
-#              instead of a bare SHA.
+#   SUBJECT    The merge/squash commit subject, reused verbatim and FIRST in the PR
+#              title so a legacy backport reads like its source
+#              ("fix: ... (#1234) (backport v0.36 pro)") instead of a bare SHA,
+#              and stays a valid conventional commit once squash-merged.
 #   SOURCE_REPO owner/repo of the monorepo (the repo the source PR lives in), parsed
 #              from origin. Used to fully-qualify the PR reference (owner/repo#N) so
 #              it links correctly even on the OSS half, whose target repo differs
@@ -286,7 +287,15 @@ backport_side() {
     echo "::warning::${side}: applied with conflicts; opening a conflicted PR for manual resolution"
   fi
 
-  local msg="backport: ${SHORT} to ${TARGET_BRANCH} (${side})
+  # Mirror the PR title (below), because the COMMIT subject -- not the PR title --
+  # is what lands on the release branch: both target repos set
+  # squash_merge_commit_title=COMMIT_OR_PR_TITLE, and GitHub uses the commit
+  # subject whenever the PR has exactly one commit, which is always the case here
+  # (one commit per side). The old "backport: <sha> to <target>" subject was not a
+  # conventional commit -- "backport" is not a valid type -- and it also defeated
+  # the goreleaser changelog filters, which match subjects like ^docs:/^test:.
+  # Keep the sha and the half in the body, where they cost nothing.
+  local msg="${SUBJECT} (backport ${TARGET_BRANCH} ${side})
 
 Backport of monorepo commit ${SHA} (${side} half) onto ${TARGET_BRANCH}."
   if [ "$conflicts" = true ]; then
@@ -344,9 +353,14 @@ Applied with merge conflicts that need manual resolution."
 
   if [ "$CREATE_PR" = "true" ]; then
     local title body origin
-    # Read like the source commit: "[v0.36] fix: ... (#1234) (pro)" -- the subject
-    # verbatim, the target line, and the side (which repo/half this PR is).
-    title="[${TARGET_BRANCH}] ${SUBJECT} (${side})"
+    # Mirrors the commit subject above: "fix: ... (#1234) (backport v0.36 pro)".
+    # The subject leads so the title is a valid conventional commit for the case
+    # GitHub does use it -- a PR with more than one commit, i.e. once someone
+    # pushes a conflict resolution. A leading "[v0.36]" broke the type prefix.
+    # These land on a public release branch directly (the OSS half is opened
+    # against oss-repo, not mirrored: sync-to-oss only covers >= v0.37) and feed
+    # GitHub's auto-generated release notes, which list PR titles.
+    title="${SUBJECT} (backport ${TARGET_BRANCH} ${side})"
     # Reference the source by PR when known (fully-qualified so it links from the
     # OSS repo too), else by the immutable monorepo commit.
     if [ -n "$SRC_PR_REF" ]; then

--- a/.github/actions/backport-legacy-split/test/run.bats
+++ b/.github/actions/backport-legacy-split/test/run.bats
@@ -464,16 +464,67 @@ short() { git -C "$MONO" rev-parse --short HEAD; }
   run bash "$SCRIPT"
   [ "$status" -eq 0 ]
 
-  # Title reads like the source: "[<target>] <subject> (<side>)" -- subject
-  # verbatim, NOT the old "backport <short-sha>".
-  [ "$(create_arg --title)" = "[v0.35] fix: the thing (#1234) (oss)" ]
+  # Title reads like the source: "<subject> (backport <target> <side>)" --
+  # subject verbatim and FIRST, NOT the old "backport <short-sha>".
+  [ "$(create_arg --title)" = "fix: the thing (#1234) (backport v0.35 oss)" ]
   [[ "$(create_arg --title)" != *"backport ${sha:0:7}"* ]]
+
+  # The PUSHED COMMIT subject must match the title. GitHub squashes with
+  # squash_merge_commit_title=COMMIT_OR_PR_TITLE, so for a single-commit PR --
+  # always the case here -- this subject, not the title, is what lands on the
+  # release branch. It must therefore be conventional too; the old
+  # "backport: <sha> to <target>" form was not ("backport" is not a valid type).
+  local br; br="$(output_value backport-branch)"
+  local pushed_subject
+  pushed_subject="$(git --git-dir="$OSS_REMOTE" log -1 --format=%s "$br")"
+  [ "$pushed_subject" = "fix: the thing (#1234) (backport v0.35 oss)" ]
+  [ "$pushed_subject" = "$(create_arg --title)" ]
+
+  # The sha and the half stay available in the commit body.
+  local pushed_body
+  pushed_body="$(git --git-dir="$OSS_REMOTE" log -1 --format=%b "$br")"
+  [[ "$pushed_body" == *"$sha"* ]]
+  [[ "$pushed_body" == *"oss half"* ]]
 
   # Body references the source commit and lists it under a readable heading.
   local body; body="$(create_body)"
   [[ "$body" == *"Backport of commit \`$sha\` to \`v0.35\` (oss half)."* ]]
   [[ "$body" == *"### Backported Commits:"* ]]
   [[ "$body" == *"fix: the thing (#1234)"* ]]
+}
+
+@test "create-pr: the pro side gets the same conventional title and commit subject" {
+  install_fake_gh
+  cd "$MONO"
+  printf 'pro change\n' > pro.go
+  git add pro.go
+  git commit -qm "feat(cli): pro thing (#42)"
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(output_value route)" = "pro-only" ]
+
+  [ "$(create_arg --title)" = "feat(cli): pro thing (#42) (backport v0.35 pro)" ]
+  local br; br="$(output_value backport-branch)"
+  [ "$(git --git-dir="$PRO_REMOTE" log -1 --format=%s "$br")" = "feat(cli): pro thing (#42) (backport v0.35 pro)" ]
+}
+
+@test "create-pr: a non-conventional source subject is carried verbatim, not prefixed" {
+  install_fake_gh
+  cd "$MONO"
+  printf 'line1\nOSS\nline3\n' > "$PFX/app.go"
+  git commit -qam "Update the deps"
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+
+  # The action does not invent a type for a subject that never had one -- that is
+  # a source-side problem fixed by linting PR titles, not here. What it must not
+  # do is re-introduce a leading "[v0.35]", which would make even a conventional
+  # subject invalid.
+  [ "$(create_arg --title)" = "Update the deps (backport v0.35 oss)" ]
+  local br; br="$(output_value backport-branch)"
+  [ "$(git --git-dir="$OSS_REMOTE" log -1 --format=%s "$br")" = "Update the deps (backport v0.35 oss)" ]
 }
 
 @test "create-pr: PR reference is fully-qualified as owner/repo#N from origin" {


### PR DESCRIPTION
The action produced a commit subject of `backport: <sha> to <target> (<side>)` and a PR title of `[<target>] <subject> (<side>)`. Neither is a conventional commit: `backport` is not a valid type, and a leading `[v0.36]` has no type at all. Both land on a public release branch — the OSS half is opened directly against `oss-repo` — so they also reach the generated release notes.

## Why the commit subject is the important one

Both target repos set `squash_merge_commit_title=COMMIT_OR_PR_TITLE`, so GitHub takes the **commit** subject whenever the PR has a single commit, which is always the case here (one commit per side). The PR title only wins once a second commit exists, e.g. a pushed conflict resolution.

Real example on `v0.36` before this change:

```
backport: 0be5f924e to v0.36 (pro) (#2043)
```

## Change

Both the commit subject and the PR title become `<subject> (backport <target> <side>)`, so either merge path lands a conventional subject. The sha and the half stay in the commit body, where they cost nothing.

This also un-breaks the goreleaser changelog filters, which match subjects like `^docs:` / `^test:` and never matched `backport: ...`.

## Verification

`commitlint` against the old and new shapes:

```
PASS  fix: the thing (#1234) (backport v0.35 oss)
PASS  feat(cli): pro thing (#42) (backport v0.35 pro)
FAIL  backport: 0be5f924e to v0.36 (pro) (#2043)
FAIL  [v0.35] fix(standalone): evict stale endpoint IPs (#1885) (oss)
```

Tests: the existing title assertion now also pins the **pushed commit subject** and asserts it equals the PR title — nothing covered the commit subject before. Adds pro-side coverage and a non-conventional-subject case, both previously untested.

`bats test/run.bats` → 31 pass (was 29). `shellcheck run.sh` → clean.

## Backward compatibility

Verified no consumer keys on the old title format: PR dedupe uses `--head`/`--base` (`run.sh:250`), `auto-approve-bot-prs` gates on the `backport/` head ref, and `link-backport-prs`' `[vX.Y]` regex matches Linear sub-issue titles, not GitHub PR titles. Existing open backport PRs with old-format titles are still detected and skipped by re-runs.

## Merge note

`backport-legacy-split/v1` must be re-pointed after merge or this is inert for callers, which reach the action through that floating tag. It currently points at `d79223d4`. Note `backport/v1` (`1103b802`) carries an even older title form, so callers today are further behind than `main` suggests.

Closes DEVOPS-1221