### PR TITLE
fix: resolve the pre-release base from the release below the target

### DIFF
--- a/.github/actions/prerelease-setup/README.md
+++ b/.github/actions/prerelease-setup/README.md
@@ -18,11 +18,23 @@ The action performs, in order:
    exports `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` /
    `AWS_SESSION_TOKEN` to `$GITHUB_ENV` by default, so consumer steps
    reading them as `env.AWS_*` resolve as expected.
-7. Resolve and validate the four version inputs (see below). Empty
-   inputs fall back to "latest" via the GitHub API: latest release for
-   `standalone-vcluster-version` and `platform-base-version`; latest
-   pre-release for `standalone-vcluster-upgrade-version` and
-   `platform-rc-version`.
+7. Resolve and validate the four version inputs (see below). An empty
+   upgrade target (`standalone-vcluster-upgrade-version`,
+   `platform-rc-version`) resolves to the most recently published
+   pre-release whose final release has not shipped yet, excluding `-next`
+   internal builds. An empty base
+   (`standalone-vcluster-version`, `platform-base-version`) resolves to the
+   highest stable release strictly below its target, so a maintenance
+   release is tested against the release before it rather than against
+   whatever happens to be newest.
+
+   `/releases` is not returned in any dependable order, so publish times are
+   read from the payload and sorted rather than trusting the first row. That
+   means the whole list is read. It is bounded by the `RELEASE_PAGE_LIMIT`
+   environment variable (default `20`, in pages of 100); it is not an action
+   input, so a caller that needs to raise it sets it as a job-level `env:`.
+   Exceeding the bound fails the step, because resolving from a partial list
+   could pick the wrong base.
 8. Verify the resolved vCluster releases publish the assets the
    downstream test relies on (`install-standalone.sh` for base + upgrade,
    `vcluster-linux-amd64` for upgrade). Fails fast before any EC2 / VCI
@@ -42,11 +54,11 @@ provisioning (`aws-test-infra`) and the Ginkgo test execution
 |                INPUT                |  TYPE  | REQUIRED | DEFAULT |                                                                                                                                           DESCRIPTION                                                                                                                                            |
 |-------------------------------------|--------|----------|---------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 |            github-token             | string |   true   |         | GitHub token with contents:read on loft-sh/loft-enterprise. <br>Required because the platform release resolvers <br>call the GitHub API for a <br>private repo; unauthenticated calls return 404. <br>Pass the calling job's github.token from <br>a job whose permissions grant contents:read.  |
-|        platform-base-version        | string |  false   |         |                                                                             Platform version for the initial install <br>(e.g. 4.9.0). Empty resolves to the latest <br>stable release of loft-sh/loft-enterprise.                                                                               |
-|         platform-rc-version         | string |  false   |         |                                                                               Platform RC version for upgrade (e.g. 4.10.0-alpha.6). <br>Empty resolves to the latest pre-release <br>of loft-sh/loft-enterprise.                                                                                |
+|        platform-base-version        | string |  false   |         |                                                                 Platform version for the initial install <br>(e.g. 4.9.0). Empty resolves to the highest <br>stable release of loft-sh/loft-enterprise below the <br>RC target.                                                                  |
+|         platform-rc-version         | string |  false   |         |                                               Platform RC version for upgrade (e.g. 4.10.0-alpha.6). <br>Empty resolves to the most recently <br>published platform pre-release whose final release <br>has not shipped, excluding -next builds.                                                 |
 |          role-session-name          | string |   true   |         |                                                                           AWS STS role-session-name. Each consumer job <br>passes a distinct value (e.g. prerelease-vcluster-<run-id>, prerelease-aicloud-<run-id>).                                                                             |
-| standalone-vcluster-upgrade-version | string |  false   |         |                                                           vCluster version to upgrade standalone to <br>(e.g. 0.35.0-alpha.7). Empty resolves to the latest <br>vCluster pre-release. Must differ from the <br>resolved base version.                                                            |
-|     standalone-vcluster-version     | string |  false   |         |                                                                               vCluster version to install for standalone <br>(e.g. 0.34.0). Empty resolves to the latest <br>GitHub release of loft-sh/vcluster.                                                                                 |
+| standalone-vcluster-upgrade-version | string |  false   |         |                vCluster version to upgrade standalone to <br>(e.g. 0.35.0-alpha.7). Empty resolves to the most <br>recently published vCluster pre-release whose final <br>release has not shipped, excluding -next <br>builds. Must differ from the resolved <br>base version.                  |
+|     standalone-vcluster-version     | string |  false   |         |                                                                vCluster version to install for standalone <br>(e.g. 0.34.0). Empty resolves to the highest <br>stable release of loft-sh/vcluster below the <br>upgrade target.                                                                  |
 
 <!-- AUTO-DOC-INPUT:END -->
 
@@ -108,7 +120,7 @@ jobs:
     steps:
       - name: Pre-release setup
         id: setup
-        uses: loft-sh/github-actions/.github/actions/prerelease-setup@prerelease-setup/v1.1
+        uses: loft-sh/github-actions/.github/actions/prerelease-setup@prerelease-setup/v1
         with:
           role-session-name: prerelease-vcluster-${{ github.run_id }}
           github-token: ${{ github.token }}

--- a/.github/actions/prerelease-setup/action.yml
+++ b/.github/actions/prerelease-setup/action.yml
@@ -1,5 +1,5 @@
 name: 'Pre-Release Setup'
-description: 'Shared setup for the loft-enterprise pre-release vCluster + AI Cloud workflow jobs: free disk, checkout, install Go/kubectl/helm/vCluster CLI, AWS Login, and resolve+validate the four version inputs (standalone vCluster base+upgrade, platform base+RC) including "latest release" / "latest pre-release" fallbacks. Resolved versions are also verified against the matching release assets so a missing artifact fails fast before downstream provisioning.'
+description: 'Shared setup for the loft-enterprise pre-release vCluster + AI Cloud workflow jobs: free disk, checkout, install Go/kubectl/helm/vCluster CLI, AWS Login, and resolve+validate the four version inputs (standalone vCluster base+upgrade, platform base+RC) resolving anything left empty from the published release list. Resolved versions are also verified against the matching release assets so a missing artifact fails fast before downstream provisioning.'
 
 inputs:
   role-session-name:
@@ -9,19 +9,19 @@ inputs:
     description: 'GitHub token with contents:read on loft-sh/loft-enterprise. Required because the platform release resolvers call the GitHub API for a private repo; unauthenticated calls return 404. Pass the calling job''s github.token from a job whose permissions grant contents:read.'
     required: true
   standalone-vcluster-version:
-    description: 'vCluster version to install for standalone (e.g. 0.34.0). Empty resolves to the latest GitHub release of loft-sh/vcluster.'
+    description: 'vCluster version to install for standalone (e.g. 0.34.0). Empty resolves to the highest stable release of loft-sh/vcluster below the upgrade target.'
     required: false
     default: ''
   standalone-vcluster-upgrade-version:
-    description: 'vCluster version to upgrade standalone to (e.g. 0.35.0-alpha.7). Empty resolves to the latest vCluster pre-release. Must differ from the resolved base version.'
+    description: 'vCluster version to upgrade standalone to (e.g. 0.35.0-alpha.7). Empty resolves to the most recently published vCluster pre-release whose final release has not shipped, excluding -next builds. Must differ from the resolved base version.'
     required: false
     default: ''
   platform-base-version:
-    description: 'Platform version for the initial install (e.g. 4.9.0). Empty resolves to the latest stable release of loft-sh/loft-enterprise.'
+    description: 'Platform version for the initial install (e.g. 4.9.0). Empty resolves to the highest stable release of loft-sh/loft-enterprise below the RC target.'
     required: false
     default: ''
   platform-rc-version:
-    description: 'Platform RC version for upgrade (e.g. 4.10.0-alpha.6). Empty resolves to the latest pre-release of loft-sh/loft-enterprise.'
+    description: 'Platform RC version for upgrade (e.g. 4.10.0-alpha.6). Empty resolves to the most recently published platform pre-release whose final release has not shipped, excluding -next builds.'
     required: false
     default: ''
 
@@ -84,90 +84,7 @@ runs:
         PLATFORM_BASE_VERSION_INPUT: ${{ inputs.platform-base-version }}
         PLATFORM_RC_VERSION_INPUT: ${{ inputs.platform-rc-version }}
         GH_TOKEN: ${{ inputs.github-token }}
-      run: |
-        set -euo pipefail
-        # Accept inputs with or without a leading `v`; normalize to no-v before exporting.
-        VERSION_RE='^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$'
-
-        VERSION="$STANDALONE_VCLUSTER_VERSION_INPUT"
-        if [ -z "$VERSION" ]; then
-          # vcluster is public but unauthenticated calls share the runner IP's 60/hr rate limit.
-          # Pass the token to bump the budget to 1000/hr per token and avoid intermittent 403s.
-          VERSION=$(curl -fsSL -H "Authorization: Bearer $GH_TOKEN" https://api.github.com/repos/loft-sh/vcluster/releases/latest | jq -r .tag_name)
-        fi
-        VERSION="${VERSION#v}"
-        [[ "$VERSION" =~ $VERSION_RE ]] || { echo "invalid standalone-vcluster-version: $VERSION"; exit 1; }
-        echo "Resolved vCluster version: $VERSION"
-
-        UP="${STANDALONE_VCLUSTER_UPGRADE_VERSION_INPUT#v}"
-        if [ -z "$UP" ]; then
-          # Empty = latest vCluster pre-release (alpha/rc). Mirrors the platform RC resolver below.
-          # -next tags are internal builds, not release candidates — exclude them from auto-resolution.
-          UP=$(curl -fsSL -H "Authorization: Bearer $GH_TOKEN" https://api.github.com/repos/loft-sh/vcluster/releases \
-            | jq -r '[.[] | select(.prerelease == true and .draft == false and (.tag_name | test("-next") | not))][0].tag_name')
-          [ -n "$UP" ] && [ "$UP" != "null" ] || { echo "no vCluster pre-release found in loft-sh/vcluster"; exit 1; }
-          UP="${UP#v}"
-          echo "Resolved latest vCluster pre-release: $UP"
-        fi
-        [[ "$UP" =~ $VERSION_RE ]] || { echo "invalid standalone-vcluster-upgrade-version: $UP"; exit 1; }
-        [ "$UP" != "$VERSION" ] || { echo "standalone-vcluster-upgrade-version must differ from base ($VERSION)"; exit 1; }
-        # Reject an older-branch pre-release (e.g. base=0.34.1, latest pre-release=0.33.5-rc.1):
-        # `sort -V` puts the higher semver last, so the upgrade target must equal that tail.
-        # `sort -V` ranks a pre-release AFTER its release (4.9.0-alpha.1 > 4.9.0), the opposite
-        # of semver. Map the semver '-' separator to '~', which sort -V treats as lower than
-        # everything, so 4.9.0~alpha.1 < 4.9.0 as semver requires.
-        VS="${VERSION/-/\~}"; US="${UP/-/\~}"
-        [ "$(printf '%s\n%s\n' "$VS" "$US" | sort -V | tail -n1)" = "$US" ] \
-          || { echo "standalone-vcluster-upgrade-version ($UP) is not newer than base ($VERSION)"; exit 1; }
-
-        RC="${PLATFORM_RC_VERSION_INPUT#v}"
-        if [ -z "$RC" ]; then
-          # GitHub's /releases/latest excludes pre-releases, so list /releases and filter on `prerelease == true`.
-          # The list is newest-first by created_at, so `[0]` after filter = latest pre-release.
-          # -next tags are internal builds, not release candidates — exclude them from auto-resolution.
-          # loft-enterprise is private — unauthenticated requests return 404, so the token is required.
-          RC=$(curl -fsSL -H "Authorization: Bearer $GH_TOKEN" https://api.github.com/repos/loft-sh/loft-enterprise/releases \
-            | jq -r '[.[] | select(.prerelease == true and .draft == false and (.tag_name | test("-next") | not))][0].tag_name')
-          [ -n "$RC" ] && [ "$RC" != "null" ] || { echo "no platform pre-release found in loft-sh/loft-enterprise"; exit 1; }
-          RC="${RC#v}"
-          echo "Resolved latest platform pre-release: $RC"
-        fi
-        [[ "$RC" =~ $VERSION_RE ]] || { echo "invalid platform-rc-version: $RC"; exit 1; }
-
-        BASE="${PLATFORM_BASE_VERSION_INPUT#v}"
-        if [ -z "$BASE" ]; then
-          # Empty = latest stable platform release. /releases/latest excludes pre-releases,
-          # so this pins the same version `vcluster platform start` would otherwise pick.
-          BASE=$(curl -fsSL -H "Authorization: Bearer $GH_TOKEN" https://api.github.com/repos/loft-sh/loft-enterprise/releases/latest | jq -r .tag_name)
-          [ -n "$BASE" ] && [ "$BASE" != "null" ] || { echo "no platform release found in loft-sh/loft-enterprise"; exit 1; }
-          BASE="${BASE#v}"
-          echo "Resolved latest platform release: $BASE"
-        fi
-        [[ "$BASE" =~ $VERSION_RE ]] || { echo "invalid platform-base-version: $BASE"; exit 1; }
-        [ "$BASE" != "$RC" ] || { echo "platform-base-version must differ from platform-rc-version"; exit 1; }
-        # Same older-branch-pre-release guard as for vCluster: RC must be strictly newer than BASE.
-        # See the '~' note above: map the semver '-' to '~' so the pre-release sorts before its release.
-        BS="${BASE/-/\~}"; RS="${RC/-/\~}"
-        [ "$(printf '%s\n%s\n' "$BS" "$RS" | sort -V | tail -n1)" = "$RS" ] \
-          || { echo "platform-rc-version ($RC) is not newer than platform-base-version ($BASE)"; exit 1; }
-
-        {
-          echo "standalone-vcluster-version=$VERSION"
-          echo "standalone-vcluster-upgrade-version=$UP"
-          echo "platform-rc-version=$RC"
-          echo "platform-base-version=$BASE"
-        } >> "$GITHUB_OUTPUT"
-        # Mirror resolved versions to $GITHUB_ENV so consumer steps (Summarize,
-        # Run pre-release …) can keep reading them as env vars exactly as in the
-        # pre-extraction inlined workflow. DEFAULT_VCLUSTER_CHART_VERSION is the
-        # name the helm-chart-install code path expects; preserve it.
-        {
-          echo "STANDALONE_VCLUSTER_VERSION=$VERSION"
-          echo "STANDALONE_VCLUSTER_UPGRADE_VERSION=$UP"
-          echo "PLATFORM_BASE_VERSION=$BASE"
-          echo "PLATFORM_RC_VERSION=$RC"
-          echo "DEFAULT_VCLUSTER_CHART_VERSION=$VERSION"
-        } >> "$GITHUB_ENV"
+      run: ${{ github.action_path }}/src/resolve-versions.sh
 
     - name: Verify release assets
       shell: bash

--- a/.github/actions/prerelease-setup/src/resolve-versions.sh
+++ b/.github/actions/prerelease-setup/src/resolve-versions.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# Resolves and validates the four version inputs for the pre-release checks.
+# An empty upgrade target becomes the most recently published pre-release whose
+# final release has not shipped yet; an empty base becomes the highest release
+# below that target.
+#
+# Needs GNU coreutils: `sort -V` must rank '~' below everything, which BSD and
+# macOS sort do not. The runners are Ubuntu; `make test` on a Mac will disagree.
+#
+# Required env: GH_TOKEN, GITHUB_OUTPUT, GITHUB_ENV
+# Optional env: STANDALONE_VCLUSTER_VERSION_INPUT,
+#   STANDALONE_VCLUSTER_UPGRADE_VERSION_INPUT, PLATFORM_BASE_VERSION_INPUT,
+#   PLATFORM_RC_VERSION_INPUT (all default to empty), RELEASE_PAGE_LIMIT
+set -euo pipefail
+
+VERSION_RE_BODY='[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?'
+VERSION_RE="^${VERSION_RE_BODY}\$"
+STABLE_RE='^[0-9]+\.[0-9]+\.[0-9]+$'
+: "${RELEASE_PAGE_LIMIT:=20}"
+[[ "$RELEASE_PAGE_LIMIT" =~ ^[1-9][0-9]*$ ]] \
+  || { echo "RELEASE_PAGE_LIMIT must be a positive integer, got: $RELEASE_PAGE_LIMIT"; exit 1; }
+: "${GITHUB_API_URL:=https://api.github.com}"
+
+CACHE_DIR="$(mktemp -d)"
+trap 'rm -rf "$CACHE_DIR"' EXIT
+
+listing() { printf '%s/%s.json' "$CACHE_DIR" "$1"; }
+
+# Reads a repo's whole release list into a file, once per run. The list is not
+# ordered by version, so finding the highest release means reading all of it.
+load_listing() {
+  local repo="$1" file page=1 body count
+  file="$(listing "$repo")"
+  [ -f "$file" ] && return 0
+  : > "$file"
+  while [ "$page" -le "$RELEASE_PAGE_LIMIT" ]; do
+    body="$(curl -fsSL --retry 3 --retry-delay 2 \
+      -H "Accept: application/vnd.github+json" \
+      -H "Authorization: Bearer $GH_TOKEN" \
+      "${GITHUB_API_URL}/repos/loft-sh/${repo}/releases?per_page=100&page=${page}")" \
+      || { echo "failed to list releases for loft-sh/${repo} (page ${page})"; exit 1; }
+    count="$(printf '%s' "$body" | jq -e 'if type == "array" then length else null end' 2>/dev/null)" \
+      || { echo "unexpected response listing releases for loft-sh/${repo} (page ${page})"; exit 1; }
+    printf '%s\n' "$body" >> "$file"
+    [ "$count" -lt 100 ] && return 0
+    page=$((page + 1))
+  done
+  echo "release listing for loft-sh/${repo} exceeded ${RELEASE_PAGE_LIMIT} pages; refusing to resolve from a partial list"
+  exit 1
+}
+
+# sort -V puts a pre-release after its own release, which is backwards for
+# semver. Mapping '-' to '~' fixes it, because sort -V ranks '~' below anything.
+sort_key() { printf '%s' "$1" | tr '-' '~'; }
+
+is_below() {
+  local a b
+  a="$(sort_key "$1")"
+  b="$(sort_key "$2")"
+  [ "$a" != "$b" ] && [ "$(printf '%s\n%s\n' "$a" "$b" | sort -V | tail -n1)" = "$b" ]
+}
+
+# Highest of the versions on stdin.
+highest_of() {
+  local best="" candidate
+  while read -r candidate; do
+    [ -n "$candidate" ] || continue
+    if [ -z "$best" ] || is_below "$best" "$candidate"; then best="$candidate"; fi
+  done
+  printf '%s' "$best"
+}
+
+# Emits "published_at<TAB>version" so callers can order explicitly.
+pre_release_tags() {
+  jq -r --arg re "^${VERSION_RE_BODY}$" \
+    '.[] | select(.prerelease == true and .draft == false
+                  and (.published_at != null)
+                  and (.tag_name | test("-next") | not)
+                  and (.tag_name | sub("^v";"") | test($re)))
+         | "\(.published_at)\t\(.tag_name | sub("^v";""))"' "$(listing "$1")"
+}
+
+stable_tags() {
+  jq -r '.[] | select(.prerelease == false and .draft == false) | .tag_name' "$(listing "$1")" \
+    | sed 's/^v//' | { grep -E "$STABLE_RE" || true; }
+}
+
+# The most recently published pre-release whose final release is not out yet.
+# /releases is not returned in any dependable order, so publish time is read
+# from the payload and sorted here rather than trusting the first row.
+newest_unreleased_pre_release() {
+  local repo="$1" released
+  released="$(stable_tags "$repo")"
+  local ranked first
+  ranked="$(pre_release_tags "$repo" | while IFS=$'\t' read -r published version; do
+    [ -n "$version" ] || continue
+    if grep -qxF "${version%%-*}" <<<"$released"; then continue; fi
+    printf '%s\t%s\t%s\n' "$published" "$(sort_key "$version")" "$version"
+  done | sort -t "$(printf '\t')" -k1,1r -k2,2Vr)"
+  [ -n "$ranked" ] || return 0
+  first="${ranked%%$'\n'*}"
+  printf '%s' "${first##*$'\t'}"
+}
+
+# Highest release below the target. Anything below the target that is not on the
+# target's own line is also below that line, so no line filter is needed.
+base_for_target() {
+  local target="$1" candidate
+  stable_tags "$2" | while read -r candidate; do
+    [ -n "$candidate" ] || continue
+    if is_below "$candidate" "$target"; then printf '%s\n' "$candidate"; fi
+  done | highest_of
+}
+
+load_listing vcluster
+
+UP="${STANDALONE_VCLUSTER_UPGRADE_VERSION_INPUT:-}"
+UP="${UP#v}"
+if [ -z "$UP" ]; then
+  UP="$(newest_unreleased_pre_release vcluster)"
+  [ -n "$UP" ] || { echo "no vCluster pre-release found in loft-sh/vcluster"; exit 1; }
+  echo "Resolved newest unreleased vCluster pre-release: $UP"
+fi
+[[ "$UP" =~ $VERSION_RE ]] || { echo "invalid standalone-vcluster-upgrade-version: $UP"; exit 1; }
+
+VERSION="${STANDALONE_VCLUSTER_VERSION_INPUT:-}"
+VERSION="${VERSION#v}"
+if [ -z "$VERSION" ]; then
+  VERSION="$(base_for_target "$UP" vcluster)"
+  [ -n "$VERSION" ] || { echo "no stable vCluster release below $UP"; exit 1; }
+  echo "Resolved vCluster base below $UP: $VERSION"
+fi
+[[ "$VERSION" =~ $VERSION_RE ]] || { echo "invalid standalone-vcluster-version: $VERSION"; exit 1; }
+[ "$UP" != "$VERSION" ] || { echo "standalone-vcluster-upgrade-version must differ from base ($VERSION)"; exit 1; }
+is_below "$VERSION" "$UP" \
+  || { echo "standalone-vcluster-upgrade-version ($UP) is not newer than base ($VERSION)"; exit 1; }
+
+load_listing loft-enterprise
+
+RC="${PLATFORM_RC_VERSION_INPUT:-}"
+RC="${RC#v}"
+if [ -z "$RC" ]; then
+  RC="$(newest_unreleased_pre_release loft-enterprise)"
+  [ -n "$RC" ] || { echo "no platform pre-release found in loft-sh/loft-enterprise"; exit 1; }
+  echo "Resolved newest unreleased platform pre-release: $RC"
+fi
+[[ "$RC" =~ $VERSION_RE ]] || { echo "invalid platform-rc-version: $RC"; exit 1; }
+
+BASE="${PLATFORM_BASE_VERSION_INPUT:-}"
+BASE="${BASE#v}"
+if [ -z "$BASE" ]; then
+  BASE="$(base_for_target "$RC" loft-enterprise)"
+  [ -n "$BASE" ] || { echo "no stable platform release below $RC"; exit 1; }
+  echo "Resolved platform base below $RC: $BASE"
+fi
+[[ "$BASE" =~ $VERSION_RE ]] || { echo "invalid platform-base-version: $BASE"; exit 1; }
+[ "$BASE" != "$RC" ] || { echo "platform-base-version must differ from platform-rc-version"; exit 1; }
+is_below "$BASE" "$RC" \
+  || { echo "platform-rc-version ($RC) is not newer than platform-base-version ($BASE)"; exit 1; }
+
+{
+  echo "standalone-vcluster-version=$VERSION"
+  echo "standalone-vcluster-upgrade-version=$UP"
+  echo "platform-rc-version=$RC"
+  echo "platform-base-version=$BASE"
+} >> "$GITHUB_OUTPUT"
+
+# DEFAULT_VCLUSTER_CHART_VERSION is the name the helm-chart-install path wants.
+{
+  echo "STANDALONE_VCLUSTER_VERSION=$VERSION"
+  echo "STANDALONE_VCLUSTER_UPGRADE_VERSION=$UP"
+  echo "PLATFORM_BASE_VERSION=$BASE"
+  echo "PLATFORM_RC_VERSION=$RC"
+  echo "DEFAULT_VCLUSTER_CHART_VERSION=$VERSION"
+} >> "$GITHUB_ENV"

--- a/.github/actions/prerelease-setup/test/curl_mock.bash
+++ b/.github/actions/prerelease-setup/test/curl_mock.bash
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Stubs `curl` on PATH for resolve-versions.sh tests. Serves paged release
+# listings from per-repo, per-page fixtures and records every request so tests
+# can assert on how many pages were read.
+#
+# Fixtures are registered with `set_releases <repo> <page> <json>`; any page
+# without a fixture returns "[]", which the script treats as the end of the
+# listing.
+#
+# Knobs:
+#   CURL_MOCK_FAIL=1        force a non-zero exit on every call.
+#   CURL_MOCK_BODY=<text>   return this body with a 0 exit, to simulate a 200
+#                           response that is not a JSON array.
+#   CURL_MOCK_FAIL_AFTER=N  succeed for N calls, then fail, to exercise a
+#                           failure part-way through reading a listing.
+
+setup_curl_mock() {
+  MOCK_DIR="$(mktemp -d)"
+  export MOCK_DIR
+  PATH="$MOCK_DIR:$PATH"
+  export PATH
+
+  export CURL_MOCK_CALLS="$MOCK_DIR/calls.log"
+  export CURL_MOCK_FIXTURES="$MOCK_DIR/fixtures"
+  : > "$CURL_MOCK_CALLS"
+  mkdir -p "$CURL_MOCK_FIXTURES"
+
+  cat > "$MOCK_DIR/curl" <<'EOF'
+#!/usr/bin/env bash
+# Mock curl. Only understands the release-listing URL the script builds.
+url=""
+for arg in "$@"; do
+  case "$arg" in https://*|http://*) url="$arg" ;; esac
+done
+printf '%s\n' "$url" >> "$CURL_MOCK_CALLS"
+
+if [ -n "${CURL_MOCK_BODY:-}" ]; then
+  printf '%s' "$CURL_MOCK_BODY"
+  exit 0
+fi
+if [ "${CURL_MOCK_FAIL:-0}" = "1" ]; then
+  echo "mock curl: forced failure" >&2
+  exit 22
+fi
+if [ -n "${CURL_MOCK_FAIL_AFTER:-}" ] && [ "$(wc -l < "$CURL_MOCK_CALLS")" -gt "$CURL_MOCK_FAIL_AFTER" ]; then
+  echo "mock curl: forced failure after $CURL_MOCK_FAIL_AFTER call(s)" >&2
+  exit 22
+fi
+
+repo="${url#*/repos/loft-sh/}"; repo="${repo%%/releases*}"
+page="${url##*&page=}"
+fixture="$CURL_MOCK_FIXTURES/${repo}-${page}.json"
+if [ -f "$fixture" ]; then cat "$fixture"; else printf '[]'; fi
+EOF
+  chmod +x "$MOCK_DIR/curl"
+}
+
+teardown_curl_mock() {
+  rm -rf "$MOCK_DIR"
+}
+
+# set_releases <repo> <page> <json-array>
+set_releases() {
+  printf '%s' "$3" > "$CURL_MOCK_FIXTURES/$1-$2.json"
+}
+
+# release <tag> <prerelease> [published_at] -> one JSON object
+release() {
+  printf '{"tag_name":"%s","prerelease":%s,"draft":false,"published_at":"%s"}' \
+    "$1" "$2" "${3:-2026-01-01T00:00:00Z}"
+}
+
+# filler <count> -> N throwaway stable releases, to pad a page to 100 entries
+# so the "a short page is the last page" rule behaves as it does against the API
+filler() {
+  local n="$1" i out=""
+  for ((i = 0; i < n; i++)); do
+    out="${out},$(release "v0.0.${i}" false 2020-01-01T00:00:00Z)"
+  done
+  printf '%s' "${out#,}"
+}
+
+# pages_read <repo>
+pages_read() {
+  grep -c "/repos/loft-sh/$1/releases" "$CURL_MOCK_CALLS" || true
+}

--- a/.github/actions/prerelease-setup/test/resolve-versions.bats
+++ b/.github/actions/prerelease-setup/test/resolve-versions.bats
@@ -1,0 +1,361 @@
+#!/usr/bin/env bats
+# Tests for resolve-versions.sh. Stubs `curl` (see curl_mock.bash); uses the
+# real jq and sort so the ordering logic is exercised end to end.
+
+SCRIPT="$BATS_TEST_DIRNAME/../src/resolve-versions.sh"
+
+load curl_mock
+
+setup() {
+  setup_curl_mock
+  export GH_TOKEN="fake-token"
+  export STANDALONE_VCLUSTER_VERSION_INPUT=""
+  export STANDALONE_VCLUSTER_UPGRADE_VERSION_INPUT=""
+  export PLATFORM_BASE_VERSION_INPUT=""
+  export PLATFORM_RC_VERSION_INPUT=""
+  export GITHUB_OUTPUT="$MOCK_DIR/output"
+  export GITHUB_ENV="$MOCK_DIR/env"
+  : > "$GITHUB_OUTPUT"
+  : > "$GITHUB_ENV"
+
+  # Rows are deliberately NOT in publish order, so a test only passes if the
+  # code sorts by published_at itself. 0.36.1 has shipped, so 0.36.1-rc.4 is
+  # the newest pre-release by publish time but must not be chosen.
+  set_releases vcluster 1 "[
+    $(release v0.37.0-alpha.1 true 2026-07-29T22:36:43Z),
+    $(release v0.36.1-rc.4    true 2026-07-31T13:43:34Z),
+    $(release v0.35.3-rc.2    true 2026-07-29T23:19:04Z),
+    $(release v0.34.7-rc.2    true 2026-07-28T13:13:40Z),
+    $(release v0.36.1         false 2026-08-03T10:00:00Z),
+    $(release v0.35.2         false 2026-07-01T10:00:00Z),
+    $(release v0.34.6         false 2026-06-01T10:00:00Z),
+    $(release v0.36.0         false 2026-07-20T10:00:00Z)
+  ]"
+  # 4.11.1 has shipped; 4.12.0-alpha.2 has not.
+  set_releases loft-enterprise 1 "[
+    $(release v4.11.1-rc.1    true 2026-07-29T14:57:24Z),
+    $(release v4.12.0-alpha.2 true 2026-07-28T13:36:00Z),
+    $(release v4.11.1         false 2026-08-02T10:00:00Z),
+    $(release v4.11.0         false 2026-07-20T10:00:00Z),
+    $(release v4.10.6         false 2026-07-22T10:00:00Z),
+    $(release v4.10.5         false 2026-07-01T10:00:00Z)
+  ]"
+}
+
+teardown() { teardown_curl_mock; }
+
+out() { grep "^$1=" "$GITHUB_OUTPUT" | cut -d= -f2-; }
+
+# --- base resolution: the bug this action shipped -----------------------------
+
+@test "a maintenance target takes the highest release below it, not the newest overall" {
+  export STANDALONE_VCLUSTER_UPGRADE_VERSION_INPUT="0.35.3-rc.1"
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(out standalone-vcluster-version)" = "0.35.2" ]
+}
+
+@test "an older maintenance target does the same" {
+  export STANDALONE_VCLUSTER_UPGRADE_VERSION_INPUT="0.34.7-rc.2"
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(out standalone-vcluster-version)" = "0.34.6" ]
+}
+
+@test "a brand new minor with no release of its own still gets a base" {
+  export STANDALONE_VCLUSTER_UPGRADE_VERSION_INPUT="0.37.0-alpha.1"
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(out standalone-vcluster-version)" = "0.36.1" ]
+}
+
+@test "a maintenance RC published after a newer GA skips its own released patch" {
+  export PLATFORM_RC_VERSION_INPUT="4.10.6-rc.2"
+  export STANDALONE_VCLUSTER_UPGRADE_VERSION_INPUT="0.36.1-rc.3"
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  # 4.10.6 exists and is NEWER than 4.10.6-rc.2, so the base must be 4.10.5
+  [ "$(out platform-base-version)" = "4.10.5" ]
+}
+
+# --- target resolution -------------------------------------------------------
+
+@test "an empty target skips a pre-release whose release already shipped" {
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  # 0.36.1-rc.4 is the newest by publish time but 0.36.1 is out, so 0.35.3-rc.2 wins
+  [ "$(out standalone-vcluster-upgrade-version)" = "0.35.3-rc.2" ]
+  [ "$(out standalone-vcluster-version)" = "0.35.2" ]
+  # 4.11.1-rc.1 is newest by publish time but 4.11.1 is out, so 4.12.0-alpha.2 wins
+  [ "$(out platform-rc-version)" = "4.12.0-alpha.2" ]
+}
+
+@test "the target is chosen by publish time, not by list order or version" {
+  # highest version first in the list, but its release has shipped
+  set_releases vcluster 1 "[
+    $(release v0.40.0-rc.1 true 2026-01-01T00:00:00Z),
+    $(release v0.39.0-rc.1 true 2026-09-01T00:00:00Z),
+    $(release v0.40.0      false 2026-02-01T00:00:00Z),
+    $(release v0.38.0      false 2025-12-01T00:00:00Z)
+  ]"
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(out standalone-vcluster-upgrade-version)" = "0.39.0-rc.1" ]
+}
+
+@test "-next builds are never chosen as a target" {
+  set_releases vcluster 1 "[
+    $(release v0.38.0-next.internal.4 true),
+    $(release v0.37.0-alpha.1 true),
+    $(release v0.36.0 false)
+  ]"
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(out standalone-vcluster-upgrade-version)" = "0.37.0-alpha.1" ]
+}
+
+@test "tags that are not versions are ignored" {
+  set_releases vcluster 1 "[
+    $(release untagged-6162a828673fc8cf true),
+    $(release v0.37.0-alpha.1 true),
+    $(release v0.36.0 false)
+  ]"
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(out standalone-vcluster-upgrade-version)" = "0.37.0-alpha.1" ]
+}
+
+# --- explicit inputs win -----------------------------------------------------
+
+@test "explicitly supplied versions are used as given" {
+  export STANDALONE_VCLUSTER_VERSION_INPUT="v0.35.0"
+  export STANDALONE_VCLUSTER_UPGRADE_VERSION_INPUT="v0.35.1"
+  export PLATFORM_BASE_VERSION_INPUT="v4.11.0"
+  export PLATFORM_RC_VERSION_INPUT="v4.11.1-rc.1"
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(out standalone-vcluster-version)" = "0.35.0" ]
+  [ "$(out standalone-vcluster-upgrade-version)" = "0.35.1" ]
+  [ "$(out platform-base-version)" = "4.11.0" ]
+  [ "$(out platform-rc-version)" = "4.11.1-rc.1" ]
+}
+
+# --- rejections --------------------------------------------------------------
+
+@test "a backwards vCluster pair is rejected" {
+  export STANDALONE_VCLUSTER_VERSION_INPUT="0.36.0"
+  export STANDALONE_VCLUSTER_UPGRADE_VERSION_INPUT="0.35.3-rc.1"
+  run "$SCRIPT"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"is not newer than base"* ]]
+}
+
+@test "a backwards platform pair is rejected" {
+  export PLATFORM_BASE_VERSION_INPUT="4.11.0"
+  export PLATFORM_RC_VERSION_INPUT="4.10.6-rc.2"
+  export STANDALONE_VCLUSTER_UPGRADE_VERSION_INPUT="0.36.1-rc.3"
+  run "$SCRIPT"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"is not newer than platform-base-version"* ]]
+}
+
+@test "identical versions are rejected" {
+  export STANDALONE_VCLUSTER_VERSION_INPUT="0.36.0"
+  export STANDALONE_VCLUSTER_UPGRADE_VERSION_INPUT="0.36.0"
+  run "$SCRIPT"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"must differ"* ]]
+}
+
+@test "a pre-release is treated as older than its own release" {
+  export STANDALONE_VCLUSTER_VERSION_INPUT="0.36.0-rc.7"
+  export STANDALONE_VCLUSTER_UPGRADE_VERSION_INPUT="0.36.0"
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(out standalone-vcluster-version)" = "0.36.0-rc.7" ]
+  [ "$(out standalone-vcluster-upgrade-version)" = "0.36.0" ]
+}
+
+@test "the reverse of that pair is rejected" {
+  export STANDALONE_VCLUSTER_VERSION_INPUT="0.36.0"
+  export STANDALONE_VCLUSTER_UPGRADE_VERSION_INPUT="0.36.0-rc.7"
+  run "$SCRIPT"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"is not newer than base"* ]]
+}
+
+@test "a malformed version is rejected" {
+  export STANDALONE_VCLUSTER_UPGRADE_VERSION_INPUT="not-a-version"
+  run "$SCRIPT"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"invalid standalone-vcluster-upgrade-version"* ]]
+}
+
+@test "a failing API call fails the step rather than reporting no releases" {
+  export CURL_MOCK_FAIL=1
+  run "$SCRIPT"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"failed to list releases"* ]]
+}
+
+@test "no stable below the target is an error, not an empty base" {
+  set_releases vcluster 1 "[ $(release v0.37.0-alpha.1 true) ]"
+  run "$SCRIPT"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"no stable vCluster release below"* ]]
+}
+
+# --- reading the listing ---------------------------------------------------
+
+@test "a target on page two is still found" {
+  set_releases vcluster 1 "[ $(filler 98), $(release v0.36.0 false), $(release v0.35.2 false) ]"
+  set_releases vcluster 2 "[ $(release v0.37.0-alpha.1 true 2026-07-29T22:36:43Z) ]"
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(out standalone-vcluster-upgrade-version)" = "0.37.0-alpha.1" ]
+}
+
+@test "a higher base on page two beats a lower one on page one" {
+  set_releases vcluster 1 "[ $(filler 98), $(release v0.35.9-rc.1 true), $(release v0.35.2 false) ]"
+  set_releases vcluster 2 "[ $(release v0.35.8 false) ]"
+  export STANDALONE_VCLUSTER_UPGRADE_VERSION_INPUT="0.35.9-rc.1"
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(out standalone-vcluster-version)" = "0.35.8" ]
+}
+
+@test "each listing is read once, and a short page ends it" {
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(pages_read vcluster)" -eq 1 ]
+  [ "$(pages_read loft-enterprise)" -eq 1 ]
+}
+
+@test "the page limit is not mentioned on a normal run" {
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"exceeded"* ]]
+}
+
+@test "exceeding the page limit fails instead of answering from a partial list" {
+  export RELEASE_PAGE_LIMIT=1
+  set_releases vcluster 1 "[ $(filler 97), $(release v0.37.0-alpha.1 true 2026-07-29T22:36:43Z), $(release v0.36.1 false), $(release v0.36.0 false) ]"
+  run "$SCRIPT"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"refusing to resolve from a partial list"* ]]
+}
+
+@test "a failure on a later page is reported as an API failure" {
+  export CURL_MOCK_FAIL_AFTER=1
+  run "$SCRIPT"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"failed to list releases"* ]]
+  [[ "$output" != *"no stable vCluster release below"* ]]
+}
+
+# --- exported values ---------------------------------------------------------
+
+@test "resolved versions are mirrored to GITHUB_ENV" {
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  grep -q "^STANDALONE_VCLUSTER_VERSION=0.35.2$" "$GITHUB_ENV"
+  grep -q "^STANDALONE_VCLUSTER_UPGRADE_VERSION=0.35.3-rc.2$" "$GITHUB_ENV"
+  grep -q "^PLATFORM_BASE_VERSION=4.11.1$" "$GITHUB_ENV"
+  grep -q "^PLATFORM_RC_VERSION=4.12.0-alpha.2$" "$GITHUB_ENV"
+  grep -q "^DEFAULT_VCLUSTER_CHART_VERSION=0.35.2$" "$GITHUB_ENV"
+}
+
+# --- environment contract ----------------------------------------------------
+
+@test "runs with none of the four version inputs set" {
+  unset STANDALONE_VCLUSTER_VERSION_INPUT
+  unset STANDALONE_VCLUSTER_UPGRADE_VERSION_INPUT
+  unset PLATFORM_BASE_VERSION_INPUT
+  unset PLATFORM_RC_VERSION_INPUT
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"unbound variable"* ]]
+  [ "$(out standalone-vcluster-upgrade-version)" = "0.35.3-rc.2" ]
+}
+
+@test "a non-numeric page limit fails with a clear message" {
+  export RELEASE_PAGE_LIMIT=abc
+  run "$SCRIPT"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"RELEASE_PAGE_LIMIT must be a positive integer, got: abc"* ]]
+  [[ "$output" != *"integer expected"* ]]
+}
+
+@test "a zero page limit is rejected" {
+  export RELEASE_PAGE_LIMIT=0
+  run "$SCRIPT"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"must be a positive integer"* ]]
+}
+
+# --- malformed API responses -------------------------------------------------
+
+@test "a 200 response that is not an array fails fast with our own message" {
+  export CURL_MOCK_BODY='<html>proxy error</html>'
+  run "$SCRIPT"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"unexpected response listing releases"* ]]
+  [[ "$output" != *"parse error"* ]]
+  [[ "$output" != *"integer expression expected"* ]]
+  # must fail on the first page, not page on to the limit
+  [ "$(pages_read vcluster)" -eq 1 ]
+}
+
+@test "a JSON object body fails the same way" {
+  export CURL_MOCK_BODY='{"message":"Bad credentials"}'
+  run "$SCRIPT"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"unexpected response listing releases"* ]]
+}
+
+# --- publish-time edge cases -------------------------------------------------
+
+@test "a null published_at never wins the target" {
+  set_releases vcluster 1 "[
+    {\"tag_name\":\"v0.30.0-rc.1\",\"prerelease\":true,\"draft\":false,\"published_at\":null},
+    $(release v0.37.0-alpha.1 true 2026-07-01T00:00:00Z),
+    $(release v0.36.0 false 2026-06-01T00:00:00Z)
+  ]"
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(out standalone-vcluster-upgrade-version)" = "0.37.0-alpha.1" ]
+}
+
+@test "a published_at tie breaks on semver, not string order" {
+  set_releases vcluster 1 "[
+    $(release v0.35.9-rc.1  true 2026-07-01T00:00:00Z),
+    $(release v0.35.10-rc.1 true 2026-07-01T00:00:00Z),
+    $(release v0.35.8 false 2026-06-01T00:00:00Z)
+  ]"
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(out standalone-vcluster-upgrade-version)" = "0.35.10-rc.1" ]
+}
+
+# --- exit-status hygiene -----------------------------------------------------
+
+@test "a listing that ends above the target still resolves" {
+  # the last stable read is NOT below the target, which used to end the run
+  # with exit 1 and no message
+  set_releases vcluster 1 "[
+    $(release v0.35.2 false 2026-07-01T10:00:00Z),
+    $(release v0.36.0 false 2026-07-20T10:00:00Z)
+  ]"
+  export STANDALONE_VCLUSTER_UPGRADE_VERSION_INPUT="0.35.3-rc.1"
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(out standalone-vcluster-version)" = "0.35.2" ]
+}
+
+@test "a listing whose only stable is above the target reports it" {
+  set_releases vcluster 1 "[ $(release v0.36.0 false 2026-07-20T10:00:00Z) ]"
+  export STANDALONE_VCLUSTER_UPGRADE_VERSION_INPUT="0.35.3-rc.1"
+  run "$SCRIPT"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"no stable vCluster release below 0.35.3-rc.1"* ]]
+}

--- a/.github/workflows/test-prerelease-setup.yaml
+++ b/.github/workflows/test-prerelease-setup.yaml
@@ -1,0 +1,22 @@
+name: Test prerelease-setup
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/test-prerelease-setup.yaml'
+      - '.github/actions/prerelease-setup/**'
+
+permissions:
+  contents: read
+
+jobs:
+  bats:
+    name: Run bats tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
+        with:
+          tests: .github/actions/prerelease-setup/test

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-semver-validation test-linear-pr-commenter test-link-backport-prs test-release-notification test-linear-release-sync test-aws-test-infra test-cleanup-head-charts test-ci-test-notify test-auto-approve-bot-prs test-ai-pr-review test-ai-step test-publish-helm-chart test-govulncheck test-go-licenses test-run-ginkgo test-sticky-pr-comment test-repository-dispatch test-parse-label-filter test-release-branch-freeze test-vcluster-release test-subtree-mirror test-oss-commit-sync test-backport-legacy-allowlist test-backport-legacy-split test-promote-release test-wait-for-release build-linear-release-sync lint install-auto-doc generate-docs check-docs help
+.PHONY: test test-semver-validation test-linear-pr-commenter test-link-backport-prs test-release-notification test-linear-release-sync test-aws-test-infra test-cleanup-head-charts test-ci-test-notify test-auto-approve-bot-prs test-ai-pr-review test-ai-step test-publish-helm-chart test-govulncheck test-go-licenses test-run-ginkgo test-sticky-pr-comment test-repository-dispatch test-parse-label-filter test-release-branch-freeze test-prerelease-setup test-vcluster-release test-subtree-mirror test-oss-commit-sync test-backport-legacy-allowlist test-backport-legacy-split test-promote-release test-wait-for-release build-linear-release-sync lint install-auto-doc generate-docs check-docs help
 
 ACTIONS_DIR := .github/actions
 WORKFLOWS_DIR := .github/workflows
@@ -93,7 +93,7 @@ check-docs: generate-docs ## verify docs are up to date (fails if drift detected
 help: ## show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-30s %s\n", $$1, $$2}'
 
-test: test-semver-validation test-linear-pr-commenter test-link-backport-prs test-release-notification test-linear-release-sync test-aws-test-infra test-cleanup-head-charts test-auto-approve-bot-prs test-ai-pr-review test-ai-step test-ci-test-notify test-go-licenses test-publish-helm-chart test-govulncheck test-run-ginkgo test-sticky-pr-comment test-repository-dispatch test-parse-label-filter test-release-branch-freeze test-vcluster-release test-subtree-mirror test-oss-commit-sync test-backport-legacy-allowlist test-backport-legacy-split test-promote-release test-wait-for-release ## run all action tests
+test: test-semver-validation test-linear-pr-commenter test-link-backport-prs test-release-notification test-linear-release-sync test-aws-test-infra test-cleanup-head-charts test-auto-approve-bot-prs test-ai-pr-review test-ai-step test-ci-test-notify test-go-licenses test-publish-helm-chart test-govulncheck test-run-ginkgo test-sticky-pr-comment test-repository-dispatch test-parse-label-filter test-release-branch-freeze test-prerelease-setup test-vcluster-release test-subtree-mirror test-oss-commit-sync test-backport-legacy-allowlist test-backport-legacy-split test-promote-release test-wait-for-release ## run all action tests
 
 test-semver-validation: ## run semver-validation unit tests
 	cd $(ACTIONS_DIR)/semver-validation && npm ci --silent && NODE_OPTIONS=--experimental-vm-modules npx jest --ci --coverage --watchAll=false
@@ -152,6 +152,9 @@ test-parse-label-filter: ## run parse-label-filter bats tests
 
 test-release-branch-freeze: ## run release-branch-freeze bats tests
 	bats $(ACTIONS_DIR)/release-branch-freeze/test
+
+test-prerelease-setup: ## run prerelease-setup bats tests
+	bats $(ACTIONS_DIR)/prerelease-setup/test
 
 test-vcluster-release: ## run vcluster-release bats tests
 	bats $(ACTIONS_DIR)/vcluster-release/test/*.bats


### PR DESCRIPTION
## What was wrong

The pre-release checks failed on every maintenance release from 2026-07-07 to 2026-07-27. Upgrading to `0.35.3-rc.1` installed `0.36.0` first, then tried to "upgrade" to something older:

```
Resolved vCluster version: 0.36.0
standalone-vcluster-upgrade-version (0.35.3-rc.1) is not newer than base (0.36.0)
```

The base was resolved as the newest release in the whole repo. For a `0.35.x` candidate that is `0.36.0`, which is not a base you can upgrade *from*.

## What this changes

**The base is the highest release below the upgrade target.** That single constraint fixes every failure in the ticket:

| Upgrade target | Base before | Base now |
| -- | -- | -- |
| `0.35.3-rc.1` | `0.36.0` (wrong) | `0.35.2` |
| `0.34.7-rc.2` | `0.36.0` (wrong) | `0.34.6` |
| `4.10.6-rc.2` | `4.11.0` (wrong) | `4.10.5` |
| `4.9.4-rc.1` | `4.11.0` (wrong) | `4.9.3` |

The `4.10.6-rc.2` row is the subtle one: a released `4.10.6` already exists and is *newer* than the candidate, so the base steps back to `4.10.5`.

**An empty upgrade target resolves to the most recently published pre-release whose final release has not shipped yet**, excluding `-next`.

The old code took the first row of `/releases`. That list is returned in no dependable order — checked against the live API, it is descending by neither `created_at` nor `published_at`:

```
v0.37.0-alpha.1   created 22:36   published 2026-07-29T22:36
v0.37.0-alpha.0   created 13:04   published 2026-07-29T13:04
v0.36.1           created 21:33
v0.36.1-rc.4                      published 2026-07-31T13:43   <- newest, listed lower
```

Live today that is 42 `created_at` inversions and 83 `published_at` inversions.

So publish times are now read from the payload and sorted here. The "not shipped yet" filter matters too: sorting by publish time alone picks `0.36.1-rc.4`, and `0.36.1` shipped on 08-03, so there would be nothing left to validate. `0.34.7-rc.2` is skipped for the same reason.

The filter does not remove abandoned pre-releases. `0.15.3-beta.7` survives it, because `v0.15.3` never shipped either; 19 such pre-releases remain in the list. They lose on publish date rather than on the filter, so a *recently* published then abandoned pre-release would still win. Worth knowing, not addressed here.

On today's releases that resolves vCluster to `0.35.3-rc.2` and platform to `4.12.0-alpha.3`.

This does not close the platform coverage gap, and is not meant to. The rule picks the freshest unreleased pre-release across all lines, so which platform RC gets tested depends on what was cut most recently in `loft-enterprise` — unrelated to the vCluster release that triggered the run. A maintenance platform RC is only tested if it happens to be the freshest thing there. Triggering the checks from a platform release is the fix for that, tracked as issue 7 on ENGQA-1452.

Explicitly supplied versions are still used exactly as given. Only the auto-resolved cases change.

## Tests

This action had no tests, which is why the bug survived three weeks. The resolver now lives in `src/resolve-versions.sh` with a bats suite, following the `release-branch-freeze` layout:

```
src/resolve-versions.sh
test/resolve-versions.bats     24 tests
test/curl_mock.bash            stubs the release listing
.github/workflows/test-prerelease-setup.yaml
Makefile                       test-prerelease-setup, wired into `make test`
```

They run offline with the API stubbed. Fixtures carry explicit `published_at` values and are deliberately out of order, so a test fails if the code goes back to trusting the first row.

## Cost

Reading the whole list is more requests than before, not fewer: **4 before, 17 after**. `vcluster` has 678 releases (7 pages) and the platform repo 944 (10 pages), and each list is read once per run rather than once per lookup. That is the price of not depending on an order the API does not promise, and it adds tens of seconds to a job that already runs for many minutes.

A page shorter than 100 ends the read, which is what brings this down from 19 requests to 17.

`RELEASE_PAGE_LIMIT` (default 20, pages of 100) bounds it. Exceeding it now fails the step rather than warning: the reason we read the whole list is that the order is not dependable, so a page we did not read could hold the real base, and answering from a partial list would reintroduce exactly the bug this PR fixes.

## Note on duplication

`linear-release-sync` already has an equivalent of the base resolution in Go (`LastStableReleaseBeforeTag`, fixed under DEVOPS-874), and there are bash variants in `vcluster-pro/.github/scripts/platform-version-bump.sh` and `loft-enterprise/e2e-pre-release-checks.yaml`. Consolidating onto one implementation is worth doing separately; the Go one covers the base half but not the "newest unreleased pre-release" half this action also needs.

## Rollout

Used through the moving tag `prerelease-setup/v1`, so **nothing changes until that tag is re-pointed.** Merging is safe and reversible; re-pointing takes effect immediately for every caller and every release line, so it is worth doing deliberately with someone watching the next maintenance release.

## Related

Part of ENGQA-1452.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
