### PR TITLE
chore: add codeowners requiring devops sign-off

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Code owners for this repository.
+#
+# The org-level "DevOps Code Owner Review" ruleset requires an approving
+# review from a code owner before anything merges to the default branch.
+#
+# Named individuals rather than @loft-sh/eng-devops on purpose: the wider
+# team holds push and maintain here, but merge sign-off sits with these two.
+*   @Piotr1215 @sydorovdmytro


### PR DESCRIPTION
## Summary

- Adds `.github/CODEOWNERS` naming @Piotr1215 and @sydorovdmytro as the code owners for this repository.
- Pairs with a new org-level ruleset, `DevOps Code Owner Review`, which requires a code owner approval on the default branch and grants bypass to org admins only.
- Individuals rather than `@loft-sh/eng-devops`, because that team already holds push and maintain here. The point is to narrow sign-off, not restate existing access.

## Why this has to land first

The ruleset selects repositories by a new `owning-team=eng-devops` org custom property. Once it is activated, a repo with no CODEOWNERS file has no code owner, so the requirement can never be satisfied and every PR becomes unmergeable for anyone who is not an org admin.

## Test plan

- CODEOWNERS syntax is validated by GitHub on push, and both owners resolve: each has write or above on this repo, which is required for an owner to be requestable.
- Auto-request begins on PRs opened after this merges. CODEOWNERS takes effect from the default branch, so it deliberately does not apply to this PR itself.
- The ruleset is created in non-enforcing `evaluate` mode, so merging this changes nothing about who can merge until it is activated as a separate step.
- After activation: `gh api repos/loft-sh/github-actions/rules/branches/main`
