### PR TITLE
feat(wait-for-release): add status-aware cross-repo release waiter

### DIFF
--- a/.github/actions/wait-for-release/README.md
+++ b/.github/actions/wait-for-release/README.md
@@ -1,0 +1,121 @@
+# Wait for release
+
+Blocks until a GitHub Release for a given version exists in a given repository.
+
+For pipelines with a cross-repo ordering dependency: one repo's build uploads
+assets into a release that another repo's build creates, and the consumer has no
+control over when the producer gets there.
+
+## Why not just poll for the release
+
+Because presence polling cannot tell **"the producer is still building"** apart
+from **"the producer died half an hour ago"**. Both look identical, since in
+both cases the release simply isn't there. So a presence-only wait spends its
+entire timeout on a precondition that can never be met, then fails with a
+message that says nothing about why.
+
+Worse, retrying the consumer is then futile by construction: the only thing that
+can fix it is re-running the *producer*. A waiter that cannot say so sends people
+into re-run loops. This was DEVOPS-1234, where a release build was re-run twice
+at 24 minutes a go against an upstream release that had already failed.
+
+Set `workflow` to the producer's workflow file and the wait becomes
+status-aware. A run that already concluded `failure`, `cancelled`, `timed_out`
+or `startup_failure` fails the wait immediately, naming the run and the recovery
+order.
+
+## Inputs
+
+<!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
+
+|      INPUT       |  TYPE  | REQUIRED | DEFAULT |                                                                                                                  DESCRIPTION                                                                                                                  |
+|------------------|--------|----------|---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|   github-token   | string |   true   |         |                                                                              Token with contents:read on `repo`, plus <br>actions:read when `workflow` is set.                                                                                |
+| interval-seconds | string |  false   | `"15"`  |                                                                                                        Seconds to sleep between polls.                                                                                                        |
+| max-api-failures | string |  false   |  `"5"`  |                                                                  Consecutive GitHub API failures tolerated before <br>failing. A single blip must never <br>fail a release.                                                                   |
+|   max-attempts   | string |  false   | `"120"` |                                                                            Polls before giving up. The wall-clock <br>ceiling is max-attempts x interval-seconds.                                                                             |
+|       repo       | string |   true   |         |                                                                                Repository publishing the release, as owner/name <br>(e.g. loft-sh/vcluster).                                                                                  |
+|     version      | string |   true   |         |                                                                                                 Release tag to wait for (e.g. v0.36.1-rc.2).                                                                                                  |
+|     workflow     | string |  false   |         | Workflow file in `repo` that produces <br>the release (e.g. release.yaml). When set, a <br>producer run that has already failed <br>fails this wait immediately rather than <br>waiting out the timeout. Omit for <br>a plain presence poll.  |
+
+<!-- AUTO-DOC-INPUT:END -->
+
+## Outputs
+
+<!-- AUTO-DOC-OUTPUT:START - Do not remove or modify this section -->
+
+|     OUTPUT     |  TYPE  |                             DESCRIPTION                             |
+|----------------|--------|---------------------------------------------------------------------|
+|  release-url   | string |               URL of the release that was <br>found.                |
+| waited-seconds | string | Approximate seconds spent waiting before the <br>release appeared.  |
+
+<!-- AUTO-DOC-OUTPUT:END -->
+
+## Usage
+
+Plain presence poll, waiting up to 30 minutes (120 x 15s):
+
+```yaml
+- uses: loft-sh/github-actions/.github/actions/wait-for-release@wait-for-release/v1
+  with:
+    repo: loft-sh/vcluster
+    version: v0.36.1-rc.2
+    github-token: ${{ secrets.GH_ACCESS_TOKEN }}
+```
+
+Status-aware, failing fast if the producing workflow has already failed:
+
+```yaml
+- uses: loft-sh/github-actions/.github/actions/wait-for-release@wait-for-release/v1
+  with:
+    repo: loft-sh/vcluster
+    version: ${{ steps.get_version.outputs.release_version }}
+    workflow: release.yaml
+    github-token: ${{ secrets.GH_ACCESS_TOKEN }}
+```
+
+Set the ceiling from the producer's real build time. `max-attempts x
+interval-seconds` should comfortably exceed it, because a budget that merely
+*usually* covers the producer is a latent failure on every run.
+
+## Behaviour
+
+| Observed | Action |
+|----------|--------|
+| Release exists | Succeed, emit `release-url` |
+| Release absent (clean 404) | Keep waiting |
+| Producer concluded `failure` / `cancelled` / `timed_out` / `startup_failure` | **Fail immediately** with the run URL and recovery order |
+| Producer still `queued` / `in_progress` | Keep waiting |
+| Producer `success` but release absent | Keep waiting one poll for read lag, then fail as inconsistent |
+| Producer run not found | Keep waiting, since dispatch can lag |
+| Producer lookup errored | Keep waiting, since the release is the authority rather than the producer's health |
+| Release lookup errored | Keep waiting, up to `max-api-failures` consecutive |
+| Attempts exhausted | Fail with the elapsed budget in the message |
+
+Two rules drive the table:
+
+**The three lookup outcomes stay strictly distinct:** present, cleanly absent,
+and API error. Collapsing them is how a waiter goes wrong. An API error read as
+"absent" waits out the timeout on a release that is actually there, and read as
+"present" it lets the caller upload into a release that does not exist.
+
+**The release is the authority; the producer's health is only a hint.** A missing
+or unreadable producer run never fails the wait, because dispatch lag and API
+blips are normal. Only a run that has definitively finished unsuccessfully is
+grounds to stop, since at that point no amount of waiting can help.
+
+## Permissions
+
+`contents: read` on `repo`, plus `actions: read` when `workflow` is set. For a
+cross-repo wait the default `GITHUB_TOKEN` is not enough, being scoped to the
+calling repo, so pass a token with read access to the target repo.
+
+## Tests
+
+```bash
+make test-wait-for-release
+```
+
+17 bats tests, needing no token and no network: a configurable `gh` stub on
+`PATH` covers each row of the table above, and `WAIT_INTERVAL_SECONDS=0` keeps
+the suite instant while still exercising the real attempt accounting.

--- a/.github/actions/wait-for-release/README.md
+++ b/.github/actions/wait-for-release/README.md
@@ -90,7 +90,7 @@ interval-seconds` should comfortably exceed it, because a budget that merely
 | Producer run not found | Keep waiting, since dispatch can lag |
 | Producer lookup errored | Keep waiting, since the release is the authority rather than the producer's health |
 | Release lookup errored | Keep waiting, up to `max-api-failures` consecutive |
-| Attempts exhausted | Fail with the elapsed budget in the message |
+| Attempts exhausted | Fail with the elapsed budget, plus the cumulative API-failure count when any occurred |
 
 Two rules drive the table:
 
@@ -104,6 +104,15 @@ or unreadable producer run never fails the wait, because dispatch lag and API
 blips are normal. Only a run that has definitively finished unsuccessfully is
 grounds to stop, since at that point no amount of waiting can help.
 
+`max-api-failures` counts *consecutive* failures, so one blip can never fail a
+release. The trade-off is that a partial outage which interleaves errors with
+real 404s, intermittent rate-limiting for instance, keeps resetting the counter
+and never trips the breaker. That fails in the safe direction, the wait simply
+times out, but a bare timeout would read as "the producer was slow" when the
+truth is "we could barely see the API". So the timeout also reports the
+cumulative failure count whenever any occurred, which keeps the two
+distinguishable in the log.
+
 ## Permissions
 
 `contents: read` on `repo`, plus `actions: read` when `workflow` is set. For a
@@ -116,6 +125,6 @@ calling repo, so pass a token with read access to the target repo.
 make test-wait-for-release
 ```
 
-17 bats tests, needing no token and no network: a configurable `gh` stub on
+20 bats tests, needing no token and no network: a configurable `gh` stub on
 `PATH` covers each row of the table above, and `WAIT_INTERVAL_SECONDS=0` keeps
 the suite instant while still exercising the real attempt accounting.

--- a/.github/actions/wait-for-release/action.yml
+++ b/.github/actions/wait-for-release/action.yml
@@ -1,0 +1,63 @@
+name: Wait for release
+description: |
+  Block until a GitHub Release for a given version exists in a given repository,
+  for pipelines where one repo's build consumes a release that another repo's
+  build produces.
+
+  Polling for the release alone cannot tell "the producer is still building"
+  apart from "the producer died half an hour ago". The optional `workflow` input
+  makes the wait status-aware: when the run that produces the release has
+  already concluded failure, cancelled or timed out, the wait fails immediately
+  with that run's URL and the recovery order, instead of spending the whole
+  timeout on a precondition that can never be met.
+inputs:
+  repo:
+    description: 'Repository publishing the release, as owner/name (e.g. loft-sh/vcluster).'
+    required: true
+  version:
+    description: 'Release tag to wait for (e.g. v0.36.1-rc.2).'
+    required: true
+  workflow:
+    description: 'Workflow file in `repo` that produces the release (e.g. release.yaml). When set, a producer run that has already failed fails this wait immediately rather than waiting out the timeout. Omit for a plain presence poll.'
+    required: false
+    default: ''
+  max-attempts:
+    description: 'Polls before giving up. The wall-clock ceiling is max-attempts x interval-seconds.'
+    required: false
+    default: '120'
+  interval-seconds:
+    description: 'Seconds to sleep between polls.'
+    required: false
+    default: '15'
+  max-api-failures:
+    description: 'Consecutive GitHub API failures tolerated before failing. A single blip must never fail a release.'
+    required: false
+    default: '5'
+  github-token:
+    description: 'Token with contents:read on `repo`, plus actions:read when `workflow` is set.'
+    required: true
+outputs:
+  waited-seconds:
+    description: 'Approximate seconds spent waiting before the release appeared.'
+    value: ${{ steps.wait.outputs.waited-seconds }}
+  release-url:
+    description: 'URL of the release that was found.'
+    value: ${{ steps.wait.outputs.release-url }}
+runs:
+  using: composite
+  steps:
+    - name: Wait for release
+      id: wait
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        INPUT_REPO: ${{ inputs.repo }}
+        INPUT_VERSION: ${{ inputs.version }}
+        INPUT_WORKFLOW: ${{ inputs.workflow }}
+        WAIT_MAX_ATTEMPTS: ${{ inputs.max-attempts }}
+        WAIT_INTERVAL_SECONDS: ${{ inputs.interval-seconds }}
+        WAIT_MAX_API_FAILURES: ${{ inputs.max-api-failures }}
+      run: ${{ github.action_path }}/src/wait-for-release.sh
+branding:
+  icon: 'clock'
+  color: 'orange'

--- a/.github/actions/wait-for-release/src/wait-for-release.sh
+++ b/.github/actions/wait-for-release/src/wait-for-release.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# Waits for a GitHub Release to appear in another repository.
+#
+# Cross-repo release pipelines carry an ordering dependency: one repo's build
+# uploads assets into a release that another repo's build creates. Waiting on
+# the release alone cannot distinguish "the producer is still building" from
+# "the producer already failed and nothing will ever appear", so the wait is
+# optionally status-aware. When INPUT_WORKFLOW names the workflow that produces
+# the release, a run that has already concluded unsuccessfully fails this wait
+# immediately, printing that run's URL and the recovery order, instead of
+# spending the whole timeout on a precondition that can never be met.
+#
+# Three lookup outcomes stay strictly distinct - present, cleanly absent, and
+# API error - because collapsing them is how a waiter goes wrong: an API error
+# read as "absent" waits out the timeout on a release that is actually there,
+# and read as "present" it lets the caller upload into a release that does not
+# exist. API errors also never end the wait on their own; up to
+# WAIT_MAX_API_FAILURES consecutive failures are tolerated so one flaky call
+# cannot fail an otherwise healthy release.
+#
+# Required env: GH_TOKEN, INPUT_REPO, INPUT_VERSION
+# Optional env:
+#   INPUT_WORKFLOW         (default empty) - producer workflow, enables fail-fast
+#   WAIT_MAX_ATTEMPTS      (default 120)   - polls before giving up
+#   WAIT_INTERVAL_SECONDS  (default 15)    - seconds between polls
+#   WAIT_MAX_API_FAILURES  (default 5)     - consecutive API failures tolerated
+# Writes: waited-seconds, release-url to $GITHUB_OUTPUT (and stdout).
+# Exits 0 once the release exists, 1 otherwise.
+set -euo pipefail
+
+: "${INPUT_REPO:?INPUT_REPO is required}"
+: "${INPUT_VERSION:?INPUT_VERSION is required}"
+
+WORKFLOW="${INPUT_WORKFLOW:-}"
+MAX_ATTEMPTS="${WAIT_MAX_ATTEMPTS:-120}"
+INTERVAL_SECONDS="${WAIT_INTERVAL_SECONDS:-15}"
+MAX_API_FAILURES="${WAIT_MAX_API_FAILURES:-5}"
+
+# A producer run that reaches any of these will never go on to create the
+# release, so observing one is grounds to stop waiting immediately.
+TERMINAL_CONCLUSIONS="failure cancelled timed_out startup_failure"
+
+# Polls to tolerate where the producer reports success but the release is still
+# missing, before calling it an inconsistency. One poll of grace absorbs the lag
+# between a run finishing and its release becoming readable.
+SUCCESS_ABSENT_GRACE=2
+
+emit() {
+  local key="$1" value="$2"
+  [ -n "${GITHUB_OUTPUT:-}" ] && printf '%s=%s\n' "$key" "$value" >>"$GITHUB_OUTPUT"
+  printf '%s=%s\n' "$key" "$value"
+}
+
+# release_present <repo> <version>
+#   0 = release exists, 1 = cleanly absent (404), 2 = API error.
+release_present() {
+  local repo="$1" version="$2" err
+  if err=$(gh api "repos/${repo}/releases/tags/${version}" 2>&1 >/dev/null); then
+    return 0
+  fi
+  if printf '%s' "$err" | grep -qiE 'not found|HTTP 404'; then
+    return 1
+  fi
+  printf '%s\n' "$err" >&2
+  return 2
+}
+
+# producer_state <repo> <workflow> <version>
+#   Prints "<status>|<conclusion>|<url>" for the producer run of <version>.
+#   0 = printed, 1 = no run yet, 2 = API error.
+#
+# `workflow_dispatch` against a tag ref records head_branch as the tag, so
+# --branch <version> selects the run for that version. A re-run keeps the same
+# run id, so status/conclusion always describe the latest attempt.
+producer_state() {
+  local repo="$1" workflow="$2" version="$3" json
+  if ! json=$(gh run list --repo "$repo" --workflow "$workflow" --branch "$version" \
+    --limit 1 --json status,conclusion,url 2>/dev/null); then
+    return 2
+  fi
+  if [ -z "$json" ] || [ "$json" = "[]" ]; then
+    return 1
+  fi
+  jq -r '.[0] | "\(.status)|\(.conclusion)|\(.url)"' <<<"$json" 2>/dev/null || return 2
+}
+
+# is_terminal <conclusion> - true when a producer conclusion rules out a release.
+is_terminal() {
+  case " ${TERMINAL_CONCLUSIONS} " in
+  *" $1 "*) return 0 ;;
+  *) return 1 ;;
+  esac
+}
+
+# check_producer <attempt> - inspect the producer run and decide whether to stop
+# waiting. Returns 0 to keep waiting, 1 to fail fast. Never fails on an API
+# error or a missing run: dispatch can lag, and the producer's own health is a
+# hint here, not the authority. The release itself is the authority.
+check_producer() {
+  local attempt="$1" state="" rc=0 run_status run_conclusion run_url
+
+  state=$(producer_state "$INPUT_REPO" "$WORKFLOW" "$INPUT_VERSION") || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    return 0
+  fi
+
+  IFS='|' read -r run_status run_conclusion run_url <<<"$state"
+
+  if is_terminal "$run_conclusion"; then
+    echo "::error::${WORKFLOW} for ${INPUT_VERSION} in ${INPUT_REPO} already concluded ${run_conclusion}; release ${INPUT_VERSION} will never appear"
+    echo "::error::failed producer run: ${run_url}"
+    echo "::error::re-run that workflow first, then re-run this job - re-running this job alone cannot succeed"
+    return 1
+  fi
+
+  if [ "$run_status" = "completed" ] && [ "$run_conclusion" = "success" ]; then
+    success_absent=$((success_absent + 1))
+    if [ "$success_absent" -ge "$SUCCESS_ABSENT_GRACE" ]; then
+      echo "::error::${WORKFLOW} for ${INPUT_VERSION} in ${INPUT_REPO} succeeded but release ${INPUT_VERSION} is still absent after ${success_absent} polls"
+      echo "::error::producer run: ${run_url}"
+      return 1
+    fi
+    echo "producer succeeded but release not readable yet (${success_absent}/${SUCCESS_ABSENT_GRACE})"
+    return 0
+  fi
+
+  echo "attempt ${attempt}/${MAX_ATTEMPTS}: producer run is ${run_status}, still waiting"
+  return 0
+}
+
+main() {
+  local attempt rc api_failures=0 waited=0
+  success_absent=0
+
+  echo "waiting for release ${INPUT_VERSION} in ${INPUT_REPO} (up to ${MAX_ATTEMPTS} x ${INTERVAL_SECONDS}s)..."
+  [ -n "$WORKFLOW" ] && echo "producer workflow: ${WORKFLOW} (will fail fast if it already failed)"
+
+  for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt++)); do
+    rc=0
+    release_present "$INPUT_REPO" "$INPUT_VERSION" || rc=$?
+
+    case "$rc" in
+    0)
+      echo "release ${INPUT_VERSION} present in ${INPUT_REPO} after attempt ${attempt}"
+      emit waited-seconds "$waited"
+      emit release-url "https://github.com/${INPUT_REPO}/releases/tag/${INPUT_VERSION}"
+      return 0
+      ;;
+    1)
+      api_failures=0
+      ;;
+    *)
+      api_failures=$((api_failures + 1))
+      echo "::warning::attempt ${attempt}/${MAX_ATTEMPTS}: release lookup failed (${api_failures}/${MAX_API_FAILURES} consecutive)"
+      if [ "$api_failures" -ge "$MAX_API_FAILURES" ]; then
+        echo "::error::giving up after ${api_failures} consecutive API failures looking up ${INPUT_VERSION} in ${INPUT_REPO}"
+        return 1
+      fi
+      ;;
+    esac
+
+    if [ -n "$WORKFLOW" ] && [ "$rc" -eq 1 ]; then
+      check_producer "$attempt" || return 1
+    fi
+
+    if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
+      sleep "$INTERVAL_SECONDS"
+      waited=$((waited + INTERVAL_SECONDS))
+    fi
+  done
+
+  echo "::error::release ${INPUT_VERSION} never appeared in ${INPUT_REPO} after ${MAX_ATTEMPTS} attempts (~$((MAX_ATTEMPTS * INTERVAL_SECONDS))s)"
+  return 1
+}
+
+# Only auto-run when executed directly; sourcing (e.g. from bats) must not.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/.github/actions/wait-for-release/src/wait-for-release.sh
+++ b/.github/actions/wait-for-release/src/wait-for-release.sh
@@ -129,7 +129,7 @@ check_producer() {
 }
 
 main() {
-  local attempt rc api_failures=0 waited=0
+  local attempt rc api_failures=0 api_failures_total=0 waited=0
   success_absent=0
 
   echo "waiting for release ${INPUT_VERSION} in ${INPUT_REPO} (up to ${MAX_ATTEMPTS} x ${INTERVAL_SECONDS}s)..."
@@ -151,6 +151,7 @@ main() {
       ;;
     *)
       api_failures=$((api_failures + 1))
+      api_failures_total=$((api_failures_total + 1))
       echo "::warning::attempt ${attempt}/${MAX_ATTEMPTS}: release lookup failed (${api_failures}/${MAX_API_FAILURES} consecutive)"
       if [ "$api_failures" -ge "$MAX_API_FAILURES" ]; then
         echo "::error::giving up after ${api_failures} consecutive API failures looking up ${INPUT_VERSION} in ${INPUT_REPO}"
@@ -169,6 +170,15 @@ main() {
     fi
   done
 
+  # The consecutive counter resets on every clean 404, so a partial outage that
+  # alternates errors with real 404s (intermittent rate-limiting, say) never
+  # trips the circuit breaker and the wait spends its whole budget. That is the
+  # safe direction to fail, but the timeout alone would read as "the producer
+  # was slow" when the truth is "we could barely see the API". Report the
+  # cumulative count so the two are distinguishable.
+  if [ "$api_failures_total" -gt 0 ]; then
+    echo "::warning::${api_failures_total} of ${MAX_ATTEMPTS} release lookups failed with an API error; the API was degraded for part or all of this wait"
+  fi
   echo "::error::release ${INPUT_VERSION} never appeared in ${INPUT_REPO} after ${MAX_ATTEMPTS} attempts (~$((MAX_ATTEMPTS * INTERVAL_SECONDS))s)"
   return 1
 }

--- a/.github/actions/wait-for-release/test/wait-for-release.bats
+++ b/.github/actions/wait-for-release/test/wait-for-release.bats
@@ -33,6 +33,7 @@ teardown() {
 # A single configurable `gh` stub, driven per-test by env:
 #   GH_STUB_RELEASE_AFTER=N    release becomes present on the Nth lookup (0 = never)
 #   GH_STUB_RELEASE_ERRORS=N   first N lookups fail with a transport error, not a 404
+#   GH_STUB_RELEASE_ERROR_EVERY=N  every Nth lookup fails, interleaved with 404s
 #   GH_STUB_RUN_STATUS         producer run status   (default in_progress)
 #   GH_STUB_RUN_CONCLUSION     producer run conclusion (default empty)
 #   GH_STUB_RUN_URL            producer run url
@@ -55,6 +56,13 @@ if [[ "$sub" == "api" ]]; then
     exit 1
   fi
 
+  # Partial outage: fail every Nth lookup, so errors interleave with clean 404s
+  # and the consecutive counter keeps resetting.
+  if [[ -n "${GH_STUB_RELEASE_ERROR_EVERY:-}" ]] && (( n % GH_STUB_RELEASE_ERROR_EVERY == 0 )); then
+    echo "HTTP 403: API rate limit exceeded" >&2
+    exit 1
+  fi
+
   after="${GH_STUB_RELEASE_AFTER:-0}"
   if (( after > 0 )) && (( n >= after )); then
     echo '{"tag_name":"stub"}'
@@ -73,9 +81,17 @@ if [[ "$sub" == "run" ]]; then
     echo "[]"
     exit 0
   fi
-  printf '[{"status":"%s","conclusion":"%s","url":"%s"}]\n' \
+  # An unconcluded run returns JSON null, not "", and jq -r renders that as the
+  # literal string "null". Emit real null so the script's actual parse path is
+  # what the suite exercises.
+  if [[ -z "${GH_STUB_RUN_CONCLUSION:-}" ]]; then
+    conclusion="null"
+  else
+    conclusion="\"${GH_STUB_RUN_CONCLUSION}\""
+  fi
+  printf '[{"status":"%s","conclusion":%s,"url":"%s"}]\n' \
     "${GH_STUB_RUN_STATUS:-in_progress}" \
-    "${GH_STUB_RUN_CONCLUSION:-}" \
+    "$conclusion" \
     "${GH_STUB_RUN_URL:-https://github.com/loft-sh/vcluster/actions/runs/30495974873}"
   exit 0
 fi
@@ -174,6 +190,20 @@ lookup_count() {
   [[ "$output" == *"already concluded timed_out"* ]]
 }
 
+@test "fails fast when the producer run hit startup_failure" {
+  export GH_STUB_RELEASE_AFTER=0
+  export INPUT_WORKFLOW="release.yaml"
+  export GH_STUB_RUN_STATUS="completed"
+  export GH_STUB_RUN_CONCLUSION="startup_failure"
+  export WAIT_MAX_ATTEMPTS=50
+
+  run bash "$SCRIPT"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"already concluded startup_failure"* ]]
+  [ "$(lookup_count)" -eq 1 ]
+}
+
 @test "keeps waiting while the producer run is still in progress" {
   export GH_STUB_RELEASE_AFTER=0
   export INPUT_WORKFLOW="release.yaml"
@@ -268,6 +298,33 @@ lookup_count() {
   [ "$(lookup_count)" -eq 3 ]
 }
 
+@test "reports cumulative failures when a partial outage never trips the breaker" {
+  # Every 2nd lookup errors, so the consecutive counter resets on the 404s in
+  # between and never reaches the ceiling. The wait times out (the safe
+  # direction), but the timeout must not read as "the producer was just slow".
+  export GH_STUB_RELEASE_AFTER=0
+  export GH_STUB_RELEASE_ERROR_EVERY=2
+  export WAIT_MAX_ATTEMPTS=6
+  export WAIT_MAX_API_FAILURES=3
+
+  run bash "$SCRIPT"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" != *"giving up after"* ]]
+  [[ "$output" == *"3 of 6 release lookups failed with an API error"* ]]
+  [[ "$output" == *"never appeared"* ]]
+}
+
+@test "reports no API-failure warning on a clean timeout" {
+  export GH_STUB_RELEASE_AFTER=0
+
+  run bash "$SCRIPT"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"never appeared"* ]]
+  [[ "$output" != *"failed with an API error"* ]]
+}
+
 @test "a clean 404 does not count as an API failure" {
   export GH_STUB_RELEASE_AFTER=0
   export WAIT_MAX_API_FAILURES=2
@@ -318,4 +375,14 @@ lookup_count() {
   run producer_state "loft-sh/vcluster" "release.yaml" "v0.36.1-rc.2"
   [ "$status" -eq 0 ]
   [[ "$output" == "completed|failure|"* ]]
+
+  # An unconcluded run sends JSON null, which jq -r renders as "null". The
+  # script compares conclusions as strings, so this must stay non-terminal.
+  export GH_STUB_RUN_STATUS="in_progress"
+  unset GH_STUB_RUN_CONCLUSION
+  run producer_state "loft-sh/vcluster" "release.yaml" "v0.36.1-rc.2"
+  [ "$status" -eq 0 ]
+  [[ "$output" == "in_progress|null|"* ]]
+  run is_terminal "null"
+  [ "$status" -ne 0 ]
 }

--- a/.github/actions/wait-for-release/test/wait-for-release.bats
+++ b/.github/actions/wait-for-release/test/wait-for-release.bats
@@ -1,0 +1,321 @@
+#!/usr/bin/env bats
+# Tests for wait-for-release.sh
+#
+# Every test runs against a configurable `gh` stub on PATH, so no real API call
+# is made and no test needs a token. WAIT_INTERVAL_SECONDS=0 keeps the poll loop
+# instant while still exercising the real attempt accounting.
+#
+# The stub counts only `gh api` calls (release lookups), so GH_STUB_RELEASE_AFTER
+# is expressed in polls: "become present on the Nth lookup".
+
+setup() {
+  SCRIPT="${BATS_TEST_DIRNAME}/../src/wait-for-release.sh"
+
+  STUB_DIR="$(mktemp -d)"
+  PATH="${STUB_DIR}:${PATH}"
+  export GH_STUB_COUNT_FILE="${STUB_DIR}/count"
+
+  export INPUT_REPO="loft-sh/vcluster"
+  export INPUT_VERSION="v0.36.1-rc.2"
+  export INPUT_WORKFLOW=""
+  export WAIT_MAX_ATTEMPTS=3
+  export WAIT_INTERVAL_SECONDS=0
+  export WAIT_MAX_API_FAILURES=5
+  export GITHUB_OUTPUT="${STUB_DIR}/github_output"
+
+  install_gh_stub
+}
+
+teardown() {
+  rm -rf "$STUB_DIR"
+}
+
+# A single configurable `gh` stub, driven per-test by env:
+#   GH_STUB_RELEASE_AFTER=N    release becomes present on the Nth lookup (0 = never)
+#   GH_STUB_RELEASE_ERRORS=N   first N lookups fail with a transport error, not a 404
+#   GH_STUB_RUN_STATUS         producer run status   (default in_progress)
+#   GH_STUB_RUN_CONCLUSION     producer run conclusion (default empty)
+#   GH_STUB_RUN_URL            producer run url
+#   GH_STUB_NO_RUN=1           `gh run list` returns [] (dispatch has not landed)
+#   GH_STUB_RUN_ERROR=1        `gh run list` fails
+install_gh_stub() {
+  cat >"${STUB_DIR}/gh" <<'EOF'
+#!/usr/bin/env bash
+set -u
+sub="$1"; shift || true
+
+if [[ "$sub" == "api" ]]; then
+  n=$(( $(cat "${GH_STUB_COUNT_FILE}" 2>/dev/null || echo 0) + 1 ))
+  echo "$n" >"${GH_STUB_COUNT_FILE}"
+
+  # A transport/auth failure prints no clean 404 - the script must treat this as
+  # "unknown", not "absent".
+  if [[ -n "${GH_STUB_RELEASE_ERRORS:-}" ]] && (( n <= GH_STUB_RELEASE_ERRORS )); then
+    echo "error connecting to api.github.com" >&2
+    exit 1
+  fi
+
+  after="${GH_STUB_RELEASE_AFTER:-0}"
+  if (( after > 0 )) && (( n >= after )); then
+    echo '{"tag_name":"stub"}'
+    exit 0
+  fi
+  echo "gh: Not Found (HTTP 404)" >&2
+  exit 1
+fi
+
+if [[ "$sub" == "run" ]]; then
+  if [[ "${GH_STUB_RUN_ERROR:-}" == "1" ]]; then
+    echo "api error" >&2
+    exit 1
+  fi
+  if [[ "${GH_STUB_NO_RUN:-}" == "1" ]]; then
+    echo "[]"
+    exit 0
+  fi
+  printf '[{"status":"%s","conclusion":"%s","url":"%s"}]\n' \
+    "${GH_STUB_RUN_STATUS:-in_progress}" \
+    "${GH_STUB_RUN_CONCLUSION:-}" \
+    "${GH_STUB_RUN_URL:-https://github.com/loft-sh/vcluster/actions/runs/30495974873}"
+  exit 0
+fi
+
+echo "unexpected gh invocation: ${sub} $*" >&2
+exit 1
+EOF
+  chmod +x "${STUB_DIR}/gh"
+}
+
+lookup_count() {
+  cat "${GH_STUB_COUNT_FILE}" 2>/dev/null || echo 0
+}
+
+# --- presence polling -------------------------------------------------------
+
+@test "succeeds immediately when the release already exists" {
+  export GH_STUB_RELEASE_AFTER=1
+
+  run bash "$SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"present in loft-sh/vcluster after attempt 1"* ]]
+  [ "$(lookup_count)" -eq 1 ]
+}
+
+@test "emits waited-seconds and release-url on success" {
+  export GH_STUB_RELEASE_AFTER=1
+
+  run bash "$SCRIPT"
+
+  [ "$status" -eq 0 ]
+  grep -q '^release-url=https://github.com/loft-sh/vcluster/releases/tag/v0.36.1-rc.2$' "$GITHUB_OUTPUT"
+  grep -q '^waited-seconds=' "$GITHUB_OUTPUT"
+}
+
+@test "keeps polling until the release appears" {
+  export GH_STUB_RELEASE_AFTER=3
+
+  run bash "$SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"after attempt 3"* ]]
+}
+
+@test "fails with a timeout once attempts are exhausted" {
+  export GH_STUB_RELEASE_AFTER=0
+
+  run bash "$SCRIPT"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"never appeared in loft-sh/vcluster after 3 attempts"* ]]
+  [ "$(lookup_count)" -eq 3 ]
+}
+
+# --- fail-fast on a dead producer -------------------------------------------
+
+@test "fails fast when the producer run already failed" {
+  export GH_STUB_RELEASE_AFTER=0
+  export INPUT_WORKFLOW="release.yaml"
+  export GH_STUB_RUN_STATUS="completed"
+  export GH_STUB_RUN_CONCLUSION="failure"
+  export WAIT_MAX_ATTEMPTS=50
+
+  run bash "$SCRIPT"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"already concluded failure"* ]]
+  [[ "$output" == *"actions/runs/30495974873"* ]]
+  [[ "$output" == *"re-run that workflow first"* ]]
+  # The point of failing fast: it must not spend the attempt budget first.
+  [ "$(lookup_count)" -eq 1 ]
+}
+
+@test "fails fast when the producer run was cancelled" {
+  export GH_STUB_RELEASE_AFTER=0
+  export INPUT_WORKFLOW="release.yaml"
+  export GH_STUB_RUN_STATUS="completed"
+  export GH_STUB_RUN_CONCLUSION="cancelled"
+
+  run bash "$SCRIPT"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"already concluded cancelled"* ]]
+}
+
+@test "fails fast when the producer run timed out" {
+  export GH_STUB_RELEASE_AFTER=0
+  export INPUT_WORKFLOW="release.yaml"
+  export GH_STUB_RUN_STATUS="completed"
+  export GH_STUB_RUN_CONCLUSION="timed_out"
+
+  run bash "$SCRIPT"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"already concluded timed_out"* ]]
+}
+
+@test "keeps waiting while the producer run is still in progress" {
+  export GH_STUB_RELEASE_AFTER=0
+  export INPUT_WORKFLOW="release.yaml"
+  export GH_STUB_RUN_STATUS="in_progress"
+
+  run bash "$SCRIPT"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"producer run is in_progress"* ]]
+  # Timed out rather than failing fast, and used the whole budget.
+  [[ "$output" == *"never appeared"* ]]
+  [ "$(lookup_count)" -eq 3 ]
+}
+
+@test "keeps waiting when the producer run has not been dispatched yet" {
+  export GH_STUB_RELEASE_AFTER=0
+  export INPUT_WORKFLOW="release.yaml"
+  export GH_STUB_NO_RUN=1
+
+  run bash "$SCRIPT"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"never appeared"* ]]
+  [[ "$output" != *"already concluded"* ]]
+  [ "$(lookup_count)" -eq 3 ]
+}
+
+@test "keeps waiting when the producer lookup itself errors" {
+  export GH_STUB_RELEASE_AFTER=0
+  export INPUT_WORKFLOW="release.yaml"
+  export GH_STUB_RUN_ERROR=1
+
+  run bash "$SCRIPT"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"never appeared"* ]]
+  [[ "$output" != *"already concluded"* ]]
+}
+
+@test "fails when the producer succeeded but the release stays absent" {
+  export GH_STUB_RELEASE_AFTER=0
+  export INPUT_WORKFLOW="release.yaml"
+  export GH_STUB_RUN_STATUS="completed"
+  export GH_STUB_RUN_CONCLUSION="success"
+  export WAIT_MAX_ATTEMPTS=50
+
+  run bash "$SCRIPT"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"succeeded but release v0.36.1-rc.2 is still absent"* ]]
+  # One poll of grace for read lag, then it stops - well short of the budget.
+  [ "$(lookup_count)" -eq 2 ]
+}
+
+@test "ignores the producer entirely when no workflow is given" {
+  export GH_STUB_RELEASE_AFTER=0
+  export INPUT_WORKFLOW=""
+  # A failed producer is visible, but with no workflow input it must not be read.
+  export GH_STUB_RUN_STATUS="completed"
+  export GH_STUB_RUN_CONCLUSION="failure"
+
+  run bash "$SCRIPT"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" != *"already concluded"* ]]
+  [[ "$output" == *"never appeared"* ]]
+}
+
+# --- API error handling -----------------------------------------------------
+
+@test "tolerates transient lookup failures and still succeeds" {
+  export GH_STUB_RELEASE_ERRORS=2
+  export GH_STUB_RELEASE_AFTER=3
+  export WAIT_MAX_ATTEMPTS=5
+
+  run bash "$SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"release lookup failed (1/5 consecutive)"* ]]
+  [[ "$output" == *"after attempt 3"* ]]
+}
+
+@test "fails after too many consecutive lookup failures" {
+  export GH_STUB_RELEASE_ERRORS=99
+  export WAIT_MAX_ATTEMPTS=50
+  export WAIT_MAX_API_FAILURES=3
+
+  run bash "$SCRIPT"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"giving up after 3 consecutive API failures"* ]]
+  [ "$(lookup_count)" -eq 3 ]
+}
+
+@test "a clean 404 does not count as an API failure" {
+  export GH_STUB_RELEASE_AFTER=0
+  export WAIT_MAX_API_FAILURES=2
+
+  run bash "$SCRIPT"
+
+  [ "$status" -eq 1 ]
+  # Absent is not an error: it must reach the timeout, not the API-failure exit.
+  [[ "$output" == *"never appeared"* ]]
+  [[ "$output" != *"consecutive API failures"* ]]
+}
+
+# --- unit-level: the three lookup outcomes stay distinct ---------------------
+
+@test "release_present distinguishes present, absent and error" {
+  source "$SCRIPT"
+
+  export GH_STUB_RELEASE_AFTER=1
+  run release_present "loft-sh/vcluster" "v0.36.1-rc.2"
+  [ "$status" -eq 0 ]
+
+  rm -f "${GH_STUB_COUNT_FILE}"
+  export GH_STUB_RELEASE_AFTER=0
+  run release_present "loft-sh/vcluster" "v0.36.1-rc.2"
+  [ "$status" -eq 1 ]
+
+  rm -f "${GH_STUB_COUNT_FILE}"
+  export GH_STUB_RELEASE_ERRORS=1
+  run release_present "loft-sh/vcluster" "v0.36.1-rc.2"
+  [ "$status" -eq 2 ]
+}
+
+@test "producer_state reports no run, api error and parsed state" {
+  source "$SCRIPT"
+
+  export GH_STUB_NO_RUN=1
+  run producer_state "loft-sh/vcluster" "release.yaml" "v0.36.1-rc.2"
+  [ "$status" -eq 1 ]
+
+  unset GH_STUB_NO_RUN
+  export GH_STUB_RUN_ERROR=1
+  run producer_state "loft-sh/vcluster" "release.yaml" "v0.36.1-rc.2"
+  [ "$status" -eq 2 ]
+
+  unset GH_STUB_RUN_ERROR
+  export GH_STUB_RUN_STATUS="completed"
+  export GH_STUB_RUN_CONCLUSION="failure"
+  run producer_state "loft-sh/vcluster" "release.yaml" "v0.36.1-rc.2"
+  [ "$status" -eq 0 ]
+  [[ "$output" == "completed|failure|"* ]]
+}

--- a/.github/workflows/test-wait-for-release.yaml
+++ b/.github/workflows/test-wait-for-release.yaml
@@ -1,0 +1,22 @@
+name: Test wait-for-release
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/test-wait-for-release.yaml'
+      - '.github/actions/wait-for-release/**'
+
+permissions:
+  contents: read
+
+jobs:
+  bats:
+    name: Run bats tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
+        with:
+          tests: .github/actions/wait-for-release/test

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-semver-validation test-linear-pr-commenter test-link-backport-prs test-release-notification test-linear-release-sync test-aws-test-infra test-cleanup-head-charts test-ci-test-notify test-auto-approve-bot-prs test-ai-pr-review test-ai-step test-publish-helm-chart test-govulncheck test-go-licenses test-run-ginkgo test-sticky-pr-comment test-repository-dispatch test-parse-label-filter test-release-branch-freeze test-vcluster-release test-subtree-mirror test-oss-commit-sync test-backport-legacy-allowlist test-backport-legacy-split test-promote-release build-linear-release-sync lint install-auto-doc generate-docs check-docs help
+.PHONY: test test-semver-validation test-linear-pr-commenter test-link-backport-prs test-release-notification test-linear-release-sync test-aws-test-infra test-cleanup-head-charts test-ci-test-notify test-auto-approve-bot-prs test-ai-pr-review test-ai-step test-publish-helm-chart test-govulncheck test-go-licenses test-run-ginkgo test-sticky-pr-comment test-repository-dispatch test-parse-label-filter test-release-branch-freeze test-vcluster-release test-subtree-mirror test-oss-commit-sync test-backport-legacy-allowlist test-backport-legacy-split test-promote-release test-wait-for-release build-linear-release-sync lint install-auto-doc generate-docs check-docs help
 
 ACTIONS_DIR := .github/actions
 WORKFLOWS_DIR := .github/workflows
@@ -93,7 +93,7 @@ check-docs: generate-docs ## verify docs are up to date (fails if drift detected
 help: ## show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-30s %s\n", $$1, $$2}'
 
-test: test-semver-validation test-linear-pr-commenter test-link-backport-prs test-release-notification test-linear-release-sync test-aws-test-infra test-cleanup-head-charts test-auto-approve-bot-prs test-ai-pr-review test-ai-step test-ci-test-notify test-go-licenses test-publish-helm-chart test-govulncheck test-run-ginkgo test-sticky-pr-comment test-repository-dispatch test-parse-label-filter test-release-branch-freeze test-vcluster-release test-subtree-mirror test-oss-commit-sync test-backport-legacy-allowlist test-backport-legacy-split test-promote-release ## run all action tests
+test: test-semver-validation test-linear-pr-commenter test-link-backport-prs test-release-notification test-linear-release-sync test-aws-test-infra test-cleanup-head-charts test-auto-approve-bot-prs test-ai-pr-review test-ai-step test-ci-test-notify test-go-licenses test-publish-helm-chart test-govulncheck test-run-ginkgo test-sticky-pr-comment test-repository-dispatch test-parse-label-filter test-release-branch-freeze test-vcluster-release test-subtree-mirror test-oss-commit-sync test-backport-legacy-allowlist test-backport-legacy-split test-promote-release test-wait-for-release ## run all action tests
 
 test-semver-validation: ## run semver-validation unit tests
 	cd $(ACTIONS_DIR)/semver-validation && npm ci --silent && NODE_OPTIONS=--experimental-vm-modules npx jest --ci --coverage --watchAll=false
@@ -170,6 +170,9 @@ test-backport-legacy-allowlist: ## run backport-legacy-allowlist bats tests
 
 test-backport-legacy-split: ## run backport-legacy-split bats tests
 	bats $(ACTIONS_DIR)/backport-legacy-split/test/run.bats
+
+test-wait-for-release: ## run wait-for-release bats tests
+	bats $(ACTIONS_DIR)/wait-for-release/test/*.bats
 
 build-linear-release-sync: ## build linear-release-sync binary (linux/amd64)
 	cd $(ACTIONS_DIR)/linear-release-sync/src && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-s -w" -o ../linear-release-sync-linux-amd64 .

--- a/README.md
+++ b/README.md
@@ -425,6 +425,40 @@ Successor to Subtree Mirror. Bidirectional per-commit sync between a monorepo su
 
 See [oss-commit-sync README](./.github/actions/oss-commit-sync/README.md) for the full contract, safety mechanisms, and migration steps.
 
+### Wait For Release Action
+
+Blocks until a GitHub Release for a version exists in another repository, for pipelines where one repo's build uploads assets into a release that another repo's build creates. Presence polling alone cannot tell "the producer is still building" apart from "the producer already failed", so the optional `workflow` input makes the wait status-aware: a producer run that has already concluded unsuccessfully fails the wait immediately, with that run's URL and the recovery order, instead of spending the whole timeout on a precondition that can never be met.
+
+**Location:** `.github/actions/wait-for-release`
+
+**Usage:**
+
+```yaml
+- uses: loft-sh/github-actions/.github/actions/wait-for-release@wait-for-release/v1
+  with:
+    repo: loft-sh/vcluster
+    version: ${{ steps.get_version.outputs.release_version }}
+    workflow: release.yaml
+    github-token: ${{ secrets.GH_ACCESS_TOKEN }}
+```
+
+**Inputs:**
+
+- `repo` (required): Repository publishing the release, as `<owner>/<repo>`.
+- `version` (required): Release tag to wait for, e.g. `v0.36.1-rc.2`.
+- `workflow` (optional): Workflow file in `repo` that produces the release. Enables fail-fast on an already-failed producer run. Omit for a plain presence poll.
+- `max-attempts` (optional, default `120`): Polls before giving up. Wall-clock ceiling is `max-attempts x interval-seconds`.
+- `interval-seconds` (optional, default `15`): Seconds between polls.
+- `max-api-failures` (optional, default `5`): Consecutive API failures tolerated, so one blip cannot fail a release.
+- `github-token` (required): Token with `contents:read` on `repo`, plus `actions:read` when `workflow` is set.
+
+**Outputs:**
+
+- `waited-seconds`: Approximate seconds spent waiting before the release appeared.
+- `release-url`: URL of the release that was found.
+
+See [wait-for-release README](./.github/actions/wait-for-release/README.md) for the full behaviour table.
+
 ## Available Reusable Workflows
 
 ### Validate Renovate Config


### PR DESCRIPTION
## Summary

- New `wait-for-release` composite action: blocks until a GitHub Release for a given `version` exists in a given `repo`, for pipelines where one repo's build uploads assets into a release that another repo's build creates.
- The optional `workflow` input makes the wait **status-aware**. Presence polling alone cannot tell "the producer is still building" apart from "the producer died half an hour ago", so a presence-only wait spends its entire timeout on a precondition that can never be met, and retrying the consumer is futile by construction. A producer run that already concluded `failure` / `cancelled` / `timed_out` / `startup_failure` now fails the wait immediately, naming that run and the recovery order.
- 17 bats tests, no token or network needed, wired into `make test` and a paths-filtered CI workflow.

## Why

`v0.36.1-rc.2` had to be re-cut. A transient GHCR push error killed the upstream OSS release build, and the downstream pro build then sat in a presence-only wait until it timed out. Because the wait could not report *why* nothing was coming, the release build was re-run twice at ~24 minutes each against a precondition that re-running it could never satisfy. Re-running the producer first would have recovered the cut with no re-cut at all.

A second defect the incident exposed: on the cut that *succeeded* right after, the same wait consumed 2m38s of its 5m budget against a producer that takes ~16m. That margin was incidental, not designed, so a cold cache or a slower runner would have failed a perfectly healthy cut.

Both defects are properties of the waiter, not of the pipeline that happened to hit them, which is why this lands here as a reusable action rather than as three copies of patched inline shell.

## Design

Two rules drive the behaviour table in the [action README](./.github/actions/wait-for-release/README.md):

**The three lookup outcomes stay strictly distinct** (present, cleanly absent, API error). Collapsing them is how a waiter goes wrong: an API error read as "absent" waits out the timeout on a release that is actually there, and read as "present" it lets the caller upload into a release that does not exist.

**The release is the authority; the producer's health is only a hint.** A missing or unreadable producer run never fails the wait, since dispatch lag and API blips are normal. Only a run that has definitively finished unsuccessfully is grounds to stop.

## Test plan

- `make test-wait-for-release` passes: 17 bats tests covering every row of the behaviour table (fail-fast on each terminal conclusion, keep-waiting on in-progress / not-yet-dispatched / producer-lookup-error, transient-error tolerance, consecutive-failure ceiling, clean 404 not counted as an error, producer ignored entirely when `workflow` is unset, and unit coverage that the three lookup outcomes stay distinct).
- `shellcheck` clean on `src/wait-for-release.sh`.
- `actionlint .github/workflows/*.yaml` clean.
- `make check-docs` clean, no drift.
- Tests use a configurable `gh` stub on `PATH` and `WAIT_INTERVAL_SECONDS=0`, so the suite needs no token, makes no API call, and runs instantly while still exercising the real attempt accounting.

## Notes for review

- **Caller migration is deliberately not in this PR.** The three `vcluster-pro` release lines that need this (`v0.34`, `v0.35`, `v0.36`) can only reference the action once it is on `main` and tagged, so those follow as separate PRs.
- **`max-attempts` / `interval-seconds` instead of a single `timeout`.** A timeout input would need arithmetic to derive the poll count, and `docs/CONVENTIONS.md` keeps YAML glue-only. Two literal inputs keep the arithmetic out of both the YAML and the script.
- **Pin form for callers.** `docs/CONVENTIONS.md` says callers pin by SHA with the tag in a comment for Renovate, while the org `github-actions-developer` skill says internal actions should use the action-specific tag and never a SHA. The examples in this PR use the tag form, matching the sibling action READMEs. Happy to switch to SHA-plus-comment in the caller PRs if that is the standing convention.

Closes DEVOPS-1234