### PR TITLE
fix(oss-commit-sync): stop reporting our own exports as lost trailers

### DIFF
--- a/.github/actions/oss-commit-sync/README.md
+++ b/.github/actions/oss-commit-sync/README.md
@@ -101,7 +101,16 @@ import; the subtree tree is *evidence* of one, and evidence survives what
 records do not — a squash, a hand-edited message, a hand-made import that
 forgot the trailer. So damaged trailer state repairs itself on every run, with
 no marker commit, no repair PR, and no operator action. `healed-count` reports
-how far it moved; non-zero means trailers are being lost somewhere.
+how far it moved.
+
+Most of that movement is routine. Every OSS commit we exported carries
+`Monorepo-Commit` and, by design, never an `Oss-Commit` trailer, so the anchor
+trails our own exports until the next import records a trailer past them, and
+healing walks over them on the way. `healed-count` is therefore split:
+`healed-export-count` is that expected part, and `healed-unrecorded-count`
+counts commits carrying **neither** trailer — an import whose provenance record
+was lost. Only the latter is annotated, and only it means trailers are being
+lost somewhere.
 
 This is safe by construction rather than by heuristic: if the subtree equals
 commit `C`'s content, replaying anything up to `C` could only produce a no-op or
@@ -176,7 +185,10 @@ describe.
 - **Trailers lagging content.** `stale-anchor` with `recorded-anchor` (what the
   trailers say) against `anchor` (what the import will use). Not an action item
   for the sync, which heals itself, but the affected external commits carry no
-  recorded provenance on the base branch, and something is losing trailers.
+  recorded provenance on the base branch, and something is losing trailers. It
+  counts `redundant-unrecorded-count` only: `redundant-export-count`, the
+  commits we exported ourselves, lags the anchor after every export and is
+  never a finding.
 - **Squash-merged sync PRs.** `squashed-trailer-count` counts commits whose
   trailer the whole-message scan finds but git's trailer block does not, which is
   the fingerprint of a squash. This is the actionable one: it is the cause of the
@@ -219,28 +231,32 @@ it sees that.
 
 <!-- AUTO-DOC-OUTPUT:START - Do not remove or modify this section -->
 
-|         OUTPUT         |  TYPE  |                                                                                                             DESCRIPTION                                                                                                             |
-|------------------------|--------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-|         anchor         | string |                                  Health: the OSS commit the import <br>will resume from, after content healing. <br>Empty only when neither a trailer <br>nor the subtree content identifies one.                                   |
-|      conflict-sha      | string |                                                                   Import: the OSS commit that failed <br>the 3-way apply, when the run <br>failed on a conflict.                                                                    |
-|       converged        | string |                                                              Health: true when the subtree already <br>holds the OSS branch tip content <br>(ignoring exclude-paths).                                                               |
-|        degraded        | string |       Health: true when a git or <br>network step failed and some figures <br>in this report are therefore incomplete. <br>The health direction never exits non-zero, <br>so gate on this rather than <br>on the job result.        |
-|        diverged        | string |                                                                   Export: true when OSS has external <br>commits not yet absorbed and the <br>run failed closed.                                                                    |
-|     exported-count     | string |                                                                  Export: number of commits created on <br>the OSS branch (including an alignment commit, if any).                                                                   |
-|      has-changes       | string |                                                                      Import: true when at least one <br>external commit was replayed onto the <br>PR branch.                                                                        |
-|      healed-count      | string | Import: number of OSS commits the <br>anchor advanced over because the subtree <br>already held their content while no <br>readable Oss-Commit trailer recorded them. Non-zero <br>means trailers are being lost during <br>merge.  |
-|        oss-tip         | string |                                                                                           Export: the OSS branch tip after <br>the run.                                                                                             |
-|     pending-count      | string |                                                                                Health: number of OSS commits genuinely <br>waiting to be imported.                                                                                  |
-|       pr-branch        | string |                                                                                     Import: the local branch holding the <br>replayed commits.                                                                                      |
-|     push-rejected      | string |                                           Export: true when the push to <br>the OSS branch was rejected by <br>branch protection / a ruleset (the sync identity is not a bypass actor).                                             |
-|         pushed         | string |                                                                                    Export: true when commits were pushed <br>to the OSS branch.                                                                                     |
-|    recorded-anchor     | string |                                             Health: the anchor the Oss-Commit trailers <br>actually record, before content healing. Behind <br>`anchor` when trailers have been lost.                                               |
-|    redundant-count     | string |                                                                 Health: number of OSS commits re-walked <br>on every import because the anchor <br>is behind them.                                                                  |
-|     replayed-count     | string |                                                                                            Import: number of external commits replayed.                                                                                             |
-|     skipped-count      | string |                                   Import: number of external commits considered <br>but not replayed, because they touch <br>only excluded paths or their content <br>is already in the subtree.                                    |
-| squashed-trailer-count | string |                                                       Health: number of sync commits whose <br>Oss-Commit trailer GitHub's squash-merge orphaned from <br>the trailer block.                                                        |
-|      stale-anchor      | string |               Health: true when the recorded trailers <br>lag the subtree content. The import <br>heals this itself; it means the <br>affected external commits carry no recorded <br>provenance on the base branch.                |
-|    suggested-anchor    | string |                                                          Health: the content-derived anchor, i.e. what <br>the import heals to. Empty when <br>the trailers are current.                                                            |
+|           OUTPUT           |  TYPE  |                                                                                                                                      DESCRIPTION                                                                                                                                      |
+|----------------------------|--------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|           anchor           | string |                                                           Health: the OSS commit the import <br>will resume from, after content healing. <br>Empty only when neither a trailer <br>nor the subtree content identifies one.                                                            |
+|        conflict-sha        | string |                                                                                            Import: the OSS commit that failed <br>the 3-way apply, when the run <br>failed on a conflict.                                                                                             |
+|         converged          | string |                                                                                       Health: true when the subtree already <br>holds the OSS branch tip content <br>(ignoring exclude-paths).                                                                                        |
+|          degraded          | string |                                Health: true when a git or <br>network step failed and some figures <br>in this report are therefore incomplete. <br>The health direction never exits non-zero, <br>so gate on this rather than <br>on the job result.                                 |
+|          diverged          | string |                                                                                            Export: true when OSS has external <br>commits not yet absorbed and the <br>run failed closed.                                                                                             |
+|       exported-count       | string |                                                                                           Export: number of commits created on <br>the OSS branch (including an alignment commit, if any).                                                                                            |
+|        has-changes         | string |                                                                                               Import: true when at least one <br>external commit was replayed onto the <br>PR branch.                                                                                                 |
+|        healed-count        | string |                                  Import: number of OSS commits the <br>anchor advanced over because the subtree <br>already held their content. Mostly our <br>own exports; see healed-unrecorded-count for the <br>part that indicates a problem.                                    |
+|    healed-export-count     | string |               Import: of healed-count, the commits we <br>created ourselves (Monorepo-Commit trailer). They never carry <br>an Oss-Commit trailer, so the anchor <br>trails every export until the next <br>import records one past them. Expected, <br>not a finding.                |
+|  healed-unrecorded-count   | string |                                                    Import: of healed-count, the commits carrying <br>neither trailer, i.e. imports whose provenance <br>record was lost. Non-zero means trailers <br>are being lost during merge.                                                     |
+|          oss-tip           | string |                                                                                                                    Export: the OSS branch tip after <br>the run.                                                                                                                      |
+|       pending-count        | string |                                                                                                         Health: number of OSS commits genuinely <br>waiting to be imported.                                                                                                           |
+|         pr-branch          | string |                                                                                                              Import: the local branch holding the <br>replayed commits.                                                                                                               |
+|       push-rejected        | string |                                                                    Export: true when the push to <br>the OSS branch was rejected by <br>branch protection / a ruleset (the sync identity is not a bypass actor).                                                                      |
+|           pushed           | string |                                                                                                             Export: true when commits were pushed <br>to the OSS branch.                                                                                                              |
+|      recorded-anchor       | string |                                                                      Health: the anchor the Oss-Commit trailers <br>actually record, before content healing. Behind <br>`anchor` when trailers have been lost.                                                                        |
+|      redundant-count       | string |                                                                                 Health: number of OSS commits the <br>anchor is behind, i.e. what content <br>healing advances over on every import.                                                                                  |
+|   redundant-export-count   | string |                                                                    Health: of redundant-count, the commits we <br>created ourselves (Monorepo-Commit trailer). Expected after every <br>export, never a finding.                                                                      |
+| redundant-unrecorded-count | string |                                                                       Health: of redundant-count, the external commits <br>carrying no readable Oss-Commit trailer. This <br>is what stale-anchor reports on.                                                                         |
+|       replayed-count       | string |                                                                                                                     Import: number of external commits replayed.                                                                                                                      |
+|       skipped-count        | string |                                                            Import: number of external commits considered <br>but not replayed, because they touch <br>only excluded paths or their content <br>is already in the subtree.                                                             |
+|   squashed-trailer-count   | string |                                                                                Health: number of sync commits whose <br>Oss-Commit trailer GitHub's squash-merge orphaned from <br>the trailer block.                                                                                 |
+|        stale-anchor        | string | Health: true when external commits sit <br>in the subtree with no trailer <br>recording them. The import heals this <br>itself; it means those commits carry <br>no recorded provenance on the base <br>branch. Our own exports lag the <br>anchor by design and never set <br>this.  |
+|      suggested-anchor      | string |                                                                                    Health: the content-derived anchor, i.e. what <br>the import heals to. Empty unless <br>stale-anchor is true.                                                                                      |
 
 <!-- AUTO-DOC-OUTPUT:END -->
 

--- a/.github/actions/oss-commit-sync/action.yml
+++ b/.github/actions/oss-commit-sync/action.yml
@@ -68,8 +68,14 @@ outputs:
     description: "Import: number of external commits considered but not replayed, because they touch only excluded paths or their content is already in the subtree."
     value: ${{ steps.sync.outputs.skipped-count }}
   healed-count:
-    description: "Import: number of OSS commits the anchor advanced over because the subtree already held their content while no readable Oss-Commit trailer recorded them. Non-zero means trailers are being lost during merge."
+    description: "Import: number of OSS commits the anchor advanced over because the subtree already held their content. Mostly our own exports; see healed-unrecorded-count for the part that indicates a problem."
     value: ${{ steps.sync.outputs.healed-count }}
+  healed-export-count:
+    description: "Import: of healed-count, the commits we created ourselves (Monorepo-Commit trailer). They never carry an Oss-Commit trailer, so the anchor trails every export until the next import records one past them. Expected, not a finding."
+    value: ${{ steps.sync.outputs.healed-export-count }}
+  healed-unrecorded-count:
+    description: "Import: of healed-count, the commits carrying neither trailer, i.e. imports whose provenance record was lost. Non-zero means trailers are being lost during merge."
+    value: ${{ steps.sync.outputs.healed-unrecorded-count }}
   conflict-sha:
     description: "Import: the OSS commit that failed the 3-way apply, when the run failed on a conflict."
     value: ${{ steps.sync.outputs.conflict-sha }}
@@ -86,17 +92,23 @@ outputs:
     description: "Health: the anchor the Oss-Commit trailers actually record, before content healing. Behind `anchor` when trailers have been lost."
     value: ${{ steps.sync.outputs.recorded-anchor }}
   stale-anchor:
-    description: "Health: true when the recorded trailers lag the subtree content. The import heals this itself; it means the affected external commits carry no recorded provenance on the base branch."
+    description: "Health: true when external commits sit in the subtree with no trailer recording them. The import heals this itself; it means those commits carry no recorded provenance on the base branch. Our own exports lag the anchor by design and never set this."
     value: ${{ steps.sync.outputs.stale-anchor }}
   suggested-anchor:
-    description: "Health: the content-derived anchor, i.e. what the import heals to. Empty when the trailers are current."
+    description: "Health: the content-derived anchor, i.e. what the import heals to. Empty unless stale-anchor is true."
     value: ${{ steps.sync.outputs.suggested-anchor }}
   pending-count:
     description: "Health: number of OSS commits genuinely waiting to be imported."
     value: ${{ steps.sync.outputs.pending-count }}
   redundant-count:
-    description: "Health: number of OSS commits re-walked on every import because the anchor is behind them."
+    description: "Health: number of OSS commits the anchor is behind, i.e. what content healing advances over on every import."
     value: ${{ steps.sync.outputs.redundant-count }}
+  redundant-export-count:
+    description: "Health: of redundant-count, the commits we created ourselves (Monorepo-Commit trailer). Expected after every export, never a finding."
+    value: ${{ steps.sync.outputs.redundant-export-count }}
+  redundant-unrecorded-count:
+    description: "Health: of redundant-count, the external commits carrying no readable Oss-Commit trailer. This is what stale-anchor reports on."
+    value: ${{ steps.sync.outputs.redundant-unrecorded-count }}
   squashed-trailer-count:
     description: "Health: number of sync commits whose Oss-Commit trailer GitHub's squash-merge orphaned from the trailer block."
     value: ${{ steps.sync.outputs.squashed-trailer-count }}

--- a/.github/actions/oss-commit-sync/health.sh
+++ b/.github/actions/oss-commit-sync/health.sh
@@ -12,6 +12,9 @@ set -euo pipefail
 #      anchor from the subtree content when the trailers lag, so a lag is
 #      harmless to the sync but means those external commits carry no recorded
 #      provenance on the base branch, and that trailers are being lost somewhere.
+#      Counted only over commits carrying neither trailer: the anchor also trails
+#      our own exports (Monorepo-Commit, never Oss-Commit), which is the steady
+#      state after every export rather than a sign of anything lost.
 #
 #   2. Was a sync PR squash-merged? GitHub's squash appends "Co-authored-by:" as
 #      a new paragraph, which orphans our trailer from the block git's own
@@ -28,7 +31,8 @@ set -euo pipefail
 # Optional env: EXCLUDE_PATHS, GITHUB_OUTPUT, GITHUB_STEP_SUMMARY.
 #
 # Outputs: converged, anchor, recorded-anchor, stale-anchor, suggested-anchor,
-# pending-count, redundant-count, squashed-trailer-count, degraded.
+# pending-count, redundant-count, redundant-export-count,
+# redundant-unrecorded-count, squashed-trailer-count, degraded.
 #
 # Never exits non-zero: an advisory check must not red the caller's job. When a
 # git or network step fails it warns, sets degraded=true, and returns 0 with
@@ -52,6 +56,8 @@ emit stale-anchor false
 emit suggested-anchor ""
 emit pending-count 0
 emit redundant-count 0
+emit redundant-export-count 0
+emit redundant-unrecorded-count 0
 emit squashed-trailer-count 0
 emit degraded false
 
@@ -100,13 +106,23 @@ fi
 # an outage: trailers are being lost somewhere (a squash, a hand-edited message,
 # a hand-made import), and until that stops, each run re-derives the anchor and
 # the affected external commits carry no recorded provenance.
+#
+# Staleness is judged on the unrecorded commits alone. The healed range also
+# holds our own exports, which carry Monorepo-Commit and by design never an
+# Oss-Commit trailer, so the anchor trails every export until the next import
+# records a trailer past it. Counting those as staleness would report a lag on a
+# perfectly healthy sync, permanently, and bury the case that does need a look.
 redundant="$IMPORT_ANCHOR_HEALED"
+redundant_exports="$IMPORT_ANCHOR_HEALED_EXPORTS"
+redundant_unrecorded="$IMPORT_ANCHOR_HEALED_UNRECORDED"
 stale=false
-if [ "$redundant" -gt 0 ]; then
+if [ "$redundant_unrecorded" -gt 0 ]; then
   stale=true
   emit suggested-anchor "$ANCHOR"
 fi
 emit redundant-count "$redundant"
+emit redundant-export-count "$redundant_exports"
+emit redundant-unrecorded-count "$redundant_unrecorded"
 emit stale-anchor "$stale"
 
 # --- genuinely pending externals --------------------------------------------
@@ -189,6 +205,8 @@ emit degraded "$degraded"
   echo "| Recorded by a trailer | \`${RECORDED:-none}\` |"
   echo "| Commits pending import | ${pending} |"
   echo "| Commits the anchor heals over | ${redundant} |"
+  echo "| ... our own exports (expected) | ${redundant_exports} |"
+  echo "| ... imports with no trailer | ${redundant_unrecorded} |"
   echo "| Squash-orphaned trailers | ${squashed} |"
 } >> "$GITHUB_STEP_SUMMARY"
 
@@ -204,17 +222,17 @@ fi
 if [ "$stale" = "true" ]; then
   {
     echo
-    echo "The recorded anchor lags the subtree by ${redundant} commit(s). The import"
-    echo "heals this from content on every run, so nothing is broken and no repair"
-    echo "is needed. It does mean those external commits carry no recorded"
-    echo "provenance on \`${BRANCH}\`, which points at trailers being lost during"
-    echo "merge: check the squash count above."
+    echo "${redundant_unrecorded} external commit(s) are in the subtree with no trailer"
+    echo "recording them. The import heals this from content on every run, so nothing"
+    echo "is broken and no repair is needed. It does mean those commits carry no"
+    echo "recorded provenance on \`${BRANCH}\`, which points at trailers being lost"
+    echo "during merge: check the squash count above."
   } >> "$GITHUB_STEP_SUMMARY"
-  echo "::notice::Recorded anchor ${RECORDED} lags content by ${redundant} commit(s); the import heals to ${ANCHOR} automatically. Provenance for those commits is not recorded on ${BRANCH}."
+  echo "::notice::${redundant_unrecorded} external commit(s) are present in ${SUBTREE_PREFIX} with no readable ${OSS_TRAILER} trailer; the import heals the anchor from ${RECORDED} to ${ANCHOR} automatically, but provenance for those commits is not recorded on ${BRANCH}."
 fi
 
 if [ -n "$first_pending" ]; then
   echo "Oldest OSS commit pending import: ${first_pending}"
 fi
 
-echo "Health: converged=${converged} anchor=${ANCHOR:-none} pending=${pending} redundant=${redundant} squash-orphaned=${squashed}"
+echo "Health: converged=${converged} anchor=${ANCHOR:-none} pending=${pending} redundant=${redundant} (exports=${redundant_exports} unrecorded=${redundant_unrecorded}) squash-orphaned=${squashed}"

--- a/.github/actions/oss-commit-sync/import.sh
+++ b/.github/actions/oss-commit-sync/import.sh
@@ -29,7 +29,9 @@ set -euo pipefail
 # which is invisible while each commit still applies as a no-op and then becomes
 # a hard conflict once a later OSS commit touches the same lines as an earlier
 # one. Commits after the healed anchor are still imported normally, so nothing is
-# skipped silently.
+# skipped silently. Most of what it heals over is our own exports, which carry
+# Monorepo-Commit and by design never an Oss-Commit trailer, so the counts are
+# reported split: only commits with neither trailer mean a record was lost.
 #
 # Diff replay (not tree snapshots) means an external commit never reverts
 # monorepo changes that have not been exported yet: only the external
@@ -47,7 +49,7 @@ set -euo pipefail
 # PR_BRANCH (default automation/sync-from-oss-<branch>), GITHUB_OUTPUT.
 #
 # Outputs: has-changes, replayed-count, skipped-count, healed-count,
-# conflict-sha, pr-branch.
+# healed-export-count, healed-unrecorded-count, conflict-sha, pr-branch.
 
 source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
@@ -65,6 +67,8 @@ emit has-changes false
 emit replayed-count 0
 emit skipped-count 0
 emit healed-count 0
+emit healed-export-count 0
+emit healed-unrecorded-count 0
 emit conflict-sha ""
 emit pr-branch "$PR_BRANCH"
 
@@ -85,6 +89,8 @@ resolve_import_anchor "$OSS_TIP" \
   || die "failed to resolve the import anchor for OSS ${BRANCH} (git error); refusing to import from an unknown point"
 RESUME="$IMPORT_ANCHOR"
 healed="$IMPORT_ANCHOR_HEALED"
+healed_exports="$IMPORT_ANCHOR_HEALED_EXPORTS"
+healed_unrecorded="$IMPORT_ANCHOR_HEALED_UNRECORDED"
 
 if [ "$IMPORT_ANCHOR_SEED_BAD" = "true" ]; then
   die "SEED_OSS_COMMIT ${SEED_OSS_COMMIT} is not a commit reachable from OSS ${BRANCH} tip"
@@ -97,10 +103,20 @@ if [ -z "$RESUME" ]; then
   die "no ${OSS_TRAILER} trailer found on ${BRANCH} and no SEED_OSS_COMMIT provided for the first run"
 fi
 
-if [ "$healed" -gt 0 ]; then
-  echo "::notice::Anchor healed from content: ${IMPORT_ANCHOR_RECORDED:-none} -> ${RESUME} (${healed} OSS commit(s) already present in ${SUBTREE_PREFIX} but not recorded by a readable ${OSS_TRAILER} trailer)."
+# Only unrecorded commits are a finding. Healing over our own exports is the
+# steady state of a healthy sync: an OSS commit we created carries
+# Monorepo-Commit and never an Oss-Commit trailer, so the anchor trails every
+# export until the next import records a trailer past it. Annotating that as
+# "not recorded by a readable trailer" reads as trailer damage on a run where
+# nothing is wrong, and it fires after every single export.
+if [ "$healed_unrecorded" -gt 0 ]; then
+  echo "::notice::Anchor healed from content: ${IMPORT_ANCHOR_RECORDED:-none} -> ${RESUME} (${healed_unrecorded} OSS commit(s) already present in ${SUBTREE_PREFIX} that no readable ${OSS_TRAILER} trailer records, plus ${healed_exports} of our own export(s)). Those imports lost their provenance record: check the merge method on the sync PRs."
+elif [ "$healed" -gt 0 ]; then
+  echo "Anchor advanced ${IMPORT_ANCHOR_RECORDED:-none} -> ${RESUME} over ${healed} of our own export(s), whose content ${SUBTREE_PREFIX} already holds. Expected after every export; nothing to do."
 fi
 emit healed-count "$healed"
+emit healed-export-count "$healed_exports"
+emit healed-unrecorded-count "$healed_unrecorded"
 
 if [ "$RESUME" = "$OSS_TIP" ]; then
   emit skipped-count "$healed"

--- a/.github/actions/oss-commit-sync/lib.sh
+++ b/.github/actions/oss-commit-sync/lib.sh
@@ -214,6 +214,43 @@ content_anchor() {
   return 0
 }
 
+# classify_healed_range <recorded-anchor> <healed-anchor>
+# Split the commits the anchor advanced over into the two cases that produce an
+# identical count but mean opposite things:
+#
+#   exports     commits we created ourselves (Monorepo-Commit trailer). They
+#               never carry an Oss-Commit trailer, because that trailer records
+#               an import and these went the other way. The anchor therefore
+#               trails every export until the next import records a trailer past
+#               them, and healing over them is the steady state, not a fault.
+#   unrecorded  commits with neither trailer: an import whose provenance record
+#               was lost (a squash that dropped the trailer, a hand-made import).
+#               This is the only case worth an annotation.
+#
+# Results in globals HEALED_TOTAL, HEALED_EXPORTS, HEALED_UNRECORDED (the last
+# two sum to the first). Returns non-zero on a git failure so callers can fail
+# closed rather than under-report.
+classify_healed_range() {
+  local from="$1" to="$2" range c
+  HEALED_TOTAL=0
+  HEALED_EXPORTS=0
+  HEALED_UNRECORDED=0
+  # Captured rather than piped from a process substitution: `set -e` cannot see a
+  # producer failure inside `done < <(...)`, so a broken rev-list would run the
+  # loop zero times and report a healed range of nothing.
+  range="$(git rev-list --first-parent "${from}..${to}")" || return 1
+  while read -r c; do
+    [ -n "$c" ] || continue
+    HEALED_TOTAL=$((HEALED_TOTAL + 1))
+    if has_trailer "$c" "$MONOREPO_TRAILER"; then
+      HEALED_EXPORTS=$((HEALED_EXPORTS + 1))
+    else
+      HEALED_UNRECORDED=$((HEALED_UNRECORDED + 1))
+    fi
+  done <<< "$range"
+  return 0
+}
+
 # resolve_import_anchor <oss-tip>
 # The single definition of where an import resumes. Both the import and the
 # health direction call it, so the two can never disagree about where the sync
@@ -229,6 +266,11 @@ content_anchor() {
 #                           empty when nothing identifies a starting point
 #   IMPORT_ANCHOR_RECORDED  what the trailers alone record, before healing
 #   IMPORT_ANCHOR_HEALED    how many commits healing advanced over
+#   IMPORT_ANCHOR_HEALED_EXPORTS     of those, how many we created ourselves
+#                           (Monorepo-Commit trailer); expected, see
+#                           classify_healed_range
+#   IMPORT_ANCHOR_HEALED_UNRECORDED  of those, how many carry neither trailer,
+#                           i.e. imports whose provenance record was lost
 #   IMPORT_ANCHOR_SAW_TRAILER  true when any Oss-Commit trailer exists, so
 #                           callers can tell "never synced" from "recorded
 #                           anchor no longer reachable on OSS"
@@ -249,6 +291,8 @@ resolve_import_anchor() {
   IMPORT_ANCHOR=""
   IMPORT_ANCHOR_RECORDED=""
   IMPORT_ANCHOR_HEALED=0
+  IMPORT_ANCHOR_HEALED_EXPORTS=0
+  IMPORT_ANCHOR_HEALED_UNRECORDED=0
   IMPORT_ANCHOR_SAW_TRAILER=false
   IMPORT_ANCHOR_SEED_BAD=false
 
@@ -283,7 +327,10 @@ resolve_import_anchor() {
 
   healed="$(content_anchor "$best" "$oss_tip")" || return 1
   if [ -n "$healed" ] && [ "$healed" != "$best" ]; then
-    IMPORT_ANCHOR_HEALED="$(git rev-list --count --first-parent "${best}..${healed}")"
+    classify_healed_range "$best" "$healed" || return 1
+    IMPORT_ANCHOR_HEALED="$HEALED_TOTAL"
+    IMPORT_ANCHOR_HEALED_EXPORTS="$HEALED_EXPORTS"
+    IMPORT_ANCHOR_HEALED_UNRECORDED="$HEALED_UNRECORDED"
     best="$healed"
   fi
   IMPORT_ANCHOR="$best"

--- a/.github/actions/oss-commit-sync/test/health.bats
+++ b/.github/actions/oss-commit-sync/test/health.bats
@@ -49,9 +49,30 @@ teardown() {
   [ "$(output_value recorded-anchor)" = "$O0" ]
   [ "$(output_value anchor)" = "$E1" ]
   [ "$(output_value redundant-count)" = "1" ]
+  [ "$(output_value redundant-unrecorded-count)" = "1" ]
+  [ "$(output_value redundant-export-count)" = "0" ]
   [ "$(output_value pending-count)" = "0" ]
   # Reported as a notice, not a warning: nothing is broken.
   [[ "$output" == *"heals"* ]]
+}
+
+@test "the anchor trailing our own exports is not staleness" {
+  # The anchor lags by design after every export: the OSS commits we created
+  # carry Monorepo-Commit and never an Oss-Commit trailer, so nothing records
+  # them as imports and nothing should. Flagging this would put a permanent lag
+  # on a healthy sync and bury the unrecorded-import case underneath it.
+  company_commit pkg/app.go "l1-company" "feat: company change" >/dev/null
+  bash "$EXPORT"
+
+  run bash "$HEALTH"
+  [ "$status" -eq 0 ]
+  [ "$(output_value converged)" = "true" ]
+  [ "$(output_value redundant-count)" = "1" ]
+  [ "$(output_value redundant-export-count)" = "1" ]
+  [ "$(output_value redundant-unrecorded-count)" = "0" ]
+  [ "$(output_value stale-anchor)" = "false" ]
+  [ -z "$(output_value suggested-anchor)" ]
+  [ "$(output_value squashed-trailer-count)" = "0" ]
 }
 
 @test "the healed anchor stops at the newest commit the subtree matches" {

--- a/.github/actions/oss-commit-sync/test/import.bats
+++ b/.github/actions/oss-commit-sync/test/import.bats
@@ -40,6 +40,44 @@ teardown() {
   [ "$(output_value replayed-count)" = "0" ]
 }
 
+@test "healing over our own exports is not reported as a lost trailer" {
+  # The steady state after any export: the OSS commits we just created are in the
+  # subtree (that is where they came from) and carry Monorepo-Commit, never an
+  # Oss-Commit trailer, so the anchor heals over them on the next import. That is
+  # not trailer damage, and an annotation claiming it is fires after every export
+  # and trains everyone to ignore the one that matters.
+  company_commit pkg/app.go "l1-company" "feat: company change" >/dev/null
+  company_commit pkg/other.go "more" "feat: second company change" >/dev/null
+  bash "$EXPORT"
+
+  run bash "$IMPORT"
+  [ "$status" -eq 0 ]
+  [ "$(output_value healed-count)" = "2" ]
+  [ "$(output_value healed-export-count)" = "2" ]
+  [ "$(output_value healed-unrecorded-count)" = "0" ]
+  [[ "$output" != *"::notice::"* ]]
+  [[ "$output" == *"our own export"* ]]
+}
+
+@test "a mixed healed range separates our exports from unrecorded imports" {
+  # Both causes at once, which is what production actually looks like: an import
+  # whose trailer a squash dropped, then our own exports on top. The count that
+  # drives the annotation must be the unrecorded one alone.
+  external_commit ext1.go "one" "feat: alice first" >/dev/null
+  bash "$IMPORT"
+  squash_merge_pr_branch "chore: sync from oss (#42)"
+  company_commit pkg/app.go "l1-company" "feat: company change" >/dev/null
+  bash "$EXPORT"
+
+  git -C "$MONO" switch -q main
+  run bash "$IMPORT"
+  [ "$status" -eq 0 ]
+  [ "$(output_value healed-count)" = "2" ]
+  [ "$(output_value healed-export-count)" = "1" ]
+  [ "$(output_value healed-unrecorded-count)" = "1" ]
+  [[ "$output" == *"::notice::Anchor healed from content"* ]]
+}
+
 @test "exclusion: producer workflow edits are dropped from a mixed commit" {
   external_commit .github/workflows/release.yaml "producer-edit" "chore: producer only" >/dev/null
   # A genuinely mixed commit: excluded workflow + real code in one commit.

--- a/.github/actions/oss-commit-sync/test/squash-tolerance.bats
+++ b/.github/actions/oss-commit-sync/test/squash-tolerance.bats
@@ -137,6 +137,10 @@ Co-authored-by: alice <alice@contributor.example>"
   [ -z "$(output_value conflict-sha)" ]
   # Anchor healed over E1 ...
   [ "$(output_value healed-count)" = "1" ]
+  # ... classified as a lost record, which is the case worth annotating.
+  [ "$(output_value healed-unrecorded-count)" = "1" ]
+  [ "$(output_value healed-export-count)" = "0" ]
+  [[ "$output" == *"::notice::Anchor healed from content"* ]]
   # ... and E2 was still imported, with its authorship and trailer intact.
   [ "$(output_value replayed-count)" = "1" ]
   [ "$(output_value has-changes)" = "true" ]


### PR DESCRIPTION
## Summary

A green `sync-from-oss` run on `vcluster-pro` printed:

```
::notice::Anchor healed from content: 887d668e -> c6abe8ca (4 OSS commit(s) already
present in staging/github.com/loft-sh/vcluster but not recorded by a readable
Oss-Commit trailer).
```

All 4 commits carried a `Monorepo-Commit` trailer: our own exports. Their content is in `staging/` because that is where it was authored, and they will never carry an `Oss-Commit` trailer, because that trailer records an *import*. `content_anchor` did not distinguish them from external commits, so the notice fired after every export with a count that grew until the next external import recorded a fresh trailer, and `health` reported the same range as `stale-anchor`.

A genuine trailer loss (squash-merged sync PR) produces the identical message, so the annotation that has to stay trustworthy was the one crying wolf.

- `classify_healed_range` splits the healed range by provenance: `Monorepo-Commit` present means our export (expected), neither trailer means an import whose record was lost.
- Import annotates only the unrecorded case and points at the merge method; healing over our own exports is a plain log line.
- Health judges `stale-anchor` on the unrecorded count alone and reports both classes in the step summary.
- New outputs: `healed-export-count`, `healed-unrecorded-count`, `redundant-export-count`, `redundant-unrecorded-count`. `healed-count` / `redundant-count` keep their totals.

## Test plan

- `make test-oss-commit-sync` — 64 tests pass, including three new cases: export-only healing (no `::notice::`), a mixed range (1 export + 1 unrecorded, notice fires), and health treating an export-only lag as `stale-anchor=false`. The existing lost-trailer case now also asserts the unrecorded classification.
- `make check-docs` clean, `make lint` (actionlint + zizmor) clean, `shellcheck` adds no new findings.

## Follow-up

Merging does not ship this: `oss-commit-sync/v1` must be advanced to the merged commit, otherwise `vcluster-pro`'s `sync-from-oss` and `sync-to-oss` keep running the old code.

Closes DEVOPS-1238