### PR TITLE
fix(auto-approve-bot-prs): merge directly and surface skips that need action

### DIFF
--- a/.github/actions/auto-approve-bot-prs/README.md
+++ b/.github/actions/auto-approve-bot-prs/README.md
@@ -181,6 +181,21 @@ default token, say), pass `ci-read-token` instead: a classic PAT with `repo`
 scope, or a GitHub App token. Both can reach the Checks API. A fine-grained PAT
 cannot, so `github-token` is never a valid value for it.
 
+## Log safety
+
+Everything this action reports is externally controlled: `gh`'s output is
+GitHub's, check-run names and commit-status contexts belong to whoever posted
+them, the authenticated login comes from the API, and `merge-method` comes from
+the calling workflow. A bare CR in any of those is enough to forge an
+annotation, because CR terminates a log line for the runner and a line starting
+`::` is parsed as a workflow command.
+
+So every such value goes through `safe`/`sanitize_for_log` from
+`src/lib/log.sh` before it reaches a log line — one rule for the whole action,
+rather than a per-field argument about which API fields are trustworthy. If
+that lib is missing the scripts fail loudly instead of falling back to
+unsanitized output, since a silent fallback would reopen every channel at once.
+
 ## Testing
 
 ```bash
@@ -188,3 +203,6 @@ make test-auto-approve-bot-prs
 ```
 
 Runs the bats suites in `test/` against the shell scripts in `src/`.
+Assertions that must be able to fail live in `test/assertions.bash`: a bare
+`! grep` is inert under the `set -e` bats runs test bodies with, so negative
+assertions use `assert_no_match`.

--- a/.github/actions/auto-approve-bot-prs/README.md
+++ b/.github/actions/auto-approve-bot-prs/README.md
@@ -75,16 +75,38 @@ which is routinely minutes after the floor expires — the bail then discards a
 rerun that was still coming. That stalled the `v0.34.7` cut
 (vcluster-pro#2155): floor expired 12:49:45, replacement registered 12:51:41.
 
+## Merging
+
+With `auto-merge: true` the action tries a **plain merge first**, and uses
+GitHub's auto-merge queue (`--auto`) only as a fallback.
+
+By the time the merge step runs, every other check is already green and the PR
+is approved, so there is normally nothing left for the queue to wait on.
+`--auto` additionally requires the repository's `allow_auto_merge` setting,
+which is invisible from here and silently turns the merge into a no-op when it
+is off — and a merge that never happens strands whatever is waiting on it (the
+`vcluster-release` orchestrator blocks on exactly this merge during a legacy
+release cut).
+
+`--auto` still has a job: a required check that registered *after* the CI wait
+declared green legitimately refuses a merge right now but can complete later.
+Queueing is the right answer there, so a refused plain merge degrades to it.
+
+A PR that is approved but ends up merged by neither path is annotated at
+**error** level, carrying both underlying `gh` errors, since this is the only
+place that cause is knowable. Re-runs stay quiet: an already-merged PR is
+benign, and a PR closed unmerged is a human decision.
+
 ## Inputs
 
 <!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
 
 |       INPUT        |  TYPE  | REQUIRED |                    DEFAULT                     |                                                                                                DESCRIPTION                                                                                                 |
 |--------------------|--------|----------|------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-|     auto-merge     | string |  false   |                   `"false"`                    |                                                                                  Enable GitHub auto-merge after approval                                                                                   |
+|     auto-merge     | string |  false   |                   `"false"`                    |                                                            Merge the PR after approving it, <br>directly where possible. See README "Merging".                                                             |
 |   ci-read-token    | string |  false   |                                                | Token for the read-only CI poll <br>only; defaults to the caller GITHUB_TOKEN, <br>which needs `checks: read` and `statuses: read`. Never <br>the approving PAT. See README "Two <br>tokens, on purpose".  |
 |    github-token    | string |   true   |                                                |                                                     PAT used to read PR state, <br>approve, and enable auto-merge. Must NOT <br>match the PR author.                                                       |
-|    merge-method    | string |  false   |                   `"squash"`                   |                                                                             Merge method for auto-merge (squash|merge|rebase)                                                                              |
+|    merge-method    | string |  false   |                   `"squash"`                   |                                                                                     Merge method (squash|merge|rebase)                                                                                     |
 |  trusted-authors   | string |  false   | `"renovate[bot],loft-bot,github-actions[bot]"` |                                                                                 Comma-separated list of trusted bot logins                                                                                 |
 | wait-max-attempts  | string |  false   |                     `"90"`                     |                                                                           Max polling attempts waiting for other <br>CI checks                                                                             |
 | wait-min-attempts  | string |  false   |                     `"12"`                     |                             Minimum polls before ci_green=true is allowed. <br>Prevents early approval while slow external <br>checks (e.g. Netlify) have not yet registered.                              |

--- a/.github/actions/auto-approve-bot-prs/README.md
+++ b/.github/actions/auto-approve-bot-prs/README.md
@@ -92,25 +92,42 @@ release cut).
 declared green legitimately refuses a merge right now but can complete later.
 Queueing is the right answer there, so a refused plain merge degrades to it.
 
+A successful queue is **not** a promise that the PR lands. Other refusals reach
+the same fallback and need a human, not patience: a strict "must be up to date
+with base" rule with no auto-update queues indefinitely; a conflict introduced by
+a base commit landing during the CI wait (up to ~15 min at the default
+90 × 10 s) needs the rebase `check-pr-ready.sh` asks for; and `allow_auto_merge`
+being off makes the queue request itself the silent no-op this ordering exists to
+avoid. So the queued warning names what to check rather than asserting the merge
+will complete on its own.
+
+Each merge call is retried **once** after a short sleep. By this point the run
+has already made up to 90 CI polls, up to 10 mergeability polls and the approval
+call, so secondary rate limiting is a live risk, and the two merge attempts would
+otherwise fire back-to-back — one blip could take out both and escalate a
+transient failure as though it were a policy refusal.
+
 A PR that is approved but ends up merged by neither path is annotated at
 **error** level, carrying both underlying `gh` errors, since this is the only
-place that cause is knowable. Re-runs stay quiet: an already-merged PR is
-benign, and a PR closed unmerged is a human decision.
+place that cause is knowable. Those two reasons are the diagnosis; the
+branch-protection checklist that follows them applies only if they point at
+policy rather than a transient API error. Re-runs stay quiet: an already-merged
+PR is benign, and a PR closed unmerged is a human decision.
 
 ## Inputs
 
 <!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
 
-|       INPUT        |  TYPE  | REQUIRED |                    DEFAULT                     |                                                                                                DESCRIPTION                                                                                                 |
-|--------------------|--------|----------|------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-|     auto-merge     | string |  false   |                   `"false"`                    |                                                            Merge the PR after approving it, <br>directly where possible. See README "Merging".                                                             |
-|   ci-read-token    | string |  false   |                                                | Token for the read-only CI poll <br>only; defaults to the caller GITHUB_TOKEN, <br>which needs `checks: read` and `statuses: read`. Never <br>the approving PAT. See README "Two <br>tokens, on purpose".  |
-|    github-token    | string |   true   |                                                |                                                     PAT used to read PR state, <br>approve, and enable auto-merge. Must NOT <br>match the PR author.                                                       |
-|    merge-method    | string |  false   |                   `"squash"`                   |                                                                                     Merge method (squash|merge|rebase)                                                                                     |
-|  trusted-authors   | string |  false   | `"renovate[bot],loft-bot,github-actions[bot]"` |                                                                                 Comma-separated list of trusted bot logins                                                                                 |
-| wait-max-attempts  | string |  false   |                     `"90"`                     |                                                                           Max polling attempts waiting for other <br>CI checks                                                                             |
-| wait-min-attempts  | string |  false   |                     `"12"`                     |                             Minimum polls before ci_green=true is allowed. <br>Prevents early approval while slow external <br>checks (e.g. Netlify) have not yet registered.                              |
-| wait-sleep-seconds | string |  false   |                     `"10"`                     |                                                                                      Seconds between polling attempts                                                                                      |
+|       INPUT        |  TYPE  | REQUIRED |                    DEFAULT                     |                                                                                                          DESCRIPTION                                                                                                           |
+|--------------------|--------|----------|------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|     auto-merge     | string |  false   |                   `"false"`                    |                                                                      Merge the PR after approving it, <br>directly where possible. See README "Merging".                                                                       |
+|   ci-read-token    | string |  false   |                                                |           Token for the read-only CI poll <br>only; defaults to the caller GITHUB_TOKEN, <br>which needs `checks: read` and `statuses: read`. Never <br>the approving PAT. See README "Two <br>tokens, on purpose".            |
+|    github-token    | string |   true   |                                                | PAT used to read PR state, <br>approve, and — when auto-merge is <br>true — merge the PR directly, <br>so it needs a merge path <br>on the base branch, not just <br>the auto-merge toggle. Must NOT match <br>the PR author.  |
+|    merge-method    | string |  false   |                   `"squash"`                   |                                                                                               Merge method (squash|merge|rebase)                                                                                               |
+|  trusted-authors   | string |  false   | `"renovate[bot],loft-bot,github-actions[bot]"` |                                                                                           Comma-separated list of trusted bot logins                                                                                           |
+| wait-max-attempts  | string |  false   |                     `"90"`                     |                                                                                     Max polling attempts waiting for other <br>CI checks                                                                                       |
+| wait-min-attempts  | string |  false   |                     `"12"`                     |                                       Minimum polls before ci_green=true is allowed. <br>Prevents early approval while slow external <br>checks (e.g. Netlify) have not yet registered.                                        |
+| wait-sleep-seconds | string |  false   |                     `"10"`                     |                                                                                                Seconds between polling attempts                                                                                                |
 
 <!-- AUTO-DOC-INPUT:END -->
 
@@ -204,5 +221,6 @@ make test-auto-approve-bot-prs
 
 Runs the bats suites in `test/` against the shell scripts in `src/`.
 Assertions that must be able to fail live in `test/assertions.bash`: a bare
-`! grep` is inert under the `set -e` bats runs test bodies with, so negative
-assertions use `assert_no_match`.
+`! grep` is inert under the `set -e` that bats runs test bodies with, so negative
+assertions use `assert_no_match`. This applies to negated *helper functions* too,
+not just inline `grep`.

--- a/.github/actions/auto-approve-bot-prs/action.yml
+++ b/.github/actions/auto-approve-bot-prs/action.yml
@@ -21,7 +21,7 @@ inputs:
     required: false
     default: 'false'
   github-token:
-    description: 'PAT used to read PR state, approve, and enable auto-merge. Must NOT match the PR author.'
+    description: 'PAT used to read PR state, approve, and — when auto-merge is true — merge the PR directly, so it needs a merge path on the base branch, not just the auto-merge toggle. Must NOT match the PR author.'
     required: true
   ci-read-token:
     description: 'Token for the read-only CI poll only; defaults to the caller GITHUB_TOKEN, which needs `checks: read` and `statuses: read`. Never the approving PAT. See README "Two tokens, on purpose".'
@@ -92,7 +92,7 @@ runs:
 
           For more information, see https://github.com/loft-sh/github-actions?tab=readme-ov-file#auto-approve-bot-prs.
 
-    - name: Enable auto-merge
+    - name: Merge PR
       if: steps.ci.outputs.ci_green == 'true' && inputs.auto-merge == 'true'
       shell: bash
       env:

--- a/.github/actions/auto-approve-bot-prs/action.yml
+++ b/.github/actions/auto-approve-bot-prs/action.yml
@@ -13,11 +13,11 @@ inputs:
     required: false
     default: 'renovate[bot],loft-bot,github-actions[bot]'
   merge-method:
-    description: 'Merge method for auto-merge (squash|merge|rebase)'
+    description: 'Merge method (squash|merge|rebase)'
     required: false
     default: 'squash'
   auto-merge:
-    description: 'Enable GitHub auto-merge after approval'
+    description: 'Merge the PR after approving it, directly where possible. See README "Merging".'
     required: false
     default: 'false'
   github-token:

--- a/.github/actions/auto-approve-bot-prs/src/check-eligibility.sh
+++ b/.github/actions/auto-approve-bot-prs/src/check-eligibility.sh
@@ -11,6 +11,14 @@ set -euo pipefail
 PR_TITLE="${PR_TITLE:-}"
 PR_BRANCH="${PR_BRANCH:-}"
 
+# This is step 1 of the composite and runs BEFORE any trust gate, so PR_TITLE and
+# PR_BRANCH are the most caller-influenced strings the action handles — anyone who
+# can open a non-fork PR against a calling repo picks them. Both are echoed back
+# on the reject paths below, so a bare CR in either would forge a workflow
+# command. Same lib, same rule, as the other three scripts. See lib/log.sh.
+# shellcheck source=.github/actions/auto-approve-bot-prs/src/lib/log.sh
+. "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/lib/log.sh"
+
 emit() {
   local k="$1" v="$2"
   [ -n "${GITHUB_OUTPUT:-}" ] && printf '%s=%s\n' "$k" "$v" >> "$GITHUB_OUTPUT"
@@ -27,7 +35,7 @@ for a in "${AUTHORS[@]}"; do
 done
 
 if [ "$author_trusted" != "true" ]; then
-  echo "::notice::Author '$PR_AUTHOR' not in trusted list"
+  echo "::notice::Author '$(safe "$PR_AUTHOR")' not in trusted list"
   emit eligible false
   emit reason ""
   exit 0
@@ -43,7 +51,7 @@ elif [[ "$PR_BRANCH" =~ ^update-platform-version- ]]; then eligible=true; reason
 fi
 
 if [ "$eligible" != "true" ]; then
-  echo "::notice::PR not in auto-approve patterns (title='$PR_TITLE' branch='$PR_BRANCH')"
+  echo "::notice::PR not in auto-approve patterns (title='$(safe "$PR_TITLE")' branch='$(safe "$PR_BRANCH")')"
 fi
 
 emit eligible "$eligible"

--- a/.github/actions/auto-approve-bot-prs/src/check-pr-ready.sh
+++ b/.github/actions/auto-approve-bot-prs/src/check-pr-ready.sh
@@ -20,25 +20,52 @@ emit() {
 # mergeable can be null briefly while GitHub computes metadata. Rerun context
 # makes this worse — observed runs where the first ~9s window returned null
 # even though the PR had been mergeable for hours. Budget ~30s before giving up.
+#
+# The filter must NOT be `.mergeable // "null"`: jq's `//` treats false as an
+# empty value, so a genuine `mergeable: false` (a real merge conflict) came back
+# as "null" and was indistinguishable from "GitHub has not computed this yet" —
+# which also meant a conflicted PR burned the whole retry budget re-polling a
+# value that was already definitive.
 mergeable="null"
 mergeable_attempts="${MERGEABLE_MAX_ATTEMPTS:-10}"
 mergeable_sleep="${MERGEABLE_SLEEP_SECONDS:-3}"
 for _ in $(seq 1 "$mergeable_attempts"); do
-  mergeable=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.mergeable // "null"' 2>/dev/null || echo "null")
+  mergeable=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" \
+    --jq '.mergeable | if . == null then "null" else tostring end' 2>/dev/null || echo "null")
   [ "$mergeable" != "null" ] && break
   sleep "$mergeable_sleep"
 done
 
+# Both outcomes below stop the run, but they need different responses, so they
+# are reported separately rather than as one notice: a conflict needs someone to
+# rebase the PR, whereas exhausting the metadata budget is transient and a re-run
+# is likely to succeed.
+if [ "$mergeable" = "false" ]; then
+  echo "::warning::PR #${PR_NUMBER} has merge conflicts with its base branch; not approving. It needs a rebase before this can proceed"
+  emit proceed false
+  exit 0
+fi
 if [ "$mergeable" != "true" ]; then
-  echo "::notice::PR mergeability is '$mergeable', skipping"
+  echo "::warning::GitHub did not report mergeability for PR #${PR_NUMBER} within ${mergeable_attempts} attempts (last value '${mergeable}'); not approving. This is usually transient - a re-run should resolve it"
   emit proceed false
   exit 0
 fi
 
 # GitHub forbids self-approval. Pre-empt hmarr's 422 setFailed path.
+#
+# Split from the identity check below because an unusable token and a
+# same-identity token are different problems: the first means GH_TOKEN is
+# expired or lacks scope, the second means the caller passed the PR author's own
+# credentials. Both are misconfigurations that can never succeed on a retry,
+# hence ::error:: rather than a notice.
 approver=$(gh api user --jq '.login' 2>/dev/null || echo "")
-if [ -z "$approver" ] || [ "$approver" = "$PR_AUTHOR" ]; then
-  echo "::notice::Skipping approval (approver='$approver' author='$PR_AUTHOR')"
+if [ -z "$approver" ]; then
+  echo "::error::could not resolve the authenticated user from the supplied token; not approving PR #${PR_NUMBER}. The token is likely expired or missing the scope needed to read the current user"
+  emit proceed false
+  exit 0
+fi
+if [ "$approver" = "$PR_AUTHOR" ]; then
+  echo "::error::the approving identity ('${approver}') is the author of PR #${PR_NUMBER}; GitHub forbids self-approval. Pass a token belonging to a different identity than the PR author"
   emit proceed false
   exit 0
 fi

--- a/.github/actions/auto-approve-bot-prs/src/check-pr-ready.sh
+++ b/.github/actions/auto-approve-bot-prs/src/check-pr-ready.sh
@@ -11,6 +11,13 @@ set -euo pipefail
 : "${PR_NUMBER:?PR_NUMBER required}"
 : "${PR_AUTHOR:?PR_AUTHOR required}"
 
+# The authenticated login below is API-derived and reaches a log line. The API
+# answers in JSON, and a `\r` escape inside a JSON string decodes to a real CR
+# through `jq -r`, so "GitHub logins cannot contain control characters" does not
+# close that channel. See lib/log.sh.
+# shellcheck source=.github/actions/auto-approve-bot-prs/src/lib/log.sh
+. "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/lib/log.sh"
+
 emit() {
   local k="$1" v="$2"
   [ -n "${GITHUB_OUTPUT:-}" ] && printf '%s=%s\n' "$k" "$v" >> "$GITHUB_OUTPUT"
@@ -46,7 +53,7 @@ if [ "$mergeable" = "false" ]; then
   exit 0
 fi
 if [ "$mergeable" != "true" ]; then
-  echo "::warning::GitHub did not report mergeability for PR #${PR_NUMBER} within ${mergeable_attempts} attempts (last value '${mergeable}'); not approving. This is usually transient - a re-run should resolve it"
+  echo "::warning::GitHub did not report mergeability for PR #${PR_NUMBER} within ${mergeable_attempts} attempts (last value '$(safe "$mergeable")'); not approving. This is usually transient - a re-run should resolve it"
   emit proceed false
   exit 0
 fi
@@ -65,7 +72,7 @@ if [ -z "$approver" ]; then
   exit 0
 fi
 if [ "$approver" = "$PR_AUTHOR" ]; then
-  echo "::error::the approving identity ('${approver}') is the author of PR #${PR_NUMBER}; GitHub forbids self-approval. Pass a token belonging to a different identity than the PR author"
+  echo "::error::the approving identity ('$(safe "$approver")') is the author of PR #${PR_NUMBER}; GitHub forbids self-approval. Pass a token belonging to a different identity than the PR author"
   emit proceed false
   exit 0
 fi

--- a/.github/actions/auto-approve-bot-prs/src/enable-auto-merge.sh
+++ b/.github/actions/auto-approve-bot-prs/src/enable-auto-merge.sh
@@ -26,10 +26,17 @@ set -euo pipefail
 : "${PR_NUMBER:?PR_NUMBER required}"
 : "${MERGE_METHOD:?MERGE_METHOD required}"
 
+# Every interpolated value below is externally controlled — gh's output is
+# GitHub's, and merge-method is the calling workflow's — so all of them are
+# sanitized before reaching a log line. See lib/log.sh for why a bare CR in one
+# of them is enough to forge a `::error::` annotation.
+# shellcheck source=.github/actions/auto-approve-bot-prs/src/lib/log.sh
+. "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/lib/log.sh"
+
 case "$MERGE_METHOD" in
   squash|merge|rebase) ;;
   *)
-    echo "::error::Invalid merge method '$MERGE_METHOD'; PR #${PR_NUMBER} was approved but not merged"
+    echo "::error::Invalid merge method '$(safe "$MERGE_METHOD")'; PR #${PR_NUMBER} was approved but not merged"
     exit 0
     ;;
 esac
@@ -54,11 +61,11 @@ case "$pr_state" in
     ;;
 esac
 
-echo "::notice::plain merge of PR #${PR_NUMBER} was refused, falling back to auto-merge. Reason: ${direct_err}"
+echo "::notice::plain merge of PR #${PR_NUMBER} was refused, falling back to auto-merge. Reason: $(safe "$direct_err")"
 
 if auto_err=$(gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --auto --"$MERGE_METHOD" 2>&1); then
   echo "::warning::PR #${PR_NUMBER} could not be merged immediately; queued via GitHub auto-merge and will land once the remaining requirements pass"
   exit 0
 fi
 
-echo "::error::PR #${PR_NUMBER} was approved but could NOT be merged, and could not be queued for auto-merge either. Anything waiting on this merge will stall. Plain merge said: ${direct_err}. Auto-merge said: ${auto_err}. Check branch protection and rulesets (is the token's team a bypass actor during a code freeze?), the token's merge permission, and whether the repository allows auto-merge."
+echo "::error::PR #${PR_NUMBER} was approved but could NOT be merged, and could not be queued for auto-merge either. Anything waiting on this merge will stall. Plain merge said: $(safe "$direct_err" 500). Auto-merge said: $(safe "$auto_err" 500). Check branch protection and rulesets (is the token's team a bypass actor during a code freeze?), the token's merge permission, and whether the repository allows auto-merge."

--- a/.github/actions/auto-approve-bot-prs/src/enable-auto-merge.sh
+++ b/.github/actions/auto-approve-bot-prs/src/enable-auto-merge.sh
@@ -1,5 +1,23 @@
 #!/usr/bin/env bash
-# Enables GitHub's auto-merge on the PR. Never exits non-zero.
+# Merges the PR. Never exits non-zero.
+#
+# A plain merge is attempted FIRST, and `--auto` is only the fallback. By the
+# time this runs the action has already waited for every other check to go green
+# (wait-for-ci.sh) and approved the PR, so there is normally nothing left for
+# GitHub's auto-merge queue to wait on. `--auto` additionally requires the
+# repository's allow_auto_merge setting, which is invisible from here and turns
+# the merge into a silent no-op when it is off - and a merge that never happens
+# strands whatever is waiting on it (the vcluster-release orchestrator blocks on
+# exactly this merge during a legacy release cut).
+#
+# `--auto` still has a job: a required check that registered AFTER the CI wait
+# declared green legitimately refuses a merge right now but can complete later.
+# Queueing is the right answer there, so a refused plain merge degrades to it.
+#
+# Nothing here exits non-zero (the composite must not red-X a caller's CI over
+# an unrelated bot PR), but an approved-and-unmerged PR is reported at
+# ::error:: level so the cause is visible in the run summary instead of being
+# buried in a notice.
 #
 # Required env: GH_TOKEN, GITHUB_REPOSITORY, PR_NUMBER, MERGE_METHOD
 set -euo pipefail
@@ -11,10 +29,36 @@ set -euo pipefail
 case "$MERGE_METHOD" in
   squash|merge|rebase) ;;
   *)
-    echo "::notice::Invalid merge method '$MERGE_METHOD'; skipping"
+    echo "::error::Invalid merge method '$MERGE_METHOD'; PR #${PR_NUMBER} was approved but not merged"
     exit 0
     ;;
 esac
 
-gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --auto --"$MERGE_METHOD" 2>&1 \
-  || echo "::notice::gh pr merge failed; auto-merge not enabled"
+if direct_err=$(gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --"$MERGE_METHOD" 2>&1); then
+  echo "Merged PR #${PR_NUMBER} (${MERGE_METHOD})"
+  exit 0
+fi
+
+# A refused plain merge is not automatically a problem: on a re-run the PR is
+# often already merged, and a PR closed unmerged is a human decision. Establish
+# which it is before escalating, so the ::error:: below keeps meaning something.
+pr_state=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json state --jq '.state' 2>/dev/null || echo "")
+case "$pr_state" in
+  MERGED)
+    echo "PR #${PR_NUMBER} is already merged; nothing to do"
+    exit 0
+    ;;
+  CLOSED)
+    echo "::warning::PR #${PR_NUMBER} is closed without being merged; not merging"
+    exit 0
+    ;;
+esac
+
+echo "::notice::plain merge of PR #${PR_NUMBER} was refused, falling back to auto-merge. Reason: ${direct_err}"
+
+if auto_err=$(gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --auto --"$MERGE_METHOD" 2>&1); then
+  echo "::warning::PR #${PR_NUMBER} could not be merged immediately; queued via GitHub auto-merge and will land once the remaining requirements pass"
+  exit 0
+fi
+
+echo "::error::PR #${PR_NUMBER} was approved but could NOT be merged, and could not be queued for auto-merge either. Anything waiting on this merge will stall. Plain merge said: ${direct_err}. Auto-merge said: ${auto_err}. Check branch protection and rulesets (is the token's team a bypass actor during a code freeze?), the token's merge permission, and whether the repository allows auto-merge."

--- a/.github/actions/auto-approve-bot-prs/src/enable-auto-merge.sh
+++ b/.github/actions/auto-approve-bot-prs/src/enable-auto-merge.sh
@@ -41,7 +41,29 @@ case "$MERGE_METHOD" in
     ;;
 esac
 
-if direct_err=$(gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --"$MERGE_METHOD" 2>&1); then
+# One bounded retry per merge call. Without it a single transient blip is
+# escalated identically to a permanent policy refusal, and the ::error:: below
+# then ships confident remediation ("check branch protection…") that is simply
+# wrong for a transient cause. Secondary rate limiting is a live risk here rather
+# than theoretical: by this point the action has already made up to 90 CI polls,
+# up to 10 mergeability polls and the approval call, and both merge attempts
+# would otherwise fire back-to-back with no delay, so one blip can take out both.
+# This mirrors the retry discipline the CI wait and the mergeability poll already
+# apply. Never fails: the caller decides what a non-zero merge means.
+MERGE_RETRY_SLEEP="${MERGE_RETRY_SLEEP_SECONDS:-5}"
+try_merge() {
+  local out rc
+  if out=$("$@" 2>&1); then printf '%s' "$out"; return 0; fi
+  # Retry blind rather than classifying the error: gh's text is not a stable
+  # API, and a permanent refusal costs only one extra call and one sleep.
+  sleep "$MERGE_RETRY_SLEEP"
+  out=$("$@" 2>&1) && { printf '%s' "$out"; return 0; }
+  rc=$?
+  printf '%s' "$out"
+  return "$rc"
+}
+
+if direct_err=$(try_merge gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --"$MERGE_METHOD"); then
   echo "Merged PR #${PR_NUMBER} (${MERGE_METHOD})"
   exit 0
 fi
@@ -63,9 +85,18 @@ esac
 
 echo "::notice::plain merge of PR #${PR_NUMBER} was refused, falling back to auto-merge. Reason: $(safe "$direct_err")"
 
-if auto_err=$(gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --auto --"$MERGE_METHOD" 2>&1); then
-  echo "::warning::PR #${PR_NUMBER} could not be merged immediately; queued via GitHub auto-merge and will land once the remaining requirements pass"
+if auto_err=$(try_merge gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --auto --"$MERGE_METHOD"); then
+  # Deliberately does NOT promise this lands on its own. Queueing succeeded, but
+  # that only means GitHub accepted the request — several refusals reach here
+  # with equal confidence and need a human, not patience: a strict
+  # "must be up to date with base" rule with no auto-update configured queues
+  # indefinitely; a conflict from a base commit landing during the CI wait (up to
+  # ~15 min at the default 90x10s) needs the rebase check-pr-ready.sh asks for;
+  # and allow_auto_merge being off makes the queue request itself a no-op. Naming
+  # the queue and the refusal reason lets the operator tell which, instead of
+  # reading a promise and stopping there.
+  echo "::warning::PR #${PR_NUMBER} could not be merged immediately and was queued via GitHub auto-merge. It will land only once the remaining requirements are satisfied — if it is still open later, check that (a) auto-merge is enabled on the repository, (b) the branch is up to date with its base, and (c) it has no conflicts. Plain merge was refused with: $(safe "$direct_err" 500)"
   exit 0
 fi
 
-echo "::error::PR #${PR_NUMBER} was approved but could NOT be merged, and could not be queued for auto-merge either. Anything waiting on this merge will stall. Plain merge said: $(safe "$direct_err" 500). Auto-merge said: $(safe "$auto_err" 500). Check branch protection and rulesets (is the token's team a bypass actor during a code freeze?), the token's merge permission, and whether the repository allows auto-merge."
+echo "::error::PR #${PR_NUMBER} was approved but could NOT be merged, and could not be queued for auto-merge either (each path was retried once). Anything waiting on this merge will stall. Plain merge said: $(safe "$direct_err" 500). Auto-merge said: $(safe "$auto_err" 500). Read those two reasons first — they name the cause. If they point at policy rather than a transient API error, check branch protection and rulesets (is the token's team a bypass actor during a code freeze?), the token's merge permission, and whether the repository allows auto-merge."

--- a/.github/actions/auto-approve-bot-prs/src/lib/log.sh
+++ b/.github/actions/auto-approve-bot-prs/src/lib/log.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Log-safety helpers shared by every script in this action. Sourced, never
+# executed — so it is deliberately not +x and defines functions only.
+#
+# EVERY externally-controlled string that reaches an `echo` in this action must
+# go through here. The channels that qualify are all hostile:
+#   - gh's stderr/stdout (GitHub-controlled), on both the CI poll and the merge,
+#   - check-run `.name` / commit-status `.context`, written by whoever posted the
+#     check on the head SHA. GitHub documents no character restriction on them,
+#     so they are the *widest* channel.
+#   - the authenticated login from `gh api user`. The API answers in JSON, and a
+#     `\r` escape inside a JSON string decodes to a real CR through `jq -r`, so
+#     "logins cannot contain control characters" does not close this one.
+#   - caller-supplied inputs that are echoed back on rejection (merge-method),
+#     which a calling workflow can set to anything.
+#
+# What sanitize_for_log defends against:
+#   - CR as well as LF terminates a log line for the runner, so a raw one splits
+#     the output into a NEW line, and a line beginning `::` is parsed as a
+#     workflow command. An attacker naming a check `x<CR>::error::…` would
+#     otherwise forge one. Collapse both, plus TAB, to spaces.
+#   - Other separators the runner or a terminal may treat as breaks (VT, FF, NUL,
+#     DEL, and via the non-ASCII strip: NEL, U+2028, U+2029) are removed.
+#   - Non-ASCII is dropped rather than byte-truncated, so the length cap cannot
+#     split a UTF-8 sequence mid-character.
+#   - `%` is the workflow-command escape introducer, so a literal `%0A`/`%25`
+#     would otherwise be decoded into the annotation. Escaped AFTER the first
+#     cut so that cut cannot bisect an escape we just wrote; a second cut then
+#     bounds the real emitted length, and the trailing-partial strip removes a
+#     `%` or `%2` left dangling by it.
+#   - LC_ALL is pinned on both `tr` calls so an inherited locale cannot defeat
+#     the class matching.
+#
+# Never fails: a subshell abort here would kill the caller under `set -e` before
+# it could emit its output contract (ci_green / proceed), which is the same
+# violation as a fatal mktemp.
+
+# sanitize_for_log — stdin to a single safe log line on stdout.
+#
+# Optional arg: max emitted characters (default 300). Escaping runs BEFORE the
+# truncation so the cap bounds the line that is actually emitted rather than a
+# pre-escape length that can then triple; the trailing-partial strip removes a
+# `%` or `%2` the cut may leave dangling. Truncation is marked, because a name
+# severed mid-word reads as a corrupted check name rather than as elision.
+sanitize_for_log() {
+  local max="${1:-300}"
+  { LC_ALL=C tr '\n\r\t' '   ' \
+      | LC_ALL=C tr -cd '\040-\176' \
+      | sed 's/%/%25/g' \
+      | LC_ALL=C awk -v m="$max" '{ if (length($0) > m) printf "%s... (truncated)\n", substr($0, 1, m); else print }' \
+      | sed 's/%2\{0,1\}$//'; } 2>/dev/null || true
+}
+
+# safe <string> [max] — sanitize a value for interpolation into a log line.
+safe() {
+  printf '%s' "${1:-}" | sanitize_for_log "${2:-300}"
+}

--- a/.github/actions/auto-approve-bot-prs/src/wait-for-ci.sh
+++ b/.github/actions/auto-approve-bot-prs/src/wait-for-ci.sh
@@ -37,47 +37,12 @@ set -euo pipefail
 : "${PR_HEAD_SHA:?PR_HEAD_SHA required}"
 : "${SELF_RUN_ID:?SELF_RUN_ID required}"
 
-# sanitize_for_log — stdin to a single safe log line on stdout.
-#
-# EVERY externally-controlled string that reaches an `echo` in this script must
-# go through here. Two channels qualify and both are hostile:
-#   - gh's stderr (GitHub-controlled), and
-#   - check-run `.name` / commit-status `.context`, which are written by whoever
-#     posted the check on the head SHA. GitHub documents no character
-#     restriction on them, so they are the *wider* of the two channels.
-#
-# What it defends against:
-#   - CR as well as LF terminates a log line for the runner, so a raw one splits
-#     the output into a NEW line, and a line beginning `::` is parsed as a
-#     workflow command. An attacker naming a check `x<CR>::error::…` would
-#     otherwise forge one. Collapse both, plus TAB, to spaces.
-#   - Other separators the runner or a terminal may treat as breaks (VT, FF, NUL,
-#     DEL, and via the non-ASCII strip: NEL, U+2028, U+2029) are removed.
-#   - Non-ASCII is dropped rather than byte-truncated, so the length cap cannot
-#     split a UTF-8 sequence mid-character.
-#   - `%` is the workflow-command escape introducer, so a literal `%0A`/`%25`
-#     would otherwise be decoded into the annotation. Escaped AFTER the first
-#     cut so that cut cannot bisect an escape we just wrote; a second cut then
-#     bounds the real emitted length, and the trailing-partial strip removes a
-#     `%` or `%2` left dangling by it.
-#   - LC_ALL is pinned on both `tr` calls so an inherited locale cannot defeat
-#     the class matching.
-#
-# Never fails: a subshell abort here would kill the script under `set -e` before
-# it could emit ci_green, which is the same contract violation as a fatal mktemp.
-# Optional arg: max emitted characters (default 300). Escaping runs BEFORE the
-# truncation so the cap bounds the line that is actually emitted rather than a
-# pre-escape length that can then triple; the trailing-partial strip removes a
-# `%` or `%2` the cut may leave dangling. Truncation is marked, because a name
-# severed mid-word reads as a corrupted check name rather than as elision.
-sanitize_for_log() {
-  local max="${1:-300}"
-  { LC_ALL=C tr '\n\r\t' '   ' \
-      | LC_ALL=C tr -cd '\040-\176' \
-      | sed 's/%/%25/g' \
-      | LC_ALL=C awk -v m="$max" '{ if (length($0) > m) printf "%s... (truncated)\n", substr($0, 1, m); else print }' \
-      | sed 's/%2\{0,1\}$//'; } 2>/dev/null || true
-}
+# sanitize_for_log / safe. Sourced before the input coercion below, because a
+# rejected wait value is itself interpolated into a log line. A missing lib is a
+# packaging fault, not a runtime one, so it exits non-zero like missing env does
+# rather than degrading to unsanitized output.
+# shellcheck source=.github/actions/auto-approve-bot-prs/src/lib/log.sh
+. "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/lib/log.sh"
 
 # gh_last_error — one-line summary of why the last gh call failed, for logs.
 # Discarding this is how a permanent permission problem masquerades as a
@@ -89,11 +54,6 @@ gh_last_error() {
   [ -n "$GH_ERR_FILE" ] || return 0
   [ -s "$GH_ERR_FILE" ] || return 0
   sanitize_for_log < "$GH_ERR_FILE"
-}
-
-# safe <string> — sanitize an API-derived value for interpolation into a log line.
-safe() {
-  printf '%s' "${1:-}" | sanitize_for_log
 }
 
 # Coerce rather than trust. A non-numeric value here used to reach `sleep` and

--- a/.github/actions/auto-approve-bot-prs/test/assertions.bash
+++ b/.github/actions/auto-approve-bot-prs/test/assertions.bash
@@ -1,0 +1,22 @@
+# Shared negative assertion. Lives here rather than in one .bats file because
+# every script in this action interpolates externally-controlled text into log
+# lines, so every suite needs it.
+
+# assert_no_match <perl-regex> <text> — fail the test if the regex matches.
+#
+# Do NOT write `! grep -q ... <<<"$output"` instead. Bash does not abort on a
+# command whose status is inverted with `!`, so under the `set -e` bats runs test
+# bodies with, a bare negated grep is a no-op unless it happens to be the final
+# line. Several assertions were silently inert that way. A plain function call
+# returning non-zero does abort, so this one actually fails.
+assert_no_match() {
+  local rc=0
+  grep -qP -- "$1" <<<"$2" || rc=$?
+  case "$rc" in
+    0) printf 'assert_no_match: unexpected match for %s\n' "$1" >&2; return 1 ;;
+    1) return 0 ;;
+    # grep returns 2 for a malformed pattern. Treating that as "no match" is the
+    # very fail-open shape this helper exists to prevent, so it must fail loudly.
+    *) printf 'assert_no_match: grep error rc=%s for pattern %s\n' "$rc" "$1" >&2; return 1 ;;
+  esac
+}

--- a/.github/actions/auto-approve-bot-prs/test/assertions.bash
+++ b/.github/actions/auto-approve-bot-prs/test/assertions.bash
@@ -5,10 +5,14 @@
 # assert_no_match <perl-regex> <text> — fail the test if the regex matches.
 #
 # Do NOT write `! grep -q ... <<<"$output"` instead. Bash does not abort on a
-# command whose status is inverted with `!`, so under the `set -e` bats runs test
-# bodies with, a bare negated grep is a no-op unless it happens to be the final
-# line. Several assertions were silently inert that way. A plain function call
-# returning non-zero does abort, so this one actually fails.
+# command whose status is inverted with `!`, so under the `set -e` that bats runs
+# test bodies with, a bare negated grep is a no-op unless it happens to be the
+# final line. Several assertions were silently inert that way. A plain function
+# call returning non-zero does abort, so this one actually fails.
+#
+# The same trap applies to negating a *helper function* (`! auto_merge_attempted`)
+# — the `!` is what disables `set -e`, not the grep. Wrap those in a helper that
+# calls this, rather than negating them at the call site.
 assert_no_match() {
   local rc=0
   grep -qP -- "$1" <<<"$2" || rc=$?

--- a/.github/actions/auto-approve-bot-prs/test/check-eligibility.bats
+++ b/.github/actions/auto-approve-bot-prs/test/check-eligibility.bats
@@ -3,6 +3,7 @@
 
 SCRIPT="$BATS_TEST_DIRNAME/../src/check-eligibility.sh"
 DEFAULT='renovate[bot],loft-bot,github-actions[bot],dependabot[bot]'
+load assertions
 
 setup() { export GITHUB_OUTPUT; GITHUB_OUTPUT="$(mktemp)"; }
 teardown() { rm -f "$GITHUB_OUTPUT"; }
@@ -69,4 +70,48 @@ assert_kv() {
 @test "missing PR_AUTHOR fails" {
   run env -u PR_AUTHOR TRUSTED_AUTHORS="$DEFAULT" PR_TITLE=y PR_BRANCH=z "$SCRIPT"
   [ "$status" -ne 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Log-injection. This script is step 1 of the composite and runs before any
+# trust gate, so PR_TITLE and PR_BRANCH are the widest channel in the action:
+# whoever opens the PR picks them, and both are echoed back when the patterns
+# do not match. CR terminates a log line for the runner, so a raw one starts a
+# NEW line and a line beginning '::' is parsed as a workflow command.
+
+@test "regression: a CR in PR_TITLE cannot forge a workflow command" {
+  run_script "$DEFAULT" 'loft-bot' $'feat: x\r::error::FORGED' 'feature/foo'
+  [ "$status" -eq 0 ]
+  assert_kv eligible false
+  assert_no_match '\r' "$output"
+  assert_no_match '(?m)^::error::FORGED' "$output"
+}
+
+@test "regression: a CR in PR_BRANCH cannot forge a workflow command" {
+  run_script "$DEFAULT" 'loft-bot' 'feat: x' $'feature/foo\r::error::FORGED'
+  [ "$status" -eq 0 ]
+  assert_kv eligible false
+  assert_no_match '\r' "$output"
+  assert_no_match '(?m)^::error::FORGED' "$output"
+}
+
+@test "regression: a CR in PR_AUTHOR cannot forge a workflow command" {
+  # The untrusted-author path echoes the author back before any gate has run.
+  run_script "$DEFAULT" $'nobody\r::error::FORGED' 'chore: x' 'x'
+  [ "$status" -eq 0 ]
+  assert_kv eligible false
+  assert_no_match '\r' "$output"
+  assert_no_match '(?m)^::error::FORGED' "$output"
+}
+
+@test "a missing log lib fails loudly instead of logging unsanitized" {
+  # An absent lib/log.sh is a packaging fault. Degrading to unsanitized output
+  # would silently reopen the channels above, so the script must die instead —
+  # and must not emit its decision. Running a copy with no sibling lib/
+  # reproduces it.
+  cp "$SCRIPT" "$BATS_TEST_TMPDIR/check-eligibility.sh"
+  run env TRUSTED_AUTHORS="$DEFAULT" PR_AUTHOR=loft-bot PR_TITLE='chore: x' \
+    PR_BRANCH=x GITHUB_OUTPUT="$GITHUB_OUTPUT" "$BATS_TEST_TMPDIR/check-eligibility.sh"
+  [ "$status" -ne 0 ]
+  assert_no_match 'eligible=' "$output"
 }

--- a/.github/actions/auto-approve-bot-prs/test/check-pr-ready.bats
+++ b/.github/actions/auto-approve-bot-prs/test/check-pr-ready.bats
@@ -2,6 +2,7 @@
 
 SCRIPT="$BATS_TEST_DIRNAME/../src/check-pr-ready.sh"
 load gh_mock
+load assertions
 
 setup() {
   setup_gh_mock
@@ -64,6 +65,29 @@ kv() { grep "^$1=" "$GITHUB_OUTPUT" | tail -n1; }
   [ "$(kv proceed)" = "proceed=false" ]
   [[ "$output" == *"::error::could not resolve the authenticated user"* ]]
   [[ "$output" != *"self-approval"* ]]
+}
+
+@test "regression: a CR in the authenticated login cannot forge a workflow command" {
+  # "GitHub logins cannot contain control characters" does not close this
+  # channel: the API answers in JSON, and a \r escape inside a JSON string
+  # decodes to a real CR through `jq -r`. GH_MOCK_APPROVER carries the escape
+  # (literal backslash-r) exactly as a real API response would.
+  #
+  # PR_AUTHOR must equal the decoded login to reach the self-approval line, so
+  # it holds the real CR.
+  GH_MOCK_MERGEABLE=true \
+    GH_MOCK_APPROVER='dependabot[bot]\r::error::FORGED' \
+    PR_AUTHOR=$'dependabot[bot]\r::error::FORGED' \
+    run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv proceed)" = "proceed=false" ]
+  # No CR anywhere: grep splits on LF only, so a line-anchored assertion alone
+  # would pass with the bug live.
+  assert_no_match '\r' "$output"
+  assert_no_match '(?m)^::error::FORGED' "$output"
+  # The identity is still reported, flattened onto the one annotation line.
+  [[ "$output" == *"the approving identity"* ]]
+  [[ "$output" == *"dependabot[bot]"* ]]
 }
 
 @test "missing PR_NUMBER fails" {

--- a/.github/actions/auto-approve-bot-prs/test/check-pr-ready.bats
+++ b/.github/actions/auto-approve-bot-prs/test/check-pr-ready.bats
@@ -23,28 +23,47 @@ kv() { grep "^$1=" "$GITHUB_OUTPUT" | tail -n1; }
   [ "$(kv proceed)" = "proceed=true" ]
 }
 
-@test "mergeable=false → proceed=false" {
+@test "mergeable=false → proceed=false, reported as a conflict needing a rebase" {
   GH_MOCK_MERGEABLE=false GH_MOCK_APPROVER="loft-bot" run "$SCRIPT"
   [ "$status" -eq 0 ]
   [ "$(kv proceed)" = "proceed=false" ]
+  [[ "$output" == *"::warning::PR #42 has merge conflicts"* ]]
+}
+
+@test "regression: mergeable=false is definitive and must not burn the retry budget" {
+  # jq's `//` used to collapse false into "null", so a conflicted PR looked
+  # like un-computed metadata and re-polled until the budget ran out.
+  # MERGEABLE_MAX_ATTEMPTS=2 here, so a second poll would prove the regression.
+  GH_MOCK_MERGEABLE=false GH_MOCK_APPROVER="loft-bot" run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(grep -c 'pulls/42' "$GH_MOCK_CALLS")" -eq 1 ]
 }
 
 @test "mergeable=null → proceed=false (never treat unknown as clean)" {
   GH_MOCK_MERGEABLE=null GH_MOCK_APPROVER="loft-bot" run "$SCRIPT"
   [ "$status" -eq 0 ]
   [ "$(kv proceed)" = "proceed=false" ]
+  # Distinct from the conflict case above: transient, so a re-run is advised
+  # rather than a rebase.
+  [[ "$output" == *"did not report mergeability"* ]]
+  [[ "$output" == *"transient"* ]]
+  [[ "$output" != *"merge conflicts"* ]]
 }
 
 @test "approver == author → proceed=false (self-review guard)" {
   GH_MOCK_MERGEABLE=true GH_MOCK_APPROVER="dependabot[bot]" run "$SCRIPT"
   [ "$status" -eq 0 ]
   [ "$(kv proceed)" = "proceed=false" ]
+  [[ "$output" == *"::error::the approving identity"* ]]
+  [[ "$output" == *"self-approval"* ]]
 }
 
-@test "empty approver → proceed=false" {
+@test "empty approver → proceed=false, reported as a token problem not self-approval" {
   GH_MOCK_MERGEABLE=true GH_MOCK_APPROVER="" run "$SCRIPT"
   [ "$status" -eq 0 ]
   [ "$(kv proceed)" = "proceed=false" ]
+  [[ "$output" == *"::error::could not resolve the authenticated user"* ]]
+  [[ "$output" != *"self-approval"* ]]
 }
 
 @test "missing PR_NUMBER fails" {

--- a/.github/actions/auto-approve-bot-prs/test/check-pr-ready.bats
+++ b/.github/actions/auto-approve-bot-prs/test/check-pr-ready.bats
@@ -94,3 +94,15 @@ kv() { grep "^$1=" "$GITHUB_OUTPUT" | tail -n1; }
   run env -u PR_NUMBER GITHUB_OUTPUT="$GITHUB_OUTPUT" GITHUB_REPOSITORY=o/r PR_AUTHOR=x "$SCRIPT"
   [ "$status" -ne 0 ]
 }
+
+@test "a missing log lib fails loudly instead of logging unsanitized" {
+  # An absent lib/log.sh is a packaging fault, and degrading to unsanitized
+  # output would silently reopen the CR channel asserted above. The script must
+  # die rather than emit its decision. Running a copy with no sibling lib/
+  # reproduces it. This test is what keeps the source-or-die guard honest: weaken
+  # it to `|| true`, or move it below the first echo, and this goes red.
+  cp "$SCRIPT" "$BATS_TEST_TMPDIR/check-pr-ready.sh"
+  GH_MOCK_MERGEABLE=true GH_MOCK_APPROVER="loft-bot" run "$BATS_TEST_TMPDIR/check-pr-ready.sh"
+  [ "$status" -ne 0 ]
+  assert_no_match 'proceed=true' "$output"
+}

--- a/.github/actions/auto-approve-bot-prs/test/enable-auto-merge.bats
+++ b/.github/actions/auto-approve-bot-prs/test/enable-auto-merge.bats
@@ -1,0 +1,101 @@
+#!/usr/bin/env bats
+
+SCRIPT="$BATS_TEST_DIRNAME/../src/enable-auto-merge.sh"
+load gh_mock
+
+setup() {
+  setup_gh_mock
+  export GITHUB_REPOSITORY="owner/repo"
+  export PR_NUMBER=42
+  export MERGE_METHOD="squash"
+}
+teardown() { teardown_gh_mock; }
+
+# Did `gh pr merge` get called with --auto at least once?
+auto_merge_attempted() { grep -q '^pr merge .*--auto' "$GH_MOCK_CALLS"; }
+# ...and without it (the plain merge)?
+plain_merge_attempted() { grep '^pr merge ' "$GH_MOCK_CALLS" | grep -qv -- '--auto'; }
+
+@test "plain merge succeeds → merged without touching auto-merge" {
+  GH_MOCK_PR_MERGE_EXIT=0 run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Merged PR #42 (squash)"* ]]
+  plain_merge_attempted
+  ! auto_merge_attempted
+  # The whole point of preferring the plain merge: no dependency on the
+  # repository's allow_auto_merge setting on the happy path.
+  [[ "$output" != *"::error::"* ]]
+  [[ "$output" != *"::warning::"* ]]
+}
+
+@test "plain merge refused on an open PR → falls back to --auto and warns" {
+  GH_MOCK_PR_MERGE_EXIT=1 GH_MOCK_PR_MERGE_AUTO_EXIT=0 GH_MOCK_PR_STATE=OPEN run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  plain_merge_attempted
+  auto_merge_attempted
+  [[ "$output" == *"::warning::PR #42 could not be merged immediately"* ]]
+  [[ "$output" != *"::error::"* ]]
+}
+
+@test "both merge paths refused → ::error:: naming both reasons, still exits 0" {
+  GH_MOCK_PR_MERGE_EXIT=1 GH_MOCK_PR_MERGE_AUTO_EXIT=1 GH_MOCK_PR_STATE=OPEN \
+    GH_MOCK_PR_MERGE_OUT="plain boom" GH_MOCK_PR_MERGE_AUTO_OUT="auto boom" run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"::error::PR #42 was approved but could NOT be merged"* ]]
+  # Both diagnostics are carried into the annotation, since this is the only
+  # place the cause is knowable.
+  [[ "$output" == *"plain boom"* ]]
+  [[ "$output" == *"auto boom"* ]]
+}
+
+@test "already merged → benign, no auto-merge attempt, no error" {
+  GH_MOCK_PR_MERGE_EXIT=1 GH_MOCK_PR_STATE=MERGED run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"already merged"* ]]
+  ! auto_merge_attempted
+  [[ "$output" != *"::error::"* ]]
+}
+
+@test "closed unmerged → warning, no auto-merge attempt, no error" {
+  GH_MOCK_PR_MERGE_EXIT=1 GH_MOCK_PR_STATE=CLOSED run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"::warning::PR #42 is closed without being merged"* ]]
+  ! auto_merge_attempted
+  [[ "$output" != *"::error::"* ]]
+}
+
+@test "unreadable PR state does not mask a failed merge" {
+  # `gh pr view` failing must not be read as "already merged" — the run still
+  # has to try --auto and, failing that, escalate.
+  GH_MOCK_PR_MERGE_EXIT=1 GH_MOCK_PR_MERGE_AUTO_EXIT=1 GH_MOCK_PR_STATE="" run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  auto_merge_attempted
+  [[ "$output" == *"::error::"* ]]
+}
+
+@test "invalid merge method → ::error::, no merge attempted" {
+  MERGE_METHOD="fast-forward" run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"::error::Invalid merge method 'fast-forward'"* ]]
+  ! plain_merge_attempted
+  ! auto_merge_attempted
+}
+
+@test "each valid merge method is passed through to gh" {
+  for m in squash merge rebase; do
+    : > "$GH_MOCK_CALLS"
+    MERGE_METHOD="$m" GH_MOCK_PR_MERGE_EXIT=0 run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    grep -q -- "--${m}" "$GH_MOCK_CALLS"
+  done
+}
+
+@test "missing PR_NUMBER fails" {
+  run env -u PR_NUMBER GITHUB_REPOSITORY=o/r MERGE_METHOD=squash "$SCRIPT"
+  [ "$status" -ne 0 ]
+}
+
+@test "missing MERGE_METHOD fails" {
+  run env -u MERGE_METHOD GITHUB_REPOSITORY=o/r PR_NUMBER=1 "$SCRIPT"
+  [ "$status" -ne 0 ]
+}

--- a/.github/actions/auto-approve-bot-prs/test/enable-auto-merge.bats
+++ b/.github/actions/auto-approve-bot-prs/test/enable-auto-merge.bats
@@ -2,6 +2,7 @@
 
 SCRIPT="$BATS_TEST_DIRNAME/../src/enable-auto-merge.sh"
 load gh_mock
+load assertions
 
 setup() {
   setup_gh_mock
@@ -98,4 +99,72 @@ plain_merge_attempted() { grep '^pr merge ' "$GH_MOCK_CALLS" | grep -qv -- '--au
 @test "missing MERGE_METHOD fails" {
   run env -u MERGE_METHOD GITHUB_REPOSITORY=o/r PR_NUMBER=1 "$SCRIPT"
   [ "$status" -ne 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Log-injection. gh's output is GitHub-controlled and merge-method is the
+# calling workflow's, and all three reach a workflow-command line here. CR
+# terminates a log line for the runner, so a raw one starts a NEW line and a
+# line beginning '::' is parsed as a command.
+#
+# Note every guard below asserts there is no CR in the output *at all*. A
+# line-anchored grep cannot fail on a CR-delimited payload, because grep splits
+# on LF only while the runner also splits on CR — so an unsanitized payload
+# would satisfy a '^::error::' check and the test would pass with the bug live.
+
+@test "regression: a CR in the plain-merge error cannot forge a workflow command" {
+  GH_MOCK_PR_MERGE_EXIT=1 GH_MOCK_PR_MERGE_AUTO_EXIT=0 GH_MOCK_PR_STATE=OPEN \
+    GH_MOCK_PR_MERGE_OUT=$'refused\r::error::FORGED\r100% done' run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  assert_no_match '\r' "$output"
+  assert_no_match '(?m)^::error::FORGED' "$output"
+  # Still reported, flattened onto the one notice line.
+  [[ "$output" == *"refused"* ]]
+  # '%' is escaped so the runner cannot decode %0A/%25 out of gh's text.
+  [[ "$output" == *"100%25 done"* ]]
+}
+
+@test "regression: a CR in the auto-merge error cannot forge a workflow command" {
+  # The second channel, reached only on the both-paths-refused route, which is
+  # also the one that emits ::error::.
+  GH_MOCK_PR_MERGE_EXIT=1 GH_MOCK_PR_MERGE_AUTO_EXIT=1 GH_MOCK_PR_STATE=OPEN \
+    GH_MOCK_PR_MERGE_OUT="plain boom" \
+    GH_MOCK_PR_MERGE_AUTO_OUT=$'auto boom\r::error::FORGED' run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  assert_no_match '\r' "$output"
+  assert_no_match '(?m)^::error::FORGED' "$output"
+  [[ "$output" == *"was approved but could NOT be merged"* ]]
+  [[ "$output" == *"auto boom"* ]]
+}
+
+@test "regression: a CR in merge-method cannot forge a workflow command" {
+  # Caller-controlled rather than API-controlled: merge-method is a plain
+  # workflow_call string input, echoed back on rejection.
+  MERGE_METHOD=$'fast-forward\r::error::FORGED' run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  assert_no_match '\r' "$output"
+  assert_no_match '(?m)^::error::FORGED' "$output"
+  [[ "$output" == *"Invalid merge method"* ]]
+  # The rejected value is still shown, so the operator can see the typo.
+  [[ "$output" == *"fast-forward"* ]]
+}
+
+@test "a missing log lib fails loudly instead of logging unsanitized" {
+  # The one place this action prefers a hard failure: an absent lib/log.sh is a
+  # packaging fault, and degrading to unsanitized output would silently reopen
+  # every channel above. Running a copy with no sibling lib/ reproduces it.
+  cp "$SCRIPT" "$BATS_TEST_TMPDIR/enable-auto-merge.sh"
+  GH_MOCK_PR_MERGE_EXIT=0 run "$BATS_TEST_TMPDIR/enable-auto-merge.sh"
+  [ "$status" -ne 0 ]
+  assert_no_match 'Merged PR' "$output"
+}
+
+@test "regression: a very long gh error is truncated with a marker, not severed" {
+  long=$(printf 'x%.0s' $(seq 1 900))
+  GH_MOCK_PR_MERGE_EXIT=1 GH_MOCK_PR_MERGE_AUTO_EXIT=1 GH_MOCK_PR_STATE=OPEN \
+    GH_MOCK_PR_MERGE_OUT="$long" GH_MOCK_PR_MERGE_AUTO_OUT="$long" run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"... (truncated)"* ]]
+  # Bounded: the 900-char payload cannot reach the annotation whole.
+  assert_no_match "x{600}" "$output"
 }

--- a/.github/actions/auto-approve-bot-prs/test/enable-auto-merge.bats
+++ b/.github/actions/auto-approve-bot-prs/test/enable-auto-merge.bats
@@ -9,6 +9,9 @@ setup() {
   export GITHUB_REPOSITORY="owner/repo"
   export PR_NUMBER=42
   export MERGE_METHOD="squash"
+  # Every refusal path retries once. Keep the backoff out of the suite runtime —
+  # at the 5s default the failure-path tests alone add over a minute.
+  export MERGE_RETRY_SLEEP_SECONDS=0
 }
 teardown() { teardown_gh_mock; }
 
@@ -17,12 +20,20 @@ auto_merge_attempted() { grep -q '^pr merge .*--auto' "$GH_MOCK_CALLS"; }
 # ...and without it (the plain merge)?
 plain_merge_attempted() { grep '^pr merge ' "$GH_MOCK_CALLS" | grep -qv -- '--auto'; }
 
+# Negative forms route through assert_no_match rather than negating the two
+# helpers above with `!`. Bash exempts a `!`-inverted command from `set -e`, so
+# `! auto_merge_attempted` is inert unless it happens to be the last line of the
+# test body — which silently unproved the "no auto-merge attempt" half of four
+# titles below. See assertions.bash.
+assert_no_auto_merge() { assert_no_match '^pr merge .*--auto' "$(cat "$GH_MOCK_CALLS")"; }
+assert_no_merge_at_all() { assert_no_match '^pr merge ' "$(cat "$GH_MOCK_CALLS")"; }
+
 @test "plain merge succeeds → merged without touching auto-merge" {
   GH_MOCK_PR_MERGE_EXIT=0 run "$SCRIPT"
   [ "$status" -eq 0 ]
   [[ "$output" == *"Merged PR #42 (squash)"* ]]
   plain_merge_attempted
-  ! auto_merge_attempted
+  assert_no_auto_merge
   # The whole point of preferring the plain merge: no dependency on the
   # repository's allow_auto_merge setting on the happy path.
   [[ "$output" != *"::error::"* ]]
@@ -53,7 +64,7 @@ plain_merge_attempted() { grep '^pr merge ' "$GH_MOCK_CALLS" | grep -qv -- '--au
   GH_MOCK_PR_MERGE_EXIT=1 GH_MOCK_PR_STATE=MERGED run "$SCRIPT"
   [ "$status" -eq 0 ]
   [[ "$output" == *"already merged"* ]]
-  ! auto_merge_attempted
+  assert_no_auto_merge
   [[ "$output" != *"::error::"* ]]
 }
 
@@ -61,7 +72,7 @@ plain_merge_attempted() { grep '^pr merge ' "$GH_MOCK_CALLS" | grep -qv -- '--au
   GH_MOCK_PR_MERGE_EXIT=1 GH_MOCK_PR_STATE=CLOSED run "$SCRIPT"
   [ "$status" -eq 0 ]
   [[ "$output" == *"::warning::PR #42 is closed without being merged"* ]]
-  ! auto_merge_attempted
+  assert_no_auto_merge
   [[ "$output" != *"::error::"* ]]
 }
 
@@ -78,8 +89,56 @@ plain_merge_attempted() { grep '^pr merge ' "$GH_MOCK_CALLS" | grep -qv -- '--au
   MERGE_METHOD="fast-forward" run "$SCRIPT"
   [ "$status" -eq 0 ]
   [[ "$output" == *"::error::Invalid merge method 'fast-forward'"* ]]
-  ! plain_merge_attempted
-  ! auto_merge_attempted
+  # One assertion covers both: the rejected-method path must issue no
+  # `gh pr merge` at all, neither plain nor --auto.
+  assert_no_merge_at_all
+}
+
+# ---------------------------------------------------------------------------
+# Retry. One bounded retry per merge call, so a single transient blip is not
+# escalated as though it were a permanent policy refusal.
+
+# How many times was `gh pr merge` called, with and without --auto? Mirrors the
+# shape of plain_merge_attempted: the mock records the whole arg line, so --auto
+# has to be excluded by match, not by position.
+plain_merge_count() { grep '^pr merge ' "$GH_MOCK_CALLS" | grep -cv -- '--auto' || true; }
+auto_merge_count() { grep -c '^pr merge .*--auto' "$GH_MOCK_CALLS" || true; }
+
+@test "a successful plain merge is not retried" {
+  GH_MOCK_PR_MERGE_EXIT=0 run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(plain_merge_count)" -eq 1 ]
+}
+
+@test "a refused plain merge is retried once before falling back" {
+  GH_MOCK_PR_MERGE_EXIT=1 GH_MOCK_PR_MERGE_AUTO_EXIT=0 GH_MOCK_PR_STATE=OPEN run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  # Twice, not once: the retry has to actually issue a second call.
+  [ "$(plain_merge_count)" -eq 2 ]
+}
+
+@test "a refused --auto is retried once before escalating" {
+  GH_MOCK_PR_MERGE_EXIT=1 GH_MOCK_PR_MERGE_AUTO_EXIT=1 GH_MOCK_PR_STATE=OPEN run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(auto_merge_count)" -eq 2 ]
+  [[ "$output" == *"::error::"* ]]
+  # The escalation says it retried, so the reader knows a transient cause was
+  # already ruled out once.
+  [[ "$output" == *"retried once"* ]]
+}
+
+@test "the queued warning does not promise the merge will complete on its own" {
+  GH_MOCK_PR_MERGE_EXIT=1 GH_MOCK_PR_MERGE_AUTO_EXIT=0 GH_MOCK_PR_STATE=OPEN \
+    GH_MOCK_PR_MERGE_OUT="not up to date with base" run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  # A queue accepted is not a merge landed: an up-to-date rule with no
+  # auto-update, a mid-wait conflict, or allow_auto_merge being off all sit here
+  # forever. The warning must point at what to check, and carry the refusal.
+  [[ "$output" == *"queued via GitHub auto-merge"* ]]
+  [[ "$output" == *"auto-merge is enabled on the repository"* ]]
+  [[ "$output" == *"up to date with its base"* ]]
+  [[ "$output" == *"not up to date with base"* ]]
+  assert_no_match 'will land once the remaining requirements pass' "$output"
 }
 
 @test "each valid merge method is passed through to gh" {

--- a/.github/actions/auto-approve-bot-prs/test/gh_mock.bash
+++ b/.github/actions/auto-approve-bot-prs/test/gh_mock.bash
@@ -31,8 +31,13 @@ set -o pipefail
 #                              exercise the log-injection sanitizer. The default
 #                              text is deliberately unchanged so existing
 #                              assertions keep working.
-# GH_MOCK_PR_MERGE_EXIT      → exit code for `gh pr merge`
-# GH_MOCK_PR_MERGE_OUT       → stdout for `gh pr merge`
+# GH_MOCK_PR_MERGE_EXIT      → exit code for a PLAIN `gh pr merge` (no --auto)
+# GH_MOCK_PR_MERGE_OUT       → stdout for a plain `gh pr merge`
+# GH_MOCK_PR_MERGE_AUTO_EXIT → exit code for `gh pr merge --auto`; defaults to
+#                              GH_MOCK_PR_MERGE_EXIT so tests that don't care
+#                              about the distinction keep working
+# GH_MOCK_PR_MERGE_AUTO_OUT  → stdout for `gh pr merge --auto`
+# GH_MOCK_PR_STATE           → state for `gh pr view --json state` (OPEN|MERGED|CLOSED)
 # GH_MOCK_CALLS              → path; each invocation appends one line of args
 
 [ -n "${GH_MOCK_CALLS:-}" ] && printf '%s\n' "$*" >> "$GH_MOCK_CALLS"
@@ -132,8 +137,25 @@ case "${1:-}" in
     shift
     case "${1:-}" in
       merge)
-        echo "${GH_MOCK_PR_MERGE_OUT:-enabled}"
+        # --auto and the plain merge are separately controllable: the script
+        # tries the plain merge first and only falls back to --auto.
+        if printf '%s\n' "$@" | grep -qx -- '--auto'; then
+          echo "${GH_MOCK_PR_MERGE_AUTO_OUT:-queued}"
+          exit "${GH_MOCK_PR_MERGE_AUTO_EXIT:-${GH_MOCK_PR_MERGE_EXIT:-0}}"
+        fi
+        echo "${GH_MOCK_PR_MERGE_OUT:-merged}"
         exit "${GH_MOCK_PR_MERGE_EXIT:-0}"
+        ;;
+      view)
+        shift
+        view_filter=""
+        while [ $# -gt 0 ]; do
+          case "$1" in
+            --jq) view_filter="$2"; shift 2 ;;
+            *) shift ;;
+          esac
+        done
+        printf '{"state":"%s"}\n' "${GH_MOCK_PR_STATE:-OPEN}" | apply_filter "$view_filter"
         ;;
       *) echo "unsupported gh pr subcommand: $*" >&2; exit 99 ;;
     esac

--- a/.github/actions/auto-approve-bot-prs/test/wait-for-ci.bats
+++ b/.github/actions/auto-approve-bot-prs/test/wait-for-ci.bats
@@ -994,3 +994,16 @@ kv() { grep "^$1=" "$GITHUB_OUTPUT" | tail -n1; }
   [ "$(kv ci_green)" = "ci_green=false" ]
   [[ "$output" == *"deploy/netlify"* ]]
 }
+
+@test "a missing log lib fails loudly instead of logging unsanitized" {
+  # An absent lib/log.sh is a packaging fault, and degrading to unsanitized
+  # output would silently reopen the check-name channel — the widest one in this
+  # script, since whoever posted the check on the head SHA picks `.name`. The
+  # script must die rather than emit a verdict. Running a copy with no sibling
+  # lib/ reproduces it. This test is what keeps the source-or-die guard honest:
+  # weaken it to `|| true`, or move it below the first echo, and this goes red.
+  cp "$SCRIPT" "$BATS_TEST_TMPDIR/wait-for-ci.sh"
+  GH_MOCK_CHECK_RUNS_JSON='{"check_runs":[]}' run "$BATS_TEST_TMPDIR/wait-for-ci.sh"
+  [ "$status" -ne 0 ]
+  assert_no_match 'ci_green=true' "$output"
+}

--- a/.github/actions/auto-approve-bot-prs/test/wait-for-ci.bats
+++ b/.github/actions/auto-approve-bot-prs/test/wait-for-ci.bats
@@ -2,6 +2,7 @@
 
 SCRIPT="$BATS_TEST_DIRNAME/../src/wait-for-ci.sh"
 load gh_mock
+load assertions
 
 setup() {
   setup_gh_mock
@@ -16,25 +17,6 @@ setup() {
 teardown() { rm -f "$GITHUB_OUTPUT"; teardown_gh_mock; }
 
 kv() { grep "^$1=" "$GITHUB_OUTPUT" | tail -n1; }
-
-# assert_no_match <perl-regex> <text> — fail the test if the regex matches.
-#
-# Do NOT write `! grep -q ... <<<"$output"` instead. Bash does not abort on a
-# command whose status is inverted with `!`, so under the `set -e` bats runs test
-# bodies with, a bare negated grep is a no-op unless it happens to be the final
-# line. Two assertions in this file were silently inert that way. A plain
-# function call returning non-zero does abort, so this one actually fails.
-assert_no_match() {
-  local rc=0
-  grep -qP -- "$1" <<<"$2" || rc=$?
-  case "$rc" in
-    0) printf 'assert_no_match: unexpected match for %s\n' "$1" >&2; return 1 ;;
-    1) return 0 ;;
-    # grep returns 2 for a malformed pattern. Treating that as "no match" is the
-    # very fail-open shape this helper exists to prevent, so it must fail loudly.
-    *) printf 'assert_no_match: grep error rc=%s for pattern %s\n' "$rc" "$1" >&2; return 1 ;;
-  esac
-}
 
 @test "no check-runs → ci_green=true" {
   GH_MOCK_CHECK_RUNS_JSON='{"check_runs":[]}' run "$SCRIPT"

--- a/.github/workflows/auto-approve-bot-prs.yaml
+++ b/.github/workflows/auto-approve-bot-prs.yaml
@@ -8,11 +8,11 @@ on:
         type: string
         default: 'renovate[bot],loft-bot,github-actions[bot]'
       merge-method:
-        description: 'Merge method for auto-merge (squash, merge, rebase)'
+        description: 'Merge method (squash, merge, rebase)'
         type: string
         default: 'squash'
       auto-merge:
-        description: 'Enable auto-merge after approval'
+        description: 'Merge the PR after approving it, directly where possible.'
         type: boolean
         default: false
       wait-max-attempts:

--- a/.github/workflows/auto-approve-bot-prs.yaml
+++ b/.github/workflows/auto-approve-bot-prs.yaml
@@ -29,7 +29,7 @@ on:
         default: '10'
     secrets:
       gh-access-token:
-        description: 'GitHub PAT for approving PRs (must be different identity from PR author)'
+        description: 'GitHub PAT for approving PRs, and for merging them directly when auto-merge is true — so it needs a merge path on the base branch, not just the auto-merge toggle (must be different identity from PR author)'
         required: true
       ci-read-token:
         description: 'Optional escape hatch for the read-only CI poll when the caller cannot grant `checks: read` / `statuses: read`. Classic PAT with `repo` scope, or an App token. Never gh-access-token.'

--- a/README.md
+++ b/README.md
@@ -484,12 +484,17 @@ Detected config files: `renovate.json`, `renovate.json5`, `.renovaterc`, `.renov
 
 ### Auto-approve bot PRs
 
-Approves (and optionally enables auto-merge on) PRs from trusted bot accounts
+Approves (and optionally merges) PRs from trusted bot accounts
 whose title or branch matches a known safe pattern (`chore:` / `fix(deps):` /
 `backport/` / `renovate/` / `update-platform-version-`). Hardened to **never
 block caller CI**: `continue-on-error: true` on the job, every shell step
 catches its own errors and exits 0, self-approval is pre-empted before calling
 the external approve action.
+
+With `auto-merge: true` the merge is performed **directly**, with GitHub's
+auto-merge queue only as a fallback — so `gh-access-token` needs a merge path on
+the base branch, not just the repository's auto-merge toggle. See the action's
+[README](.github/actions/auto-approve-bot-prs/README.md#merging).
 
 **Location:** `.github/workflows/auto-approve-bot-prs.yaml`
 

--- a/docs/workflows/auto-approve-bot-prs.md
+++ b/docs/workflows/auto-approve-bot-prs.md
@@ -12,8 +12,8 @@ secret.
 
 |       INPUT        |  TYPE   | REQUIRED |                    DEFAULT                     |                                                      DESCRIPTION                                                       |
 |--------------------|---------|----------|------------------------------------------------|------------------------------------------------------------------------------------------------------------------------|
-|     auto-merge     | boolean |  false   |                    `false`                     |                                            Enable auto-merge after approval                                            |
-|    merge-method    | string  |  false   |                   `"squash"`                   |                                  Merge method for auto-merge (squash, merge, rebase)                                   |
+|     auto-merge     | boolean |  false   |                    `false`                     |                             Merge the PR after approving it, <br>directly where possible.                              |
+|    merge-method    | string  |  false   |                   `"squash"`                   |                                          Merge method (squash, merge, rebase)                                          |
 |  trusted-authors   | string  |  false   | `"renovate[bot],loft-bot,github-actions[bot]"` |                                       Comma-separated list of trusted bot logins                                       |
 | wait-max-attempts  | string  |  false   |                     `"90"`                     | Max polling attempts waiting for other <br>CI checks (raise this when a slow required check, e.g. e2e, gates the PR).  |
 | wait-min-attempts  | string  |  false   |                     `"12"`                     |                                     Minimum polls before ci_green=true is allowed.                                     |

--- a/docs/workflows/auto-approve-bot-prs.md
+++ b/docs/workflows/auto-approve-bot-prs.md
@@ -25,10 +25,10 @@ secret.
 
 <!-- AUTO-DOC-SECRETS:START - Do not remove or modify this section -->
 
-|     SECRET      | REQUIRED |                                                                                               DESCRIPTION                                                                                               |
-|-----------------|----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-|  ci-read-token  |  false   | Optional escape hatch for the read-only <br>CI poll when the caller cannot <br>grant `checks: read` / `statuses: read`. Classic PAT <br>with `repo` scope, or an App <br>token. Never gh-access-token.  |
-| gh-access-token |   true   |                                                                GitHub PAT for approving PRs (must be different identity from PR author)                                                                 |
+|     SECRET      | REQUIRED |                                                                                                            DESCRIPTION                                                                                                             |
+|-----------------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|  ci-read-token  |  false   |              Optional escape hatch for the read-only <br>CI poll when the caller cannot <br>grant `checks: read` / `statuses: read`. Classic PAT <br>with `repo` scope, or an App <br>token. Never gh-access-token.                |
+| gh-access-token |   true   | GitHub PAT for approving PRs, and <br>for merging them directly when auto-merge <br>is true — so it needs <br>a merge path on the base <br>branch, not just the auto-merge toggle <br>(must be different identity from PR author)  |
 
 <!-- AUTO-DOC-SECRETS:END -->
 


### PR DESCRIPTION
Follow-up to #201 (the in-pipeline pro dependency bump). Three changes, all aimed at the same failure class: the action was silent about outcomes that require someone to act, so a PR that never merged looked identical to a PR that merged fine.

References DEVOPS-1209

## Merge directly, keep `--auto` as the fallback

By the time the merge step runs, `wait-for-ci.sh` has confirmed every other check is green and the PR is approved, so there is normally nothing left for GitHub's auto-merge queue to wait on. `--auto` additionally requires the repository's `allow_auto_merge` setting, which is invisible from inside the action and silently turns the merge into a no-op when it is off — and a merge that never happens strands whatever is waiting on it. The `vcluster-release` orchestrator blocks on exactly this merge during a legacy release cut, so that no-op stalls a release.

A refused direct merge still degrades to queueing, which is the right answer when a required check registered *after* the CI wait declared green. Re-runs are handled explicitly: an already-merged PR is benign, and a PR closed unmerged is a human decision, so neither escalates.

## Report actionable skips at warning/error level

Nothing here exits non-zero — the composite must not red-X a caller's CI over an unrelated bot PR — but notices are invisible on a green run, and the cause of a non-merge is only knowable inside the action. A caller waiting on the merge can see *that* it did not happen, never *why*.

An approved-but-unmerged PR now carries both underlying `gh` errors in an `::error::` annotation. Four causes that previously shared one notice are split, because they need different responses:

| cause | before | now |
| --- | --- | --- |
| merge conflict with base | `::notice::PR mergeability is '…'` | `::warning::` — needs a rebase |
| mergeability budget exhausted | same notice | `::warning::` — transient, re-run |
| token cannot resolve its own user | `::notice::Skipping approval (…)` | `::error::` — expired/insufficient scope |
| approver identity == PR author | same notice | `::error::` — self-approval is impossible |
| approved but not merged, not queued | `::notice::gh pr merge failed` | `::error::` with both `gh` errors |

## A real defect found while splitting those

`--jq '.mergeable // "null"'` collapsed a genuine `mergeable: false` into `"null"`, because jq's `//` treats `false` as an empty value:

```console
$ echo '{"mergeable":false}' | jq -r '.mergeable // "null"'
null
```

So a conflicted PR was indistinguishable from un-computed metadata, **and** burned the full ~30s retry budget re-polling a value that was already definitive. The filter now tests for null explicitly. Both halves are pinned by regression tests that fail against the old filter and pass with the fix:

```
not ok 2 mergeable=false → proceed=false, reported as a conflict needing a rebase
not ok 3 regression: mergeable=false is definitive and must not burn the retry budget
```

## Tests

`enable-auto-merge.sh` had no coverage; this adds `enable-auto-merge.bats` (10 cases: direct-merge success without touching `--auto`, fallback-to-queue, both-refused escalation, already-merged, closed-unmerged, unreadable state, invalid merge method, per-method passthrough, env guards). The `gh` mock gains separate control of the direct and `--auto` merges plus `gh pr view --json state`.

`make test-auto-approve-bot-prs` — 61 pass, 0 fail. `shellcheck`, `actionlint` and `make check-docs` clean.

## Compatibility

No new inputs; `auto-merge: true` behaves the same from a caller's point of view, minus the dependency on the repo setting. Existing callers on `auto-merge: false` are unaffected by the merge change and only see the improved annotations. Docs regenerated via `make generate-docs`.