### PR TITLE
fix(auto-approve): hold cancelled checks while a newer suite is still running

### DIFF
--- a/.github/actions/auto-approve-bot-prs/README.md
+++ b/.github/actions/auto-approve-bot-prs/README.md
@@ -31,6 +31,27 @@ minutes to register their first `pending` signal, the action enforces a
 This prevents early approval against a PR that looks quiet simply because
 slow external checks have not shown up yet.
 
+### Cancelled checks
+
+`cancelled` is neither a pass nor a failure. It is usually GitHub's
+concurrency-group cancellation superseding a run, in which case a replacement
+is on its way and the cancelled attempt should be ignored once the replacement
+registers. So it is held rather than bailed on, and released two ways:
+
+- **Superseded** — a non-completed check-run exists in a **newer check suite**
+  than the cancelled one. A rerun is demonstrably in flight, so the wait
+  continues until it registers (bounded by `wait-max-attempts`). Suite ids are
+  monotonic, which is what makes "newer" observable without `actions: read`.
+- **Final** — no newer suite is running. Past `wait-min-attempts` the
+  cancellation is treated as real (a human pressed cancel) and approval is
+  skipped.
+
+Do not tie this to `wait-min-attempts` alone. A cancelled job queued behind a
+long build in the same workflow cannot be replaced until that build finishes,
+which is routinely minutes after the floor expires — the bail then discards a
+rerun that was still coming. That stalled the `v0.34.7` cut
+(vcluster-pro#2155): floor expired 12:49:45, replacement registered 12:51:41.
+
 ## Inputs
 
 <!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->

--- a/.github/actions/auto-approve-bot-prs/README.md
+++ b/.github/actions/auto-approve-bot-prs/README.md
@@ -31,6 +31,29 @@ minutes to register their first `pending` signal, the action enforces a
 This prevents early approval against a PR that looks quiet simply because
 slow external checks have not shown up yet.
 
+### Which attempt counts
+
+GitHub keeps every attempt for a name on the same SHA — reruns, and each
+concurrency-superseded run — so the poll picks one per name. It ranks by
+**information content first, then recency**:
+
+| rank | conclusion | meaning |
+|------|------------|---------|
+| 3 | not completed | verdict not in yet, wait |
+| 2 | success, neutral, failure, timed_out, … | carries a verdict |
+| 1 | skipped, cancelled | carries no verdict about the code |
+
+Recency alone is not safe. A workflow that skips its expensive job on a no-op
+PR-description edit publishes a `skipped` check-run named after the job that
+already **failed** on that SHA, with a later `started_at` — so latest-wins would
+pick `skipped`, count it green, and approve a PR whose suite failed. Ranking
+keeps the failure. A genuine re-run that *succeeds* still clears it, because
+success carries a verdict and recency then decides.
+
+This is not a Checks API artifact and `filter=latest` does not help: that
+dedupes within a check suite, and every run gets its own suite, so the API
+faithfully returns all attempts.
+
 ### Cancelled checks
 
 `cancelled` is neither a pass nor a failure. It is usually GitHub's

--- a/.github/actions/auto-approve-bot-prs/src/wait-for-ci.sh
+++ b/.github/actions/auto-approve-bot-prs/src/wait-for-ci.sh
@@ -210,13 +210,41 @@ while [ "$attempt" -lt "$max_attempts" ]; do
   # a common case when concurrency-group cancellation and the winning run
   # start within the same second. GitHub allocates check-run IDs
   # monotonically, so the larger id is always the newer attempt.
+  #
+  # "Latest wins" alone lets a `skipped` bury a real failure. A workflow that
+  # skips its expensive job on a no-op PR-description edit (vcluster-pro's e2e
+  # gates on DEVOPS-1057 do exactly this) publishes a check-run named the same as
+  # the job that already FAILED on this SHA, with a later started_at. Dedup then
+  # picks `skipped`, which counts as green below, and a PR whose suite genuinely
+  # failed becomes approvable. Note the Checks API is not the problem here and
+  # `filter=latest` would not help: it dedupes within a check suite, and each run
+  # gets its own suite, so the API faithfully returns every attempt. The
+  # collapsing is ours, so the fix is ours.
+  #
+  # Rank by information content, then recency. `skipped` and `cancelled` carry no
+  # verdict about the code; success/neutral and the failure classes do. So prefer
+  # the latest attempt that actually reached a verdict, and fall back to the
+  # latest attempt overall when none did. A still-running attempt outranks
+  # everything, because a rerun in flight means the verdict is not in yet.
+  #
+  # This ordering is what keeps each case right:
+  #   cancelled then skipped   -> skipped   (concurrency replacement; unblocks)
+  #   cancelled then success   -> success   (ditto)
+  #   failure   then skipped   -> failure   (the bug above; stays blocked)
+  #   failure   then success   -> success   (a real re-run of a flake; unblocks)
+  #   success   then pending   -> pending   (wait for the rerun)
   other=""
   if [ "$poll_errored" -eq 0 ]; then
     if ! other=$(jq_or_fail '
+      def rank:
+        if (.status // "") != "completed" then 3
+        elif ([.conclusion // ""] | inside(["skipped","cancelled"])) then 1
+        else 2
+        end;
       (.check_runs // [])
       | [.[] | select((.details_url // "") | contains("'"$EXCLUDE_PATTERN"'") | not)]
       | group_by(.name // "")
-      | map(sort_by(.started_at // "", .id // 0) | last)
+      | map(sort_by(rank, .started_at // "", .id // 0) | last)
     ' "$runs_raw"); then
       last_error="malformed check-runs response (jq could not parse it)"
       echo "::warning::attempt ${attempt}/${max_attempts}: check-runs jq parse failed"

--- a/.github/actions/auto-approve-bot-prs/src/wait-for-ci.sh
+++ b/.github/actions/auto-approve-bot-prs/src/wait-for-ci.sh
@@ -13,6 +13,12 @@
 # lets slow registrants (observed: 2+ minutes in the wild) appear before
 # approval.
 #
+# `cancelled` is not treated as final while a newer check suite on the same head
+# SHA is still running: that is a concurrency rerun on its way to replacing it.
+# The floor does not bound this case — a cancelled job queued behind a long
+# build cannot be replaced until that build finishes, minutes after the floor
+# expires. max_attempts is the bound.
+#
 # API errors never degrade to silent green. Every gh/jq error is captured and
 # treated as "unknown state" — the poll does not count toward the settle
 # floor, and consecutive errors eventually time out to ci_green=false.
@@ -220,13 +226,12 @@ while [ "$attempt" -lt "$max_attempts" ]; do
 
   # `cancelled` is special: GitHub's concurrency-group cancellation marks the
   # superseded run cancelled and immediately queues a replacement. There's a
-  # short window (observed: 5–10s) where the cancelled attempt is registered
-  # but the replacement is not yet visible. In that window the dedup-by-latest
-  # logic above has nothing to pick — only the cancelled attempt exists — so
-  # treating cancelled as a hard failure here would defeat the dedup fix and
-  # bail before the rerun lands. Split it out: terminal failures bail
-  # immediately; cancelled-only is held until the settle floor so the
-  # replacement has a chance to register and dedup can pick it.
+  # window where the cancelled attempt is registered but the replacement is not
+  # yet visible. In that window the dedup-by-latest logic above has nothing to
+  # pick — only the cancelled attempt exists — so treating cancelled as a hard
+  # failure here would defeat the dedup fix and bail before the rerun lands.
+  # Split it out: terminal failures bail immediately; cancelled is held while a
+  # replacement is still plausibly on its way (see the watermark below).
   cr_pending=0 cr_real_failed=0 cr_real_failed_detail=""
   cr_cancelled=0 cr_cancelled_detail="" cr_pending_names=""
   if [ "$poll_errored" -eq 0 ]; then
@@ -236,6 +241,47 @@ while [ "$attempt" -lt "$max_attempts" ]; do
     cr_cancelled=$(         jq_or_fail '[.[] | select(.conclusion == "cancelled")] | length'                                                                                                      "$other" ) || poll_errored=1
     cr_cancelled_detail=$(  jq_or_fail -r '[.[] | select(.conclusion == "cancelled") | .name // "unnamed"] | join(", ")'                                                                          "$other" ) || poll_errored=1
     cr_pending_names=$(     jq_or_fail -r '[.[] | select(.status != "completed") | .name // "unnamed"] | join(", ")'                                                                              "$other" ) || poll_errored=1
+  fi
+
+  # How long a cancelled check may be held used to be exactly the settle floor
+  # (~120s at the defaults). That assumed a replacement registers in seconds,
+  # which is only true when the cancelled job starts immediately. When it sits
+  # behind an earlier job in the same workflow — an image build, say — the
+  # replacement's check-run does not exist until that build finishes, minutes
+  # later. The floor then expires first and the bail throws away a rerun that
+  # was still coming. Observed on vcluster-pro#2155: two e2e runs cancelled by
+  # concurrency at 12:47, replacement check-runs registered 12:51:41, bail at
+  # 12:49:45 — and the release cut it was gating stalled behind it.
+  #
+  # So do not time the tolerance. Condition it on an observable: is a NEWER
+  # check suite than the cancelled one still running? GitHub allocates check
+  # suite ids monotonically and a re-triggered workflow lands in a new suite,
+  # so a non-completed check-run in a higher-numbered suite is exactly the
+  # "a rerun is in flight" signal, and its absence is "nothing more is coming".
+  #
+  # Read from the check-runs payload we already have, not from /actions/runs.
+  # Resolving each cancelled suite to its workflow and looking for a newer run
+  # of that same workflow would be more precise, but that endpoint needs
+  # `actions: read` — a grant every caller would have to add, degrading to this
+  # same bail until they all did. DEVOPS-1254 was exactly that class of bug.
+  #
+  # The wait stays bounded three ways: `other` excludes our own run, so this job
+  # cannot justify waiting on itself; a genuine user-cancelled check has no
+  # newer suite behind it and still bails at the floor; and anything left in
+  # flight is capped by max_attempts.
+  #
+  # The watermark is derived inside jq rather than round-tripped through the
+  # shell so the comparison stays numeric — suite ids are ~11 digits and a
+  # string compare would order them by prefix. `// 0` on both sides makes a
+  # missing check_suite read as oldest, never as newer.
+  cr_newer_suite_pending=0
+  if [ "$poll_errored" -eq 0 ] && [ "$cr_cancelled" -gt 0 ]; then
+    # shellcheck disable=SC2016  # $w is a jq variable, not a shell one
+    cr_newer_suite_pending=$(jq_or_fail '
+      ([.[] | select(.conclusion == "cancelled") | .check_suite.id // 0] | max // 0) as $w
+      | [.[] | select(.status != "completed") | select((.check_suite.id // 0) > $w)]
+      | length
+    ' "$other" ) || poll_errored=1
   fi
 
   # -- Fetch commit statuses ------------------------------------------------
@@ -315,13 +361,16 @@ while [ "$attempt" -lt "$max_attempts" ]; do
   fi
 
   # Cancelled checks may be in the middle of a concurrency-triggered rerun.
-  # Past the settle floor we stop waiting and treat them as final — the
-  # replacement should have registered by now if it was ever going to.
-  if [ "$cr_cancelled" -gt 0 ] && [ "$attempt" -ge "$min_attempts" ]; then
+  # Past the settle floor we stop waiting and treat them as final — unless a
+  # newer check suite is still running, which means the rerun that will replace
+  # them has started but not yet reached the cancelled job. Waiting on that is
+  # bounded by max_attempts.
+  if [ "$cr_cancelled" -gt 0 ] && [ "$attempt" -ge "$min_attempts" ] \
+     && [ "$cr_newer_suite_pending" -eq 0 ]; then
     # ::error:: because a cancelled check is not red anywhere else: unlike the
     # failed-checks path below, this annotation is the only signal an operator
     # gets, and a release cut may be blocking on the merge.
-    echo "::error::Cancelled checks did not get replaced within settle period; skipping approval. Cancelled: $(safe "${cr_cancelled_detail:-unknown}")"
+    echo "::error::Cancelled checks are final (no newer check suite is still running); skipping approval. Cancelled: $(safe "${cr_cancelled_detail:-unknown}")"
     emit ci_green false
     exit 0
   fi
@@ -332,8 +381,17 @@ while [ "$attempt" -lt "$max_attempts" ]; do
     waiting=$(printf '%s\n%s' "$cr_pending_names" "$st_pending_names" | awk 'NF' | paste -sd, - | sed 's/,/, /g' | sanitize_for_log 1000)
     echo "  pending: ${waiting:-<unnamed>}"
   fi
+  # Distinguish the two holds, because they end differently: one is waiting on a
+  # rerun that is demonstrably running (ends when it registers, or at
+  # max_attempts), the other is inside the settle floor on nothing but hope
+  # (ends at min_attempts). Reading "waiting for replacement" on a poll where
+  # nothing was coming is what made the vcluster-pro#2155 timeline hard to read.
   if [ "$cr_cancelled" -gt 0 ]; then
-    echo "  cancelled (waiting for concurrency replacement): $(safe "$cr_cancelled_detail")"
+    if [ "$cr_newer_suite_pending" -gt 0 ]; then
+      echo "  cancelled (superseded; newer check suite still running): $(safe "$cr_cancelled_detail")"
+    else
+      echo "  cancelled (waiting for concurrency replacement): $(safe "$cr_cancelled_detail")"
+    fi
   fi
 
   # Hold the "green" verdict until the settle floor. A first-poll "pending=0"

--- a/.github/actions/auto-approve-bot-prs/test/wait-for-ci.bats
+++ b/.github/actions/auto-approve-bot-prs/test/wait-for-ci.bats
@@ -715,25 +715,32 @@ assert_no_match() {
   export WAIT_MIN_ATTEMPTS=4
   export WAIT_MAX_ATTEMPTS=6
 
+  cancelled='{"name":"Mobile Safari (iPhone)","id":100,"status":"completed","conclusion":"cancelled","started_at":"2026-04-27T07:40:05Z","details_url":"https://external/runs/220/job/1"}'
+  replacement='{"name":"Mobile Safari (iPhone)","id":200,"status":"completed","conclusion":"skipped","started_at":"2026-04-27T07:40:15Z","details_url":"https://external/runs/221/job/1"}'
+
+  # Polls 1-2: only the cancelled attempt is visible (the failure window).
+  # One JSON object per PHYSICAL line — the mock serves a sequence entry with
+  # `sed -n "${n}p"`, so a pretty-printed fixture arrives as an unparseable
+  # fragment. This test used to be written that way: polls 3-4 errored out, the
+  # sequence fell through to the empty default, and the green verdict came from
+  # "no checks at all" rather than from dedup picking the replacement. It passed
+  # without ever exercising the path it names.
   export GH_MOCK_CHECK_RUNS_SEQ="$MOCK_DIR/cr_seq"
   {
-    # Polls 1-2: only the cancelled attempt is visible (the failure window).
-    echo '{"check_runs":[{"name":"Mobile Safari (iPhone)","id":100,"status":"completed","conclusion":"cancelled","started_at":"2026-04-27T07:40:05Z","details_url":"https://external/runs/220/job/1"}]}'
-    echo '{"check_runs":[{"name":"Mobile Safari (iPhone)","id":100,"status":"completed","conclusion":"cancelled","started_at":"2026-04-27T07:40:05Z","details_url":"https://external/runs/220/job/1"}]}'
-    # Poll 3+: replacement skipped attempt registers; dedup picks the newer id.
-    echo '{"check_runs":[
-      {"name":"Mobile Safari (iPhone)","id":100,"status":"completed","conclusion":"cancelled","started_at":"2026-04-27T07:40:05Z","details_url":"https://external/runs/220/job/1"},
-      {"name":"Mobile Safari (iPhone)","id":200,"status":"completed","conclusion":"skipped","started_at":"2026-04-27T07:40:15Z","details_url":"https://external/runs/221/job/1"}
-    ]}'
-    echo '{"check_runs":[
-      {"name":"Mobile Safari (iPhone)","id":100,"status":"completed","conclusion":"cancelled","started_at":"2026-04-27T07:40:05Z","details_url":"https://external/runs/220/job/1"},
-      {"name":"Mobile Safari (iPhone)","id":200,"status":"completed","conclusion":"skipped","started_at":"2026-04-27T07:40:15Z","details_url":"https://external/runs/221/job/1"}
-    ]}'
+    printf '{"check_runs":[%s]}\n' "$cancelled"
+    printf '{"check_runs":[%s]}\n' "$cancelled"
   } > "$GH_MOCK_CHECK_RUNS_SEQ"
+  # Poll 3+: replacement skipped attempt registers; dedup picks the newer id.
+  export GH_MOCK_CHECK_RUNS_JSON
+  GH_MOCK_CHECK_RUNS_JSON="$(printf '{"check_runs":[%s,%s]}' "$cancelled" "$replacement")"
 
   run "$SCRIPT"
   [ "$status" -eq 0 ]
   [ "$(kv ci_green)" = "ci_green=true" ]
+  # The verdict came from a poll that saw the replacement, not from a parse
+  # failure degrading into an empty check list.
+  assert_no_match 'jq parse failed' "$output"
+  [[ "$output" == *"cancelled=1"* ]]
 }
 
 @test "regression: cancelled replacement that arrives as success also unblocks" {
@@ -744,19 +751,22 @@ assert_no_match() {
   export WAIT_MIN_ATTEMPTS=3
   export WAIT_MAX_ATTEMPTS=5
 
+  cancelled='{"name":"e2e","id":100,"status":"completed","conclusion":"cancelled","started_at":"2026-04-27T07:40:05Z","details_url":"https://external/runs/220/job/1"}'
+  replacement='{"name":"e2e","id":200,"status":"completed","conclusion":"success","started_at":"2026-04-27T07:40:15Z","details_url":"https://external/runs/221/job/1"}'
+
   export GH_MOCK_CHECK_RUNS_SEQ="$MOCK_DIR/cr_seq"
   {
-    echo '{"check_runs":[{"name":"e2e","id":100,"status":"completed","conclusion":"cancelled","started_at":"2026-04-27T07:40:05Z","details_url":"https://external/runs/220/job/1"}]}'
-    echo '{"check_runs":[{"name":"e2e","id":100,"status":"completed","conclusion":"cancelled","started_at":"2026-04-27T07:40:05Z","details_url":"https://external/runs/220/job/1"}]}'
-    echo '{"check_runs":[
-      {"name":"e2e","id":100,"status":"completed","conclusion":"cancelled","started_at":"2026-04-27T07:40:05Z","details_url":"https://external/runs/220/job/1"},
-      {"name":"e2e","id":200,"status":"completed","conclusion":"success","started_at":"2026-04-27T07:40:15Z","details_url":"https://external/runs/221/job/1"}
-    ]}'
+    printf '{"check_runs":[%s]}\n' "$cancelled"
+    printf '{"check_runs":[%s]}\n' "$cancelled"
   } > "$GH_MOCK_CHECK_RUNS_SEQ"
+  export GH_MOCK_CHECK_RUNS_JSON
+  GH_MOCK_CHECK_RUNS_JSON="$(printf '{"check_runs":[%s,%s]}' "$cancelled" "$replacement")"
 
   run "$SCRIPT"
   [ "$status" -eq 0 ]
   [ "$(kv ci_green)" = "ci_green=true" ]
+  assert_no_match 'jq parse failed' "$output"
+  [[ "$output" == *"cancelled=1"* ]]
 }
 
 @test "regression: cancelled-only that never gets replaced bails at settle floor (bounded wait)" {
@@ -772,7 +782,98 @@ assert_no_match() {
   [ "$status" -eq 0 ]
   [ "$(kv ci_green)" = "ci_green=false" ]
   [[ "$output" == *"e2e"* ]]
-  [[ "$output" == *"Cancelled checks did not get replaced"* ]]
+  [[ "$output" == *"Cancelled checks are final"* ]]
+}
+
+@test "regression: devops-1254 — cancelled behind a running newer suite outlives the settle floor" {
+  # vcluster-pro#2155, the v0.34.7 cut. Three pull_request events (opened plus
+  # two bot body edits) fired within 23s; concurrency cancelled the first two
+  # e2e-next runs. The winning run's `E2E Next Tests` job sits behind an image
+  # build, so its check-run did not register until 12:51:41 — while the settle
+  # floor expired at 12:49:45 and the pre-fix bail discarded a rerun that was
+  # visibly still running. The build job's check-run, in a NEWER check suite
+  # than the cancelled attempts, is the evidence that it was still coming.
+  export WAIT_MIN_ATTEMPTS=2
+  export WAIT_MAX_ATTEMPTS=6
+
+  # One JSON object per PHYSICAL line: the mock reads a sequence entry with
+  # `sed -n "${n}p"`, so a pretty-printed fixture is served to the script as a
+  # fragment that fails to parse.
+  cancelled='{"name":"E2E Next Tests","id":100,"status":"completed","conclusion":"cancelled","started_at":"2026-08-03T12:47:44Z","check_suite":{"id":100},"details_url":"https://github.com/o/r/actions/runs/220/job/1"}'
+  building='{"name":"Build vcluster-pro image","id":110,"status":"in_progress","conclusion":null,"started_at":"2026-08-03T12:48:50Z","check_suite":{"id":300},"details_url":"https://github.com/o/r/actions/runs/222/job/1"}'
+  built='{"name":"Build vcluster-pro image","id":110,"status":"completed","conclusion":"success","started_at":"2026-08-03T12:48:50Z","check_suite":{"id":300},"details_url":"https://github.com/o/r/actions/runs/222/job/1"}'
+  replacement='{"name":"E2E Next Tests","id":200,"status":"completed","conclusion":"success","started_at":"2026-08-03T12:51:43Z","check_suite":{"id":300},"details_url":"https://github.com/o/r/actions/runs/222/job/1"}'
+
+  export GH_MOCK_CHECK_RUNS_SEQ="$MOCK_DIR/cr_seq"
+  {
+    # Polls 1-3: cancelled attempt from suite 100, and the replacement run's
+    # build job (suite 300) still in progress ahead of the cancelled job.
+    for _ in 1 2 3; do printf '{"check_runs":[%s,%s]}\n' "$cancelled" "$building"; done
+    # Poll 4: the build finished and the replacement E2E check-run registered.
+    printf '{"check_runs":[%s,%s,%s]}\n' "$cancelled" "$built" "$replacement"
+  } > "$GH_MOCK_CHECK_RUNS_SEQ"
+
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv ci_green)" = "ci_green=true" ]
+  # Held past the floor (attempt 2) instead of bailing there.
+  [[ "$output" == *"attempt 3/"* ]]
+  [[ "$output" == *"cancelled (superseded; newer check suite still running)"* ]]
+  assert_no_match 'Cancelled checks are final' "$output"
+}
+
+@test "regression: pending check in an OLDER suite does not extend the cancelled hold" {
+  # The watermark is directional. A check still running in a suite older than
+  # the cancelled attempt is not a replacement for it — nothing newer has been
+  # queued — so the floor must still end the wait. Without the comparison this
+  # would degrade into "any pending check keeps cancelled alive", which is the
+  # unbounded wait the settle floor exists to prevent.
+  export WAIT_MIN_ATTEMPTS=2
+  export WAIT_MAX_ATTEMPTS=20
+  GH_MOCK_CHECK_RUNS_JSON='{"check_runs":[
+    {"name":"e2e","status":"completed","conclusion":"cancelled","check_suite":{"id":300},"details_url":"https://github.com/o/r/actions/runs/222/job/1"},
+    {"name":"slow-lint","status":"in_progress","conclusion":null,"check_suite":{"id":100},"details_url":"https://github.com/o/r/actions/runs/223/job/1"}
+  ]}' run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv ci_green)" = "ci_green=false" ]
+  [[ "$output" == *"Cancelled checks are final"* ]]
+  # Bailed at the floor, not at max_attempts.
+  assert_no_match 'attempt 3/' "$output"
+}
+
+@test "regression: our own in-progress check cannot justify holding a cancelled check" {
+  # The self-exclusion is what keeps the new hold bounded: this job's own
+  # check-run is always in progress while it polls, and it always lands in the
+  # newest check suite. If it counted as "a newer suite is still running", every
+  # cancelled check would be held to max_attempts and the settle floor would be
+  # dead code.
+  export WAIT_MIN_ATTEMPTS=2
+  export WAIT_MAX_ATTEMPTS=20
+  GH_MOCK_CHECK_RUNS_JSON='{"check_runs":[
+    {"name":"e2e","status":"completed","conclusion":"cancelled","check_suite":{"id":100},"details_url":"https://github.com/o/r/actions/runs/220/job/1"},
+    {"name":"auto-approve","status":"in_progress","conclusion":null,"check_suite":{"id":900},"details_url":"https://github.com/o/r/actions/runs/111111/job/1"}
+  ]}' run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv ci_green)" = "ci_green=false" ]
+  [[ "$output" == *"Cancelled checks are final"* ]]
+  assert_no_match 'attempt 3/' "$output"
+}
+
+@test "regression: cancelled check-runs with no suite id still bail at the floor" {
+  # Not every check-run carries a check_suite (external apps, and every fixture
+  # written before this watermark existed). A missing id must read as 0 on both
+  # sides of the comparison — never as "newer" — so the pre-existing bail
+  # behaviour is what an absent suite falls back to.
+  export WAIT_MIN_ATTEMPTS=2
+  export WAIT_MAX_ATTEMPTS=20
+  GH_MOCK_CHECK_RUNS_JSON='{"check_runs":[
+    {"name":"e2e","status":"completed","conclusion":"cancelled","details_url":"https://github.com/o/r/actions/runs/220/job/1"},
+    {"name":"other","status":"in_progress","conclusion":null,"details_url":"https://github.com/o/r/actions/runs/221/job/1"}
+  ]}' run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv ci_green)" = "ci_green=false" ]
+  [[ "$output" == *"Cancelled checks are final"* ]]
+  assert_no_match 'attempt 3/' "$output"
 }
 
 @test "regression: terminal failure during settle window still bails immediately" {

--- a/.github/actions/auto-approve-bot-prs/test/wait-for-ci.bats
+++ b/.github/actions/auto-approve-bot-prs/test/wait-for-ci.bats
@@ -859,6 +859,80 @@ assert_no_match() {
   assert_no_match 'attempt 3/' "$output"
 }
 
+@test "regression: a skipped rerun must not bury a failure on the same SHA" {
+  # Raised in review of vcluster-pro#2156. A workflow that skips its expensive
+  # job on a no-op PR-description edit (the DEVOPS-1057 gates) publishes a
+  # check-run with the SAME NAME as the job that already failed on this SHA, and
+  # a later started_at. Plain latest-wins dedup then picks `skipped`, which
+  # counts as green, and a PR whose suite genuinely failed becomes approvable.
+  #
+  # Not a Checks API artifact: `filter=latest` dedupes within a check suite and
+  # each run gets its own suite, so the API returns both attempts. The
+  # collapsing was ours.
+  GH_MOCK_CHECK_RUNS_JSON='{"check_runs":[
+    {"name":"E2E Tests","id":100,"status":"completed","conclusion":"failure","started_at":"2026-08-03T13:41:46Z","details_url":"https://github.com/o/r/actions/runs/220/job/1"},
+    {"name":"E2E Tests","id":200,"status":"completed","conclusion":"skipped","started_at":"2026-08-03T13:46:07Z","details_url":"https://github.com/o/r/actions/runs/221/job/1"}
+  ]}' run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv ci_green)" = "ci_green=false" ]
+  [[ "$output" == *"E2E Tests=failure"* ]]
+}
+
+@test "regression: a real re-run that succeeds still clears an earlier failure" {
+  # The other half of the ranking, and the reason a failure cannot simply be
+  # sticky per name: "Re-run failed jobs" on the same SHA is a normal way to
+  # clear a flake on a bump PR. success carries a verdict, so recency decides
+  # between it and the failure, and the newer success wins.
+  GH_MOCK_CHECK_RUNS_JSON='{"check_runs":[
+    {"name":"E2E Tests","id":100,"status":"completed","conclusion":"failure","started_at":"2026-08-03T13:41:46Z","details_url":"https://github.com/o/r/actions/runs/220/job/1"},
+    {"name":"E2E Tests","id":200,"status":"completed","conclusion":"success","started_at":"2026-08-03T13:46:07Z","details_url":"https://github.com/o/r/actions/runs/221/job/1"}
+  ]}' run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv ci_green)" = "ci_green=true" ]
+}
+
+@test "regression: a running rerun outranks an earlier verdict and is waited on" {
+  # A pending attempt means the verdict is not in yet, so it must outrank an
+  # older success — otherwise we would approve against a stale green while the
+  # rerun that supersedes it is still executing. Latest-wins already did this by
+  # started_at, so this pins behaviour the ranking must not break rather than
+  # behaviour it introduces; it passes against the pre-ranking script too.
+  export WAIT_MIN_ATTEMPTS=1
+  export WAIT_MAX_ATTEMPTS=2
+  GH_MOCK_CHECK_RUNS_JSON='{"check_runs":[
+    {"name":"E2E Tests","id":100,"status":"completed","conclusion":"success","started_at":"2026-08-03T13:41:46Z","details_url":"https://github.com/o/r/actions/runs/220/job/1"},
+    {"name":"E2E Tests","id":200,"status":"in_progress","conclusion":null,"started_at":"2026-08-03T13:46:07Z","details_url":"https://github.com/o/r/actions/runs/221/job/1"}
+  ]}' run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv ci_green)" = "ci_green=false" ]
+  [[ "$output" == *"pending: E2E Tests"* ]]
+}
+
+@test "regression: skipped still supersedes cancelled (concurrency replacement)" {
+  # The ranking must not undo the replacement fix: skipped and cancelled both
+  # carry no verdict, so recency alone decides between them and the newer
+  # skipped wins, leaving nothing to block on.
+  GH_MOCK_CHECK_RUNS_JSON='{"check_runs":[
+    {"name":"E2E Istio","id":100,"status":"completed","conclusion":"cancelled","started_at":"2026-08-03T12:47:44Z","details_url":"https://github.com/o/r/actions/runs/220/job/1"},
+    {"name":"E2E Istio","id":200,"status":"completed","conclusion":"skipped","started_at":"2026-08-03T12:51:41Z","details_url":"https://github.com/o/r/actions/runs/221/job/1"}
+  ]}' run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv ci_green)" = "ci_green=true" ]
+}
+
+@test "regression: a failure outranks a LATER cancelled attempt" {
+  # Ordering is by information content first, so a failure is not displaced by a
+  # rerun that was itself cancelled — that rerun produced no verdict, and the
+  # failure is still the last thing this SHA actually proved.
+  GH_MOCK_CHECK_RUNS_JSON='{"check_runs":[
+    {"name":"E2E Tests","id":100,"status":"completed","conclusion":"failure","started_at":"2026-08-03T13:41:46Z","details_url":"https://github.com/o/r/actions/runs/220/job/1"},
+    {"name":"E2E Tests","id":200,"status":"completed","conclusion":"cancelled","started_at":"2026-08-03T13:46:07Z","details_url":"https://github.com/o/r/actions/runs/221/job/1"}
+  ]}' run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv ci_green)" = "ci_green=false" ]
+  [[ "$output" == *"E2E Tests=failure"* ]]
+}
+
 @test "regression: cancelled check-runs with no suite id still bail at the floor" {
   # Not every check-run carries a check_suite (external apps, and every fixture
   # written before this watermark existed). A missing id must read as 0 on both


### PR DESCRIPTION
## What

Stops `wait-for-ci.sh` treating a concurrency-cancelled check as final while the
rerun that will replace it is demonstrably still running.

## Why

The `v0.34.7` cut stalled the same way `v0.36.1` did, one bug further down the
same path. [vcluster-pro#2155](https://github.com/loft-sh/vcluster-pro/pull/2155)
had every check green and was mergeable; the bot never approved it.

DEVOPS-1254 (#209 + the caller PRs) fixed the 403 that made the poll blind.
That worked — attempt 1 enumerated 10 pending checks cleanly. This is what it
then did:

```
attempt 12/600: check_runs(pending=5 failed=0 cancelled=2)
::error::Cancelled checks did not get replaced within settle period; skipping approval.
          Cancelled: E2E Istio (${{ matrix.istio-version }}), E2E Next Tests
ci_green=false
```

Three `pull_request` events fired within 23s (`opened`, plus two bot body
edits), so concurrency cancelled the first two `e2e-next` runs. The winning
run's `E2E Next Tests` job sits behind an image build, so its check-run did not
register until **12:51:41** — while the cancelled tolerance, tied to
`wait-min-attempts`, expired at **12:49:45**. The bail discarded a rerun that
was visibly still running. Nothing was wrong with the PR.

## Approach

Timing the tolerance cannot work. It was calibrated on the docs backport storm
(#2019/#2020), where the cancelled job restarted immediately and 5-10s was
enough. A cancelled job queued behind a build is minutes away by construction,
and no floor is both long enough for that and short enough to still be a floor.

So condition it on an observable: **is a check suite newer than the cancelled
one still running?** Suite ids are monotonic and a re-triggered workflow lands
in a new suite, so a non-completed check-run in a higher-numbered suite is
precisely "a rerun is in flight", and its absence is "nothing more is coming".

Read from the check-runs payload already in hand rather than `/actions/runs`,
which would need `actions: read` in every caller and silently degrade to this
same bail until they all had it — DEVOPS-1254 was exactly that class of bug.

### The wait stays bounded

| Case | Ends at |
|------|---------|
| Rerun in flight | when its check-run registers, else `wait-max-attempts` |
| Human-cancelled (no newer suite) | `wait-min-attempts`, as today |
| Our own in-progress check | never counts — `other` already excludes our run |

That last row is load-bearing. This job's own check-run is always in progress
and always in the newest suite, so without the pre-existing self-exclusion the
floor would be dead code. There is a test pinning it.

## Tests

`make test-auto-approve-bot-prs` — 78 pass. Four new regression tests: the
#2155 shape, a pending check in an *older* suite (proves the comparison is
directional, not "any pending check keeps cancelled alive"), our own check not
justifying the hold, and a missing `check_suite` reading as oldest. Verified
each fails against the pre-fix script.

## Drive-by: two tests were passing for the wrong reason

The two tests guarding the replacement path used pretty-printed fixtures. The
mock serves a sequence entry with `sed -n "${n}p"`, so polls 3+ arrived as
unparseable fragments, fell through to the empty `{"check_runs":[]}` default,
and the green verdict came from "no checks at all" — dedup was never exercised:

```
::warning::attempt 3/6: check-runs jq parse failed
::warning::attempt 4/6: check-runs jq parse failed
attempt 5/6: check_runs(pending=0 failed=0 cancelled=0)
ci_green=true
```

Fixed to one object per physical line, and they now assert no parse failure
occurred and that a cancelled check was actually seen.

## Sequencing

**Do not repoint `auto-approve-bot-prs/v1` until the caller guard lands.** The
callers need no new permission for this change, so the tag move is safe on its
own — but the cancellations it tolerates should not be happening in the first
place. loft-sh/vcluster-pro#2156 removes their source on `v0.34`.

Part of DEVOPS-1254.