### PR TITLE
feat(parse-label-filter): decide skip from which field the edit touched

### DIFF
--- a/.github/actions/parse-label-filter/README.md
+++ b/.github/actions/parse-label-filter/README.md
@@ -21,17 +21,55 @@ Pair this with a concurrency group that separates edited from code events, e.g.
 `...-${{ github.event.action == 'edited' && 'edited' || 'code' }}`, so a bot
 edit cannot cancel a still-running code run and then skip.
 
+## Tell it which field the edit touched
+
+`edited` fires for the title, the body, the base branch and more, and the payload
+carries a `changes` key only for what actually changed. So comparing bodies alone
+cannot tell a title edit from a body edit: a non-body edit sends an empty
+`previous-pr-body`, which reads as *"the label-filter block was removed"*.
+
+Pass both booleans so the three cases separate — they have different answers, and
+one flag cannot express them:
+
+```yaml
+  body-changed: ${{ github.event.changes.body != null }}
+  base-changed: ${{ github.event.changes.base != null }}
+```
+
+| `edited` carrying | verdict | why |
+|---|---|---|
+| `changes.title` only | **skip** | title, labels, assignees cannot change a filter that lives in the body |
+| `changes.body` | compare the blocks | the filter may have moved |
+| `changes.base` | **never skip** | a different base can mean a different thing under test |
+
+The base case is why `body-changed` alone is not enough: a retarget carries no
+body change, so it would report as skippable — but a caller that resolves
+anything from `base_ref` (an OSS branch, a chart line) is now testing a different
+pairing and the previous result does not carry over.
+
+Both inputs are optional and omitting them keeps the legacy body comparison, so
+adopting this needs no coordinated rollout. That legacy path still misreads a
+title-only edit as a filter change, which costs a redundant suite — worse when
+the concurrency guard above means it queues rather than replacing. A test pins
+that behaviour, so the cost of omitting them is explicit rather than folklore.
+
+Only the exact strings `"false"` and `"true"` are acted on; anything else falls
+back to comparing, so a caller expression that renders oddly cannot produce a
+silent skip.
+
 ## Inputs
 
 <!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
 
-|       INPUT        |  TYPE  | REQUIRED | DEFAULT |                                                                          DESCRIPTION                                                                          |
-|--------------------|--------|----------|---------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
-|    event-action    | string |  false   |         |                                                 The event action. Pass the github.event.action <br>context.                                                   |
-|     event-name     | string |  false   |         |                                                The triggering event. Pass the github.event_name <br>context.                                                  |
-| label-filter-input | string |  false   |         | Fallback label filter from a manual <br>dispatch. Pass the ginkgo-label workflow input. <br>Used only when the PR description <br>has no label-filter block.  |
-|      pr-body       | string |  false   |         |                                         Current PR description. Pass the github.event.pull_request.body <br>context.                                          |
-|  previous-pr-body  | string |  false   |         |                           PR description before an edit. Pass <br>github.event.changes.body.from; only populated on edited events.                            |
+|       INPUT        |  TYPE  | REQUIRED | DEFAULT |                                                                                              DESCRIPTION                                                                                               |
+|--------------------|--------|----------|---------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|    base-changed    | string |  false   |         |     Whether this edit retargeted the base <br>branch. Pass "${{ github.event.changes.base != null <br>}}". A retarget is never skippable, <br>because it changes what the suite <br>runs against.      |
+|    body-changed    | string |  false   |         | Whether this edit touched the PR <br>body. Pass "${{ github.event.changes.body != null <br>}}". Omit to keep the legacy <br>body comparison, which misreads a title-only <br>edit as a filter change.  |
+|    event-action    | string |  false   |         |                                                                      The event action. Pass the github.event.action <br>context.                                                                       |
+|     event-name     | string |  false   |         |                                                                     The triggering event. Pass the github.event_name <br>context.                                                                      |
+| label-filter-input | string |  false   |         |                     Fallback label filter from a manual <br>dispatch. Pass the ginkgo-label workflow input. <br>Used only when the PR description <br>has no label-filter block.                       |
+|      pr-body       | string |  false   |         |                                                             Current PR description. Pass the github.event.pull_request.body <br>context.                                                               |
+|  previous-pr-body  | string |  false   |         |                                               PR description before an edit. Pass <br>github.event.changes.body.from; only populated on edited events.                                                 |
 
 <!-- AUTO-DOC-INPUT:END -->
 
@@ -39,10 +77,10 @@ edit cannot cancel a still-running code run and then skip.
 
 <!-- AUTO-DOC-OUTPUT:START - Do not remove or modify this section -->
 
-|    OUTPUT    |  TYPE  |                                                             DESCRIPTION                                                              |
-|--------------|--------|--------------------------------------------------------------------------------------------------------------------------------------|
-| label-filter | string |             Resolved Ginkgo label filter: the parsed <br>PR-description block, else the dispatch input, <br>else "pr".               |
-| skip-edited  | string | Either "true" or "false". "true" only <br>when this is a pull_request edited <br>event whose label-filter block did not <br>change.  |
+|    OUTPUT    |  TYPE  |                                                                                                                                             DESCRIPTION                                                                                                                                             |
+|--------------|--------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| label-filter | string |                                                                                             Resolved Ginkgo label filter: the parsed <br>PR-description block, else the dispatch input, <br>else "pr".                                                                                              |
+| skip-edited  | string | Either "true" or "false". "true" only <br>when this is a pull_request edited <br>event that cannot have changed what <br>the suite would test: never for <br>a base retarget, always for an <br>edit that did not touch the <br>body, otherwise only when the label-filter <br>block is unchanged.  |
 
 <!-- AUTO-DOC-OUTPUT:END -->
 
@@ -64,6 +102,10 @@ jobs:
           previous-pr-body: ${{ github.event.changes.body.from }}
           event-name: ${{ github.event_name }}
           event-action: ${{ github.event.action }}
+          # Part of the usage, not an optional extra: without these, a
+          # title-only edit or a base retarget is misread. See above.
+          body-changed: ${{ github.event.changes.body != null }}
+          base-changed: ${{ github.event.changes.base != null }}
           label-filter-input: ${{ inputs.ginkgo-label }}
 
   e2e-tests:

--- a/.github/actions/parse-label-filter/README.md
+++ b/.github/actions/parse-label-filter/README.md
@@ -61,15 +61,15 @@ silent skip.
 
 <!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
 
-|       INPUT        |  TYPE  | REQUIRED | DEFAULT |                                                                                              DESCRIPTION                                                                                               |
-|--------------------|--------|----------|---------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-|    base-changed    | string |  false   |         |     Whether this edit retargeted the base <br>branch. Pass "${{ github.event.changes.base != null <br>}}". A retarget is never skippable, <br>because it changes what the suite <br>runs against.      |
-|    body-changed    | string |  false   |         | Whether this edit touched the PR <br>body. Pass "${{ github.event.changes.body != null <br>}}". Omit to keep the legacy <br>body comparison, which misreads a title-only <br>edit as a filter change.  |
-|    event-action    | string |  false   |         |                                                                      The event action. Pass the github.event.action <br>context.                                                                       |
-|     event-name     | string |  false   |         |                                                                     The triggering event. Pass the github.event_name <br>context.                                                                      |
-| label-filter-input | string |  false   |         |                     Fallback label filter from a manual <br>dispatch. Pass the ginkgo-label workflow input. <br>Used only when the PR description <br>has no label-filter block.                       |
-|      pr-body       | string |  false   |         |                                                             Current PR description. Pass the github.event.pull_request.body <br>context.                                                               |
-|  previous-pr-body  | string |  false   |         |                                               PR description before an edit. Pass <br>github.event.changes.body.from; only populated on edited events.                                                 |
+|       INPUT        |  TYPE  | REQUIRED | DEFAULT |                                                                                             DESCRIPTION                                                                                              |
+|--------------------|--------|----------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|    base-changed    | string |  false   |         |     Whether this edit retargeted the base <br>branch: pass a null test on <br>github.event.changes.base. A retarget is never skippable, <br>because it changes what the suite <br>runs against.      |
+|    body-changed    | string |  false   |         | Whether this edit touched the PR <br>body: pass a null test on <br>github.event.changes.body. Omit to keep the legacy <br>body comparison, which misreads a title-only <br>edit as a filter change.  |
+|    event-action    | string |  false   |         |                                                                     The event action. Pass the github.event.action <br>context.                                                                      |
+|     event-name     | string |  false   |         |                                                                    The triggering event. Pass the github.event_name <br>context.                                                                     |
+| label-filter-input | string |  false   |         |                    Fallback label filter from a manual <br>dispatch. Pass the ginkgo-label workflow input. <br>Used only when the PR description <br>has no label-filter block.                      |
+|      pr-body       | string |  false   |         |                                                            Current PR description. Pass the github.event.pull_request.body <br>context.                                                              |
+|  previous-pr-body  | string |  false   |         |                                              PR description before an edit. Pass <br>github.event.changes.body.from; only populated on edited events.                                                |
 
 <!-- AUTO-DOC-INPUT:END -->
 

--- a/.github/actions/parse-label-filter/README.md
+++ b/.github/actions/parse-label-filter/README.md
@@ -47,7 +47,16 @@ body change, so it would report as skippable — but a caller that resolves
 anything from `base_ref` (an OSS branch, a chart line) is now testing a different
 pairing and the previous result does not carry over.
 
-Both inputs are optional and omitting them keeps the legacy body comparison, so
+### Both lines or neither
+
+The two are **one wiring**, and the action only acts on the pair. Copy just
+`body-changed` and nothing is skipped that would not be skipped today: the action
+cannot tell your omitted `base-changed` from a `base-changed: false`, so honouring
+`body-changed` alone would suppress the suite on exactly the base retarget the
+table says must always run. Half-wired therefore falls back to comparing the
+blocks — a redundant run — and warns, rather than skipping.
+
+Both inputs are optional and omitting both keeps the legacy body comparison, so
 adopting this needs no coordinated rollout. That legacy path still misreads a
 title-only edit as a filter change, which costs a redundant suite — worse when
 the concurrency guard above means it queues rather than replacing. A test pins
@@ -55,21 +64,22 @@ that behaviour, so the cost of omitting them is explicit rather than folklore.
 
 Only the exact strings `"false"` and `"true"` are acted on; anything else falls
 back to comparing, so a caller expression that renders oddly cannot produce a
-silent skip.
+silent skip. It does warn, because otherwise a broken expression and a caller
+that never wired the inputs read identically in the log.
 
 ## Inputs
 
 <!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
 
-|       INPUT        |  TYPE  | REQUIRED | DEFAULT |                                                                                             DESCRIPTION                                                                                              |
-|--------------------|--------|----------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-|    base-changed    | string |  false   |         |     Whether this edit retargeted the base <br>branch: pass a null test on <br>github.event.changes.base. A retarget is never skippable, <br>because it changes what the suite <br>runs against.      |
-|    body-changed    | string |  false   |         | Whether this edit touched the PR <br>body: pass a null test on <br>github.event.changes.body. Omit to keep the legacy <br>body comparison, which misreads a title-only <br>edit as a filter change.  |
-|    event-action    | string |  false   |         |                                                                     The event action. Pass the github.event.action <br>context.                                                                      |
-|     event-name     | string |  false   |         |                                                                    The triggering event. Pass the github.event_name <br>context.                                                                     |
-| label-filter-input | string |  false   |         |                    Fallback label filter from a manual <br>dispatch. Pass the ginkgo-label workflow input. <br>Used only when the PR description <br>has no label-filter block.                      |
-|      pr-body       | string |  false   |         |                                                            Current PR description. Pass the github.event.pull_request.body <br>context.                                                              |
-|  previous-pr-body  | string |  false   |         |                                              PR description before an edit. Pass <br>github.event.changes.body.from; only populated on edited events.                                                |
+|       INPUT        |  TYPE  | REQUIRED | DEFAULT |                                                                          DESCRIPTION                                                                          |
+|--------------------|--------|----------|---------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|    base-changed    | string |  false   |         |   Whether this edit retargeted the base <br>branch. Pass a null test on <br>the changes.base payload key, together with <br>body-changed; see the README.     |
+|    body-changed    | string |  false   |         |       Whether this edit touched the PR <br>body. Pass a null test on <br>the changes.body payload key, together with <br>base-changed; see the README.        |
+|    event-action    | string |  false   |         |                                                 The event action. Pass the github.event.action <br>context.                                                   |
+|     event-name     | string |  false   |         |                                                The triggering event. Pass the github.event_name <br>context.                                                  |
+| label-filter-input | string |  false   |         | Fallback label filter from a manual <br>dispatch. Pass the ginkgo-label workflow input. <br>Used only when the PR description <br>has no label-filter block.  |
+|      pr-body       | string |  false   |         |                                         Current PR description. Pass the github.event.pull_request.body <br>context.                                          |
+|  previous-pr-body  | string |  false   |         |                           PR description before an edit. Pass <br>github.event.changes.body.from; only populated on edited events.                            |
 
 <!-- AUTO-DOC-INPUT:END -->
 
@@ -77,10 +87,10 @@ silent skip.
 
 <!-- AUTO-DOC-OUTPUT:START - Do not remove or modify this section -->
 
-|    OUTPUT    |  TYPE  |                                                                                                                                             DESCRIPTION                                                                                                                                             |
-|--------------|--------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| label-filter | string |                                                                                             Resolved Ginkgo label filter: the parsed <br>PR-description block, else the dispatch input, <br>else "pr".                                                                                              |
-| skip-edited  | string | Either "true" or "false". "true" only <br>when this is a pull_request edited <br>event that cannot have changed what <br>the suite would test: never for <br>a base retarget, always for an <br>edit that did not touch the <br>body, otherwise only when the label-filter <br>block is unchanged.  |
+|    OUTPUT    |  TYPE  |                                                                                        DESCRIPTION                                                                                         |
+|--------------|--------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| label-filter | string |                                        Resolved Ginkgo label filter: the parsed <br>PR-description block, else the dispatch input, <br>else "pr".                                          |
+| skip-edited  | string | Either "true" or "false". "true" only <br>when this is a pull_request edited <br>event that cannot have changed what <br>the suite would test; see the <br>README for the per-field rule.  |
 
 <!-- AUTO-DOC-OUTPUT:END -->
 
@@ -103,7 +113,8 @@ jobs:
           event-name: ${{ github.event_name }}
           event-action: ${{ github.event.action }}
           # Part of the usage, not an optional extra: without these, a
-          # title-only edit or a base retarget is misread. See above.
+          # title-only edit is misread. Wire both lines or neither — one
+          # alone is ignored, and warns. See above.
           body-changed: ${{ github.event.changes.body != null }}
           base-changed: ${{ github.event.changes.base != null }}
           label-filter-input: ${{ inputs.ginkgo-label }}

--- a/.github/actions/parse-label-filter/action.yml
+++ b/.github/actions/parse-label-filter/action.yml
@@ -25,12 +25,16 @@ inputs:
     description: 'The event action. Pass the github.event.action context.'
     required: false
     default: ''
+  # Descriptions must not contain a literal ${{ }}: the runner parses expressions
+  # in the manifest and rejects the `github` context here ("Unrecognized
+  # named-value"), failing the whole action load. See the README for the exact
+  # caller expressions.
   body-changed:
-    description: 'Whether this edit touched the PR body. Pass "${{ github.event.changes.body != null }}". Omit to keep the legacy body comparison, which misreads a title-only edit as a filter change.'
+    description: 'Whether this edit touched the PR body: pass a null test on github.event.changes.body. Omit to keep the legacy body comparison, which misreads a title-only edit as a filter change.'
     required: false
     default: ''
   base-changed:
-    description: 'Whether this edit retargeted the base branch. Pass "${{ github.event.changes.base != null }}". A retarget is never skippable, because it changes what the suite runs against.'
+    description: 'Whether this edit retargeted the base branch: pass a null test on github.event.changes.base. A retarget is never skippable, because it changes what the suite runs against.'
     required: false
     default: ''
   label-filter-input:

--- a/.github/actions/parse-label-filter/action.yml
+++ b/.github/actions/parse-label-filter/action.yml
@@ -25,6 +25,14 @@ inputs:
     description: 'The event action. Pass the github.event.action context.'
     required: false
     default: ''
+  body-changed:
+    description: 'Whether this edit touched the PR body. Pass "${{ github.event.changes.body != null }}". Omit to keep the legacy body comparison, which misreads a title-only edit as a filter change.'
+    required: false
+    default: ''
+  base-changed:
+    description: 'Whether this edit retargeted the base branch. Pass "${{ github.event.changes.base != null }}". A retarget is never skippable, because it changes what the suite runs against.'
+    required: false
+    default: ''
   label-filter-input:
     description: 'Fallback label filter from a manual dispatch. Pass the ginkgo-label workflow input. Used only when the PR description has no label-filter block.'
     required: false
@@ -34,7 +42,7 @@ outputs:
     description: 'Resolved Ginkgo label filter: the parsed PR-description block, else the dispatch input, else "pr".'
     value: ${{ steps.parse.outputs.label-filter }}
   skip-edited:
-    description: 'Either "true" or "false". "true" only when this is a pull_request edited event whose label-filter block did not change.'
+    description: 'Either "true" or "false". "true" only when this is a pull_request edited event that cannot have changed what the suite would test: never for a base retarget, always for an edit that did not touch the body, otherwise only when the label-filter block is unchanged.'
     value: ${{ steps.parse.outputs.skip-edited }}
 runs:
   using: composite
@@ -47,6 +55,8 @@ runs:
         INPUT_PREVIOUS_PR_BODY: ${{ inputs.previous-pr-body }}
         INPUT_EVENT_NAME: ${{ inputs.event-name }}
         INPUT_EVENT_ACTION: ${{ inputs.event-action }}
+        INPUT_BODY_CHANGED: ${{ inputs.body-changed }}
+        INPUT_BASE_CHANGED: ${{ inputs.base-changed }}
         INPUT_LABEL_FILTER_INPUT: ${{ inputs.label-filter-input }}
       run: ${{ github.action_path }}/src/parse-label-filter.sh
 branding:

--- a/.github/actions/parse-label-filter/action.yml
+++ b/.github/actions/parse-label-filter/action.yml
@@ -30,11 +30,11 @@ inputs:
   # named-value"), failing the whole action load. See the README for the exact
   # caller expressions.
   body-changed:
-    description: 'Whether this edit touched the PR body: pass a null test on github.event.changes.body. Omit to keep the legacy body comparison, which misreads a title-only edit as a filter change.'
+    description: 'Whether this edit touched the PR body. Pass a null test on the changes.body payload key, together with base-changed; see the README.'
     required: false
     default: ''
   base-changed:
-    description: 'Whether this edit retargeted the base branch: pass a null test on github.event.changes.base. A retarget is never skippable, because it changes what the suite runs against.'
+    description: 'Whether this edit retargeted the base branch. Pass a null test on the changes.base payload key, together with body-changed; see the README.'
     required: false
     default: ''
   label-filter-input:
@@ -46,7 +46,7 @@ outputs:
     description: 'Resolved Ginkgo label filter: the parsed PR-description block, else the dispatch input, else "pr".'
     value: ${{ steps.parse.outputs.label-filter }}
   skip-edited:
-    description: 'Either "true" or "false". "true" only when this is a pull_request edited event that cannot have changed what the suite would test: never for a base retarget, always for an edit that did not touch the body, otherwise only when the label-filter block is unchanged.'
+    description: 'Either "true" or "false". "true" only when this is a pull_request edited event that cannot have changed what the suite would test; see the README for the per-field rule.'
     value: ${{ steps.parse.outputs.skip-edited }}
 runs:
   using: composite

--- a/.github/actions/parse-label-filter/src/parse-label-filter.sh
+++ b/.github/actions/parse-label-filter/src/parse-label-filter.sh
@@ -9,6 +9,8 @@
 #   INPUT_EVENT_ACTION        github.event.action
 #   INPUT_BODY_CHANGED        "true"/"false": did this edit touch the body?
 #   INPUT_BASE_CHANGED        "true"/"false": did this edit retarget the base?
+#                             The two are one wiring, not two: both must be
+#                             passed for either to be acted on.
 #   INPUT_LABEL_FILTER_INPUT  manual-dispatch label filter (inputs.ginkgo-label)
 #
 # Writes to $GITHUB_OUTPUT:
@@ -46,6 +48,37 @@ normalize() {
 emit() {
   printf '%s=%s\n' "$1" "$2" >> "${GITHUB_OUTPUT:?GITHUB_OUTPUT required}"
   printf '%s=%s\n' "$1" "$2"
+}
+
+# safe_for_log <string> — an input value, made safe to interpolate into a log
+# line. The two boolean inputs are echoed back when they do not parse, and a
+# mis-wired caller can render the payload itself there (`changes.body` rather
+# than a null test on it), which carries the PR body — attacker-controlled text.
+# A raw CR or LF in it would start a new log line, and a line beginning `::` is
+# read by the runner as a workflow command, so collapse both, drop the rest of
+# the non-printables, escape the `%` that introduces a command escape, and cap
+# the length. Never fails: a subshell abort here would kill the script under
+# `set -e` before it could emit skip-edited.
+safe_for_log() {
+  { printf '%s' "${1:-}" \
+      | LC_ALL=C tr '\n\r\t' '   ' \
+      | LC_ALL=C tr -cd '\040-\176' \
+      | sed 's/%/%25/g' \
+      | LC_ALL=C awk '{ if (length($0) > 60) printf "%s... (truncated)\n", substr($0, 1, 60); else print }' \
+      | sed 's/%2\{0,1\}$//'; } 2>/dev/null || true
+}
+
+# warn_unless_boolean <input-name> <value> — flag a value that will be ignored.
+# Only the exact strings are acted on, and the fallback is deliberate, but
+# without this line a caller whose expression renders `"True"`, `"null"` or the
+# object itself looks identical in the log to a caller that never wired the
+# input at all — and the broken one has silently reverted to the misread these
+# inputs exist to fix.
+warn_unless_boolean() {
+  case "$2" in
+    '' | true | false) return 0 ;;
+  esac
+  echo "::warning::${1}='$(safe_for_log "$2")' is not \"true\" or \"false\"; falling back to comparing the label-filter blocks"
 }
 
 current_filter="$(extract_label_filter "$pr_body")"
@@ -87,13 +120,27 @@ fi
 # body-comparison behaviour, so this is not a breaking change and needs no
 # coordinated rollout. That legacy path still misreads a title-only edit, which
 # is why passing them is documented as the correct usage.
+#
+# They are one wiring and not two, which is why the skip below demands BOTH.
+# `base_changed` unset is indistinguishable here from `base_changed=false`, so a
+# caller that copied only the `body-changed` line would report an ordinary base
+# retarget — no `changes.body`, so body-changed renders "false" — as skippable,
+# and suppress the suite for the one case that must never skip. Requiring both
+# means a half-wired caller falls back to comparing instead: a redundant run,
+# which is the direction a mistake has to fail in.
+warn_unless_boolean "body-changed" "$body_changed"
+warn_unless_boolean "base-changed" "$base_changed"
+if [[ -z "$body_changed" && -n "$base_changed" ]] || [[ -n "$body_changed" && -z "$base_changed" ]]; then
+  echo "::warning::body-changed and base-changed must be passed together; only one was, so this run falls back to comparing the label-filter blocks"
+fi
+
 if [[ "$base_changed" == "true" ]]; then
   echo "::notice::Not skipping e2e: the PR was retargeted to a different base branch"
   emit "skip-edited" "false"
   exit 0
 fi
 
-if [[ "$body_changed" == "false" ]]; then
+if [[ "$body_changed" == "false" && "$base_changed" == "false" ]]; then
   echo "::notice::Skipping e2e: PR edited but the description was not touched"
   emit "skip-edited" "true"
   exit 0

--- a/.github/actions/parse-label-filter/src/parse-label-filter.sh
+++ b/.github/actions/parse-label-filter/src/parse-label-filter.sh
@@ -7,17 +7,22 @@
 #   INPUT_PREVIOUS_PR_BODY    PR body before an edit (github.event.changes.body.from)
 #   INPUT_EVENT_NAME          github.event_name
 #   INPUT_EVENT_ACTION        github.event.action
+#   INPUT_BODY_CHANGED        "true"/"false": did this edit touch the body?
+#   INPUT_BASE_CHANGED        "true"/"false": did this edit retarget the base?
 #   INPUT_LABEL_FILTER_INPUT  manual-dispatch label filter (inputs.ginkgo-label)
 #
 # Writes to $GITHUB_OUTPUT:
 #   label-filter=<resolved>   parsed block, else dispatch input, else "pr"
-#   skip-edited=true|false    true only for an edited event with unchanged filter
+#   skip-edited=true|false    true only for an edited event that cannot have
+#                             changed what the suite would test
 set -euo pipefail
 
 pr_body="${INPUT_PR_BODY:-}"
 previous_pr_body="${INPUT_PREVIOUS_PR_BODY:-}"
 event_name="${INPUT_EVENT_NAME:-}"
 event_action="${INPUT_EVENT_ACTION:-}"
+body_changed="${INPUT_BODY_CHANGED:-}"
+base_changed="${INPUT_BASE_CHANGED:-}"
 label_filter_input="${INPUT_LABEL_FILTER_INPUT:-}"
 
 # Extract the content of a ```label-filter``` fenced block from the given text.
@@ -61,6 +66,36 @@ emit "label-filter" "$label_filter"
 # else (open, reopen, synchronize, release, dispatch) always runs.
 if [[ "$event_name" != "pull_request" || "$event_action" != "edited" ]]; then
   emit "skip-edited" "false"
+  exit 0
+fi
+
+# `edited` fires for the title, the body, the base branch, and more, and the
+# payload carries a `changes` key only for what actually changed. Comparing
+# bodies alone therefore cannot tell a body edit from a title edit: a non-body
+# edit sends an empty previous-body, which reads as "the filter was removed".
+# Callers pass what changed so the three cases can be separated. Each has a
+# different answer, so a single boolean would not do:
+#
+#   base retargeted  -> never skip. A different base can mean a different thing
+#                       under test (e.g. a caller resolving an OSS branch from
+#                       base_ref), and the previous result does not carry over.
+#   body untouched   -> always skip. Title, labels, assignees and milestones
+#                       cannot change a filter that lives in the body.
+#   body changed     -> compare the blocks, as before.
+#
+# Both inputs are optional: a caller that passes neither keeps the legacy
+# body-comparison behaviour, so this is not a breaking change and needs no
+# coordinated rollout. That legacy path still misreads a title-only edit, which
+# is why passing them is documented as the correct usage.
+if [[ "$base_changed" == "true" ]]; then
+  echo "::notice::Not skipping e2e: the PR was retargeted to a different base branch"
+  emit "skip-edited" "false"
+  exit 0
+fi
+
+if [[ "$body_changed" == "false" ]]; then
+  echo "::notice::Skipping e2e: PR edited but the description was not touched"
+  emit "skip-edited" "true"
   exit 0
 fi
 

--- a/.github/actions/parse-label-filter/test/parse-label-filter.bats
+++ b/.github/actions/parse-label-filter/test/parse-label-filter.bats
@@ -6,7 +6,7 @@ SCRIPT="$BATS_TEST_DIRNAME/../src/parse-label-filter.sh"
 setup() {
   export GITHUB_OUTPUT; GITHUB_OUTPUT="$(mktemp)"
   # Start from a clean slate each test; individual tests set what they need.
-  unset INPUT_PR_BODY INPUT_PREVIOUS_PR_BODY INPUT_EVENT_NAME \
+  unset INPUT_PR_BODY INPUT_PREVIOUS_PR_BODY INPUT_EVENT_NAME INPUT_BODY_CHANGED INPUT_BASE_CHANGED \
     INPUT_EVENT_ACTION INPUT_LABEL_FILTER_INPUT
 }
 
@@ -188,4 +188,144 @@ body_with_filter() {
   [ "$status" -eq 0 ]
   [ "$(kv label-filter)" = "label-filter=db-datasource && aws|| istio" ]
   [ "$(kv skip-edited)" = "skip-edited=true" ]
+}
+
+# ---------------------------------------------------------------------------
+# Which field the edit touched (DEVOPS-1057, raised reviewing vcluster-pro#2156)
+#
+# `edited` fires for the title, the body, the base branch and more, and the
+# payload carries a `changes` key only for what changed. Comparing bodies alone
+# cannot tell a title edit from a body edit, because a non-body edit sends an
+# empty previous-body that reads as "the filter was removed".
+
+# A body shaped like vcluster-pro's PR template, whose label-filter block is
+# pre-filled with `none` — the default shape for a template-following PR, and
+# what makes the legacy misread bite rather than being harmless.
+template_body() {
+  printf '%s\n' '## What' 'stuff' '' '```label-filter' 'none' '```'
+}
+
+@test "title-only edit -> skip=true (body untouched cannot change the filter)" {
+  export INPUT_EVENT_NAME="pull_request"
+  export INPUT_EVENT_ACTION="edited"
+  export INPUT_PR_BODY="$(template_body)"
+  # No changes.body key in the payload, so the caller passes body-changed=false
+  # and previous-pr-body arrives empty.
+  export INPUT_PREVIOUS_PR_BODY=""
+  export INPUT_BODY_CHANGED="false"
+  export INPUT_BASE_CHANGED="false"
+
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv skip-edited)" = "skip-edited=true" ]
+  [[ "$output" == *"description was not touched"* ]]
+}
+
+@test "regression: legacy caller misreads a title-only edit as a filter change" {
+  # Pins the behaviour the new inputs exist to fix, and the reason omitting them
+  # is not merely a style choice. Same event as above from a caller that passes
+  # neither input: "none" is compared against "", so the suite re-runs.
+  export INPUT_EVENT_NAME="pull_request"
+  export INPUT_EVENT_ACTION="edited"
+  export INPUT_PR_BODY="$(template_body)"
+  export INPUT_PREVIOUS_PR_BODY=""
+
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv skip-edited)" = "skip-edited=false" ]
+}
+
+@test "base retarget -> skip=false even though the body did not change" {
+  # A retarget carries changes.base and no changes.body, so body-changed=false.
+  # It must still run: a caller that resolves anything from base_ref (an OSS
+  # branch, a chart line) is now testing a different pairing, and the previous
+  # result does not carry over. This is why one body-changed boolean is not
+  # enough — it would report this as skippable.
+  export INPUT_EVENT_NAME="pull_request"
+  export INPUT_EVENT_ACTION="edited"
+  export INPUT_PR_BODY="$(template_body)"
+  export INPUT_PREVIOUS_PR_BODY=""
+  export INPUT_BODY_CHANGED="false"
+  export INPUT_BASE_CHANGED="true"
+
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv skip-edited)" = "skip-edited=false" ]
+  [[ "$output" == *"retargeted"* ]]
+}
+
+@test "base retarget wins over an unchanged label-filter" {
+  # Ordering check: base is tested before the block comparison, so a simultaneous
+  # base+body edit that leaves the filter identical still runs.
+  export INPUT_EVENT_NAME="pull_request"
+  export INPUT_EVENT_ACTION="edited"
+  export INPUT_PR_BODY="$(template_body)"
+  export INPUT_PREVIOUS_PR_BODY="$(template_body)"
+  export INPUT_BODY_CHANGED="true"
+  export INPUT_BASE_CHANGED="true"
+
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv skip-edited)" = "skip-edited=false" ]
+}
+
+@test "body edit with body-changed=true still compares the blocks" {
+  export INPUT_EVENT_NAME="pull_request"
+  export INPUT_EVENT_ACTION="edited"
+  export INPUT_PR_BODY="$(printf '%s\n' 'bot summary appended' '```label-filter' 'none' '```')"
+  export INPUT_PREVIOUS_PR_BODY="$(template_body)"
+  export INPUT_BODY_CHANGED="true"
+  export INPUT_BASE_CHANGED="false"
+
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv skip-edited)" = "skip-edited=true" ]
+}
+
+@test "body that gained a label-filter block still runs" {
+  # The case that rules out `changes.body.from || pull_request.body` as a caller
+  # workaround: the body genuinely changed FROM empty, so there is a new filter
+  # to honour and skipping would drop the suite the author just requested.
+  export INPUT_EVENT_NAME="pull_request"
+  export INPUT_EVENT_ACTION="edited"
+  export INPUT_PR_BODY="$(printf '%s\n' '```label-filter' 'istio' '```')"
+  export INPUT_PREVIOUS_PR_BODY=""
+  export INPUT_BODY_CHANGED="true"
+  export INPUT_BASE_CHANGED="false"
+
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv label-filter)" = "label-filter=istio" ]
+  [ "$(kv skip-edited)" = "skip-edited=false" ]
+}
+
+@test "the new inputs never make a non-edited event skippable" {
+  # body-changed=false is about an edit, not a licence to skip. A synchronize
+  # carries no changes at all, and a caller wiring these from the payload would
+  # pass false for it.
+  export INPUT_EVENT_NAME="pull_request"
+  export INPUT_EVENT_ACTION="synchronize"
+  export INPUT_PR_BODY="$(template_body)"
+  export INPUT_BODY_CHANGED="false"
+  export INPUT_BASE_CHANGED="false"
+
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv skip-edited)" = "skip-edited=false" ]
+}
+
+@test "unexpected input values fall back to comparing, never to skipping" {
+  # Default-deny on garbage: only the exact string "false" means "body untouched"
+  # and only "true" means "retargeted", so a caller passing an expression that
+  # rendered oddly gets the conservative path rather than a silent skip.
+  export INPUT_EVENT_NAME="pull_request"
+  export INPUT_EVENT_ACTION="edited"
+  export INPUT_PR_BODY="$(template_body)"
+  export INPUT_PREVIOUS_PR_BODY=""
+  export INPUT_BODY_CHANGED="False"
+  export INPUT_BASE_CHANGED="yes"
+
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv skip-edited)" = "skip-edited=false" ]
 }

--- a/.github/actions/parse-label-filter/test/parse-label-filter.bats
+++ b/.github/actions/parse-label-filter/test/parse-label-filter.bats
@@ -16,6 +16,23 @@ teardown() {
 
 kv() { grep "^$1=" "$GITHUB_OUTPUT" | tail -n1; }
 
+# assert_no_match <perl-regex> <text> — fail the test if the regex matches.
+#
+# Do NOT write `! grep -q ... <<<"$output"` instead. Bash does not abort on a
+# command whose status is inverted with `!`, so under the `set -e` bats runs test
+# bodies with, a bare negated grep is a no-op unless it happens to be the final
+# line. A plain function call returning non-zero does abort, so this one really
+# fails.
+assert_no_match() {
+  local rc=0
+  grep -qP -- "$1" <<<"$2" || rc=$?
+  case "$rc" in
+    0) printf 'assert_no_match: unexpected match for %s\n' "$1" >&2; return 1 ;;
+    1) return 0 ;;
+    *) printf 'assert_no_match: grep error rc=%s for %s\n' "$rc" "$1" >&2; return 1 ;;
+  esac
+}
+
 # A PR body with a label-filter fenced block, indented like a real description.
 body_with_filter() {
   printf '%s\n' \
@@ -200,10 +217,10 @@ body_with_filter() {
 
 # A body shaped like vcluster-pro's PR template, whose label-filter block is
 # pre-filled with `none` — the default shape for a template-following PR, and
-# what makes the legacy misread bite rather than being harmless.
-template_body() {
-  printf '%s\n' '## What' 'stuff' '' '```label-filter' 'none' '```'
-}
+# what makes the legacy misread bite rather than being harmless. Only the fenced
+# block reaches the parser, so this is `body_with_filter` under a name that
+# carries that intent.
+template_body() { body_with_filter 'none'; }
 
 @test "title-only edit -> skip=true (body untouched cannot change the filter)" {
   export INPUT_EVENT_NAME="pull_request"
@@ -314,18 +331,132 @@ template_body() {
   [ "$(kv skip-edited)" = "skip-edited=false" ]
 }
 
-@test "unexpected input values fall back to comparing, never to skipping" {
-  # Default-deny on garbage: only the exact string "false" means "body untouched"
-  # and only "true" means "retargeted", so a caller passing an expression that
-  # rendered oddly gets the conservative path rather than a silent skip.
+@test "an unexpected body-changed falls back to comparing, never to skipping" {
+  # Default-deny on garbage: only the exact string "false" means "body untouched",
+  # so a caller whose expression rendered oddly gets the conservative path. Pinned
+  # per input, and by branch rather than only by value — a case-insensitive match
+  # on "False" would flip this to skip=true.
   export INPUT_EVENT_NAME="pull_request"
   export INPUT_EVENT_ACTION="edited"
   export INPUT_PR_BODY="$(template_body)"
   export INPUT_PREVIOUS_PR_BODY=""
   export INPUT_BODY_CHANGED="False"
+  export INPUT_BASE_CHANGED="false"
+
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv skip-edited)" = "skip-edited=false" ]
+  assert_no_match "description was not touched" "$output"
+  [[ "$output" == *"body-changed='False' is not"* ]]
+}
+
+@test "an unexpected base-changed neither retargets nor rides along with a skip" {
+  # base-changed's default-deny in both directions. "yes" must not fire the
+  # retarget guard (the notice pins the branch, since that guard also emits
+  # skip=false), and it must not count as the "false" the body guard demands —
+  # so this falls through to comparing, which is the only remaining path.
+  export INPUT_EVENT_NAME="pull_request"
+  export INPUT_EVENT_ACTION="edited"
+  export INPUT_PR_BODY="$(template_body)"
+  export INPUT_PREVIOUS_PR_BODY=""
+  export INPUT_BODY_CHANGED="false"
   export INPUT_BASE_CHANGED="yes"
 
   run "$SCRIPT"
   [ "$status" -eq 0 ]
   [ "$(kv skip-edited)" = "skip-edited=false" ]
+  assert_no_match "retargeted" "$output"
+  assert_no_match "description was not touched" "$output"
+  [[ "$output" == *"base-changed='yes' is not"* ]]
+}
+
+@test "a garbage value is sanitized before it reaches the warning" {
+  # A mis-wired caller can render the payload rather than a null test on it, and
+  # that carries the PR body. The runner reads a CR as a line break and a line
+  # that then begins `::` as a workflow command, so a value carrying both must not
+  # be able to forge one. Assert on the CR itself and on line starts, not on the
+  # `::error::` text: once the CR is collapsed that text is inert prose, and
+  # grepping for it would fail on a correctly sanitized line.
+  export INPUT_EVENT_NAME="pull_request"
+  export INPUT_EVENT_ACTION="edited"
+  export INPUT_PR_BODY="$(template_body)"
+  export INPUT_PREVIOUS_PR_BODY=""
+  export INPUT_BODY_CHANGED="$(printf 'x\r::error::forged')"
+  export INPUT_BASE_CHANGED="false"
+
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv skip-edited)" = "skip-edited=false" ]
+  assert_no_match '\r' "$output"
+  assert_no_match '^::error::' "$output"
+  [[ "$output" == *"is not \"true\" or \"false\""* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Half-wired callers. The two inputs are one wiring: an omitted base-changed is
+# indistinguishable from base-changed=false, so acting on body-changed alone
+# would skip a base retarget. Both must be present, and a caller that passes one
+# gets the legacy comparison — a redundant run — instead.
+
+@test "half-wired body-changed does not skip a base retarget" {
+  # The dangerous case: a caller copied only the body-changed line, then a PR
+  # author retargets their base. No changes.body, so body-changed renders "false"
+  # while base-changed stays at its empty default. Skipping here would suppress
+  # the suite for the one event that must always run.
+  export INPUT_EVENT_NAME="pull_request"
+  export INPUT_EVENT_ACTION="edited"
+  export INPUT_PR_BODY="$(template_body)"
+  export INPUT_PREVIOUS_PR_BODY=""
+  export INPUT_BODY_CHANGED="false"
+
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv skip-edited)" = "skip-edited=false" ]
+  assert_no_match "description was not touched" "$output"
+  [[ "$output" == *"must be passed together"* ]]
+}
+
+@test "half-wired base-changed still never skips a retarget" {
+  # The other half, wired the other way: base-changed alone is enough to run,
+  # because that guard only ever refuses to skip.
+  export INPUT_EVENT_NAME="pull_request"
+  export INPUT_EVENT_ACTION="edited"
+  export INPUT_PR_BODY="$(template_body)"
+  export INPUT_PREVIOUS_PR_BODY="$(template_body)"
+  export INPUT_BASE_CHANGED="true"
+
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv skip-edited)" = "skip-edited=false" ]
+  [[ "$output" == *"retargeted"* ]]
+  [[ "$output" == *"must be passed together"* ]]
+}
+
+@test "wiring both inputs raises no pairing warning" {
+  export INPUT_EVENT_NAME="pull_request"
+  export INPUT_EVENT_ACTION="edited"
+  export INPUT_PR_BODY="$(template_body)"
+  export INPUT_PREVIOUS_PR_BODY=""
+  export INPUT_BODY_CHANGED="false"
+  export INPUT_BASE_CHANGED="false"
+
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv skip-edited)" = "skip-edited=true" ]
+  assert_no_match "must be passed together" "$output"
+  assert_no_match "::warning::" "$output"
+}
+
+@test "wiring neither input raises no pairing warning" {
+  # The legacy path stays quiet: omitting both is a supported configuration, so
+  # it must not emit the warning that flags a broken one.
+  export INPUT_EVENT_NAME="pull_request"
+  export INPUT_EVENT_ACTION="edited"
+  export INPUT_PR_BODY="$(template_body)"
+  export INPUT_PREVIOUS_PR_BODY="$(template_body)"
+
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv skip-edited)" = "skip-edited=true" ]
+  assert_no_match "::warning::" "$output"
 }


### PR DESCRIPTION
## What

Adds optional `body-changed` and `base-changed` inputs so `skip-edited` is
decided from *which field* an `edited` event touched, instead of being inferred
from a body comparison that cannot see the difference.

## Why

`skip-edited` inferred "the body before the edit" from
`github.event.changes.body.from`. That key is **absent unless the body changed**,
so every non-body `edited` event arrived with an empty previous body — which
parses as *"the label-filter block was removed"*.

vcluster-pro's PR template ships a pre-filled block:

```
​```label-filter
none
​```
```

so for the default PR shape a **title-only edit** compares `none` against `""`,
reports a changed filter, and re-runs the suite for nothing. With the DEVOPS-1057
concurrency guard also in place, that run *queues behind* the in-flight one
rather than replacing it — the exact downgrade the guard and `skip-edited` are
paired to prevent. Found reviewing loft-sh/vcluster-pro#2156.

Comparing bodies cannot fix this, because the information is not in the bodies.

## Approach

| `edited` carrying | verdict | why |
|---|---|---|
| `changes.title` only | **skip** | title, labels, assignees cannot change a filter that lives in the body |
| `changes.body` | compare the blocks | unchanged from today |
| `changes.base` | **never skip** | a different base can mean a different thing under test |

```yaml
  body-changed: ${{ github.event.changes.body != null }}
  base-changed: ${{ github.event.changes.base != null }}
```

### Why two inputs and not one

Both were tried as one and are wrong:

- **`body-changed` alone** reports a base retarget as skippable, since a retarget
  carries no body change either. A caller resolving an OSS branch from
  `base_ref` would then never test the new pairing. This was caught by Bugbot on
  the caller-side attempt in vcluster-pro#2156.
- **`changes.body.from || pull_request.body`** in the caller silences a body that
  genuinely changed *from empty* — a PR that just gained a label-filter block,
  which must run.

Both are now tests, so neither can be reintroduced.

### The two inputs are one wiring

The skip requires **both**, because an omitted `base-changed` is
indistinguishable from `base-changed: false`. Acting on `body-changed` alone
would let a caller that copied only that line skip an ordinary base retarget —
the one case the table says must never skip — and partial adoption is a real
path, since the follow-up wires four `vcluster-pro` branches by hand. Half-wired
therefore falls back to comparing the blocks (a redundant run) and warns.

## Compatibility

Both inputs are optional and omitting **both** keeps the legacy body comparison,
so this needs no coordinated rollout across the four `vcluster-pro` branches that
call it. A regression test pins the legacy misread, so the cost of omitting them
is explicit rather than folklore.

Only the exact strings `"true"`/`"false"` are acted on — a caller expression that
renders oddly falls back to comparing rather than producing a silent skip. That
fallback now warns, since a broken expression and a caller that never wired the
input otherwise read identically in the log. The echoed value is sanitized: the
plausible mis-wiring (dropping the `!= null`) renders the payload, which carries
the PR body, so a raw CR in it must not be able to forge a `::error::` line.

## Tests

`make test-parse-label-filter` — 27 pass (14 new). Guards mutation-checked:
dropping the pairing requirement reds two cases, loosening `base-changed` to a
truthy match reds one, and bypassing the sanitizer reds one. shellcheck clean,
docs regenerated, `make check-docs` clean.

## Follow-up

Wiring the two inputs into the callers (`main`, `v0.34`, `v0.35`, `v0.36` of
`vcluster-pro`) once `parse-label-filter/v1` is repointed — both lines together.
Not urgent — omitting them is exactly today's behaviour.

Part of DEVOPS-1057.