### PR TITLE
fix(promote-release): install crane before the ghcr login

### DIFF
--- a/.github/actions/promote-release/README.md
+++ b/.github/actions/promote-release/README.md
@@ -214,6 +214,17 @@ config that step writes, so no separate crane login is needed. `action.yml` also
 installs crane (`imjasonh/setup-crane`), so callers don't need to install it
 themselves.
 
+The install runs **before** the login, and the order is load-bearing.
+`setup-crane` finishes with its own `crane auth login ghcr.io` hardcoded to the
+workflow's `github.token`, writing the same `~/.docker/config.json` entry as
+`docker/login-action` — last writer wins. Installed after the login, that
+replaces `github-token` with the workflow token, which can still write every
+package owned by the caller repo and is denied on every package owned by another
+one (`DENIED: permission_denied: write_package`). A promotion spanning both then
+dies partway through with one image family's moving tags already retagged. The
+smoke job pins the order by reading the stored username back: `docker-username`
+means the login won, `dummy` means `setup-crane` did.
+
 Both steps run for a `dry-run` as well, because the rehearsal resolves every
 source manifest (see [Source-manifest pre-flight](#source-manifest-pre-flight))
 and a package that is not publicly readable fails crane's anonymous token

--- a/.github/actions/promote-release/action.yml
+++ b/.github/actions/promote-release/action.yml
@@ -111,6 +111,20 @@ runs:
     # worthless. Nothing here writes to the registry; `crane tag` is the only
     # mutation and it stays behind the script's dry-run guard.
     #
+    # crane is installed BEFORE the logins on purpose: setup-crane ends with its
+    # own `crane auth login ghcr.io` hardcoded to the workflow's github.token,
+    # and it and docker/login-action write the same ~/.docker/config.json entry,
+    # so whichever runs last owns the credential. Installed last, github.token
+    # silently replaced the token this action was handed - which still retags
+    # every package owned by the caller repo and denies every package owned by
+    # another one (DENIED: permission_denied: write_package), so a promotion
+    # covering both fails halfway through with the moving tags of one image
+    # family already moved. The smoke job pins the order by asserting the stored
+    # username is the one passed here rather than setup-crane's "dummy".
+    - name: Install crane
+      uses: imjasonh/setup-crane@feee3b6bb0d4c68370f256a4502498c9227e5c6b # v0.7
+      with:
+        version: v0.20.2
     # Login is split by mode rather than carrying `continue-on-error` on one
     # step, because the value would have to be an expression and
     # `continue-on-error: ${{ inputs.x }}` is evaluated in the composite's own
@@ -137,10 +151,6 @@ runs:
         registry: ghcr.io
         username: ${{ inputs.docker-username }}
         password: ${{ inputs.github-token }}
-    - name: Install crane
-      uses: imjasonh/setup-crane@feee3b6bb0d4c68370f256a4502498c9227e5c6b # v0.7
-      with:
-        version: v0.20.2
     - name: Promote release
       id: promote
       shell: bash

--- a/.github/workflows/test-promote-release.yaml
+++ b/.github/workflows/test-promote-release.yaml
@@ -58,6 +58,8 @@ jobs:
       # the crane install, is covered by accident - reverting that one trips the
       # script's `command -v crane` check and fails this job outright.)
       - name: Verify the rehearsal authenticated to GHCR
+        env:
+          EXPECTED_USER: ${{ github.actor }}
         run: |
           config="${DOCKER_CONFIG:-$HOME/.docker}/config.json"
           if [[ ! -f "$config" ]]; then
@@ -69,4 +71,26 @@ jobs:
             jq -r '.auths | keys' "$config"
             exit 1
           fi
-          echo "dry-run authenticated to ghcr.io"
+          # setup-crane logs in to the same ghcr.io entry as "dummy" with the
+          # workflow's github.token, so whichever step runs last owns the
+          # credential crane will push with. github.token can only write packages
+          # owned by the caller repo, and the difference is invisible until a
+          # promotion touches a package owned by another repo. The username is
+          # the only part of the entry a test can read back, and it is enough:
+          # "dummy" means setup-crane won and the action's own token was thrown
+          # away.
+          auth=$(jq -r '.auths["ghcr.io"].auth // ""' "$config")
+          if [[ -n "$auth" ]]; then
+            user=$(base64 -d <<<"$auth" | cut -d: -f1)
+          else
+            user=$(jq -r '.auths["ghcr.io"].username // ""' "$config")
+          fi
+          if [[ -z "$user" ]]; then
+            echo "::error::could not read the ghcr.io username from $config; a credential helper is storing it out of band and this assertion needs rewriting"
+            exit 1
+          fi
+          if [[ "$user" != "$EXPECTED_USER" ]]; then
+            echo "::error::ghcr.io is authenticated as '$user', expected '$EXPECTED_USER'; the GHCR login must run after the crane install so the action's github-token is what crane pushes with"
+            exit 1
+          fi
+          echo "dry-run authenticated to ghcr.io as $user"


### PR DESCRIPTION
`setup-crane` ends with its own `crane auth login ghcr.io` hardcoded to `github.token`. It wrote the same `~/.docker/config.json` entry as `docker/login-action` and ran after it, so the workflow token replaced the `github-token` this action was handed. Crane then pushed as the caller repo's `GITHUB_TOKEN`: fine for packages that repo owns, `DENIED: permission_denied: write_package` for everything else. That took down the first real vcluster-pro promotion halfway through — `vcluster-pro*` retagged, `vcluster-oss`/`vcluster-cli` denied, OSS release and Homebrew never reached.

Moves `Install crane` above the two login steps and makes the smoke job read the stored username back, since `dummy` vs `docker-username` is the only visible difference between the two credentials.

Closes DEVOPS-1303

## Test plan

- `bats .github/actions/promote-release/test` — 95/95 pass locally
- smoke job asserts `auths["ghcr.io"]` is `${{ github.actor }}`, not `dummy`