### PR TITLE
chore(codeowners): own review routing with the eng-merge-devops team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,7 @@
 # The org-level "DevOps Code Owner Review" ruleset requires an approving
 # review from a code owner before anything merges to the default branch.
 #
-# Named individuals rather than @loft-sh/eng-devops on purpose: the wider
-# team holds push and maintain here, but merge sign-off sits with these two.
-*   @Piotr1215 @sydorovdmytro
+# Owned by the team rather than by named individuals, so any member of
+# @loft-sh/eng-merge-devops can give the required sign-off and one person
+# being away no longer blocks merges here.
+*   @loft-sh/eng-merge-devops


### PR DESCRIPTION
## Summary

- Replaces `@Piotr1215` and `@sydorovdmytro` in `.github/CODEOWNERS` with `@loft-sh/eng-merge-devops`. Neither individual handle remains anywhere in the file.
- Rewrites the header comment, which argued for named individuals on purpose and would otherwise assert the opposite of what the owner line now does.
- No other file is touched.

Review routing depended on two named individuals, so whenever either was away this repo had no reachable code owner and its own merges stalled with no fallback. `@loft-sh/eng-merge-devops` already contains both handles plus `@vcauesantos`, so this widens who can sign off without moving trust to anyone new.

## Test plan

- `@loft-sh/eng-merge-devops` holds `maintain` on this repo, read from `gh api repos/loft-sh/github-actions/teams`. GitHub ignores a team owner that lacks write access and leaves the repo with no effective owner, so access was confirmed before either individual handle came out.
- `.github/CODEOWNERS` is the only CODEOWNERS file here; the root and `docs/` paths both return 404.
- `gh api repos/loft-sh/github-actions/codeowners/errors?ref=devops-1309/codeowners-eng-merge-devops` returns `{"errors":[]}`, so the team owner resolves on this branch instead of resolving to nobody. The reviewers GitHub requests on this PR are still computed from the base branch, which is why the check runs against the ref.
- Grepped the file as it stands on the branch for either individual handle: zero matches.

One of 16 sibling PRs across the org, so this one references the issue rather than closing it.

References DEVOPS-1309
