### PR TITLE
docs: drop dev-vcluster webhook from ci-test-notify example

### DIFF
--- a/.github/actions/ci-test-notify/README.md
+++ b/.github/actions/ci-test-notify/README.md
@@ -70,7 +70,7 @@ Build URL: <link to workflow run>
       E2E Tests: failure
 
       ${{ needs.e2e-tests.outputs.failure-summary || 'Check build logs for details.' }}
-    webhook-url: ${{ secrets.SLACK_WEBHOOK_URL_DEV_VCLUSTER }}
+    webhook-url: ${{ secrets.SLACK_WEBHOOK_URL_CI_TESTS_ALERTS }}
 ```
 
 ## Notification gating


### PR DESCRIPTION
The `ci-test-notify` README used `SLACK_WEBHOOK_URL_DEV_VCLUSTER` in its failure-only example. That channel is being archived, so the example now points at `SLACK_WEBHOOK_URL_CI_TESTS_ALERTS` like the others.

Docs only, no action behaviour change.

Closes DEVOPS-1180
