### PR TITLE
feat(run-ginkgo): rerun only the previous attempt's failed specs

### DIFF
--- a/.github/actions/run-ginkgo/README.md
+++ b/.github/actions/run-ginkgo/README.md
@@ -8,19 +8,19 @@ markdown summary generation.
 
 <!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
 
-|          INPUT          |  TYPE  | REQUIRED |         DEFAULT         |                                                                                                            DESCRIPTION                                                                                                            |
-|-------------------------|--------|----------|-------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-|     additional-args     | string |  false   |                         |                                                                                     Extra arguments passed to the test <br>binary (after --)                                                                                      |
-| additional-ginkgo-flags | string |  false   |                         |                                                                           Extra ginkgo CLI flags (e.g. -v, --skip-package=linters, --show-node-events)                                                                            |
-|      ginkgo-label       | string |  false   |                         |                                                                      Ginkgo label filter expression. When set, <br>adds --label-filter and -r (recursive).                                                                        |
-|      github-token       | string |  false   | `"${{ github.token }}"` |                                                                          GitHub token for the gh CLI <br>to fetch job details during report <br>upload.                                                                           |
-|          procs          | string |  false   |          `"8"`          |                                                                                                Number of parallel Ginkgo processes                                                                                                |
-|     reports-bucket      | string |  false   |                         |                                                                                    GCS bucket name for uploading the <br>Ginkgo JSON report.                                                                                      |
-|    rerun-failed-only    | string |  false   |        `"false"`        | Set to 'true' to restrict re-runs <br>(run attempt > 1) to the specs that did <br>not pass in the previous attempt. <br>Requires reports-bucket and workflow-file, and the <br>previous attempt to have uploaded its <br>report.  |
-|        test-dir         | string |  false   |      `"e2e-next"`       |                                                                                                 Directory containing test suites                                                                                                  |
-|         timeout         | string |  false   |         `"60m"`         |                                                                                                        Ginkgo test timeout                                                                                                        |
-|      upload-report      | string |  false   |        `"false"`        |                                            Set to 'true' to upload the <br>Ginkgo JSON report to GCS after <br>the test run. Requires reports-bucket and <br>workflow-file to be set.                                             |
-|      workflow-file      | string |  false   |                         |                                                            Workflow file name (e.g. e2e-ginkgo.yaml) used as <br>the GCS path segment and report <br>metadata field.                                                              |
+|          INPUT          |  TYPE  | REQUIRED |         DEFAULT         |                                                                 DESCRIPTION                                                                 |
+|-------------------------|--------|----------|-------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|
+|     additional-args     | string |  false   |                         |                                          Extra arguments passed to the test <br>binary (after --)                                           |
+| additional-ginkgo-flags | string |  false   |                         |                                Extra ginkgo CLI flags (e.g. -v, --skip-package=linters, --show-node-events)                                 |
+|      ginkgo-label       | string |  false   |                         |                           Ginkgo label filter expression. When set, <br>adds --label-filter and -r (recursive).                             |
+|      github-token       | string |  false   | `"${{ github.token }}"` |                               GitHub token for the gh CLI <br>to fetch job details during report <br>upload.                                |
+|          procs          | string |  false   |          `"8"`          |                                                     Number of parallel Ginkgo processes                                                     |
+|     reports-bucket      | string |  false   |                         |                                         GCS bucket name for uploading the <br>Ginkgo JSON report.                                           |
+|    rerun-failed-only    | string |  false   |        `"false"`        |                    Set to 'true' to narrow a <br>re-run to the previous attempt's failures. <br>Requires upload-report.                     |
+|        test-dir         | string |  false   |      `"e2e-next"`       |                                                      Directory containing test suites                                                       |
+|         timeout         | string |  false   |         `"60m"`         |                                                             Ginkgo test timeout                                                             |
+|      upload-report      | string |  false   |        `"false"`        | Set to 'true' to upload the <br>Ginkgo JSON report to GCS after <br>the test run. Requires reports-bucket and <br>workflow-file to be set.  |
+|      workflow-file      | string |  false   |                         |                 Workflow file name (e.g. e2e-ginkgo.yaml) used as <br>the GCS path segment and report <br>metadata field.                   |
 
 <!-- AUTO-DOC-INPUT:END -->
 
@@ -63,8 +63,10 @@ in attempt 1 already passed on the exact commit under test.
 ```
 
 It reads the previous attempt's report from
-`gs://<reports-bucket>/<repo>/<workflow-file>/<run_id>/<attempt-1>/*.json`, so it
-requires `upload-report: "true"` plus an authenticated `gcloud` earlier in the job.
+`gs://<reports-bucket>/<repo>/<workflow-file>/<run_id>/<attempt-1>/*.json`, so
+**`upload-report: "true"` is a prerequisite** — without it nothing ever publishes the
+report this reads and the re-run is never narrowed (the action emits a `::warning::`
+for that combination). It also needs an authenticated `gcloud` earlier in the job.
 Every attempt uploads its own report, so attempt 3 narrows down to what attempt 2
 left failing.
 
@@ -83,14 +85,27 @@ The `focused-rerun` output is `true` when the narrowing was applied.
 It falls back to a full run, with a `::notice::` explaining why, when:
 
 - this is the first attempt of the run;
-- no report from the previous attempt is in the bucket;
+- no report from the previous attempt is in the bucket, or it cannot be parsed —
+  `upload-report.sh` is `continue-on-error`, so a half-written report is normal;
 - the previous attempt failed without any failed spec (build or infra failure);
 - a suite setup/teardown node (`BeforeSuite`, `AfterSuite`, …) failed, which
-  makes a spec-level focus meaningless.
+  makes a spec-level focus meaningless;
+- the previous attempt did not complete — it carries `SpecialSuiteFailureReasons`
+  (interrupt, suite timeout) or ran with `--fail-fast`. Ginkgo marks never-executed
+  specs `skipped`, indistinguishable in the report from a deliberate skip, so
+  narrowing would permanently drop specs that ran in neither attempt.
 
 Note that the report and the summary of a focused re-run only cover the specs that
-were re-run. When a job fans out over a matrix, all of the previous attempt's
-reports are merged, so every matrix leg re-runs the union of the failures.
+were re-run; the uploaded report carries `focused_rerun=true` in its GCS metadata so
+downstream flakiness stats can exclude it.
+
+**Matrix jobs:** every `*.json` under the previous attempt's prefix is merged, one per
+matrix leg, so a leg receives the union of all legs' failures and re-runs the part of
+it that exists in its own spec tree. If that intersection is empty — an unrelated
+suite, or a leg whose own attempt-1 report never uploaded — Ginkgo would exit 0 having
+run nothing, so `generate-summary.sh` fails the job when a focused re-run matches zero
+specs. (`--fail-on-empty` is not used for this: Ginkgo applies it per suite, so it
+would fail every suite in a `-r` run that the focus legitimately does not target.)
 
 ## Testing
 

--- a/.github/actions/run-ginkgo/README.md
+++ b/.github/actions/run-ginkgo/README.md
@@ -8,18 +8,19 @@ markdown summary generation.
 
 <!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
 
-|          INPUT          |  TYPE  | REQUIRED |         DEFAULT         |                                                                 DESCRIPTION                                                                 |
-|-------------------------|--------|----------|-------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|
-|     additional-args     | string |  false   |                         |                                          Extra arguments passed to the test <br>binary (after --)                                           |
-| additional-ginkgo-flags | string |  false   |                         |                                Extra ginkgo CLI flags (e.g. -v, --skip-package=linters, --show-node-events)                                 |
-|      ginkgo-label       | string |  false   |                         |                           Ginkgo label filter expression. When set, <br>adds --label-filter and -r (recursive).                             |
-|      github-token       | string |  false   | `"${{ github.token }}"` |                               GitHub token for the gh CLI <br>to fetch job details during report <br>upload.                                |
-|          procs          | string |  false   |          `"8"`          |                                                     Number of parallel Ginkgo processes                                                     |
-|     reports-bucket      | string |  false   |                         |                                         GCS bucket name for uploading the <br>Ginkgo JSON report.                                           |
-|        test-dir         | string |  false   |      `"e2e-next"`       |                                                      Directory containing test suites                                                       |
-|         timeout         | string |  false   |         `"60m"`         |                                                             Ginkgo test timeout                                                             |
-|      upload-report      | string |  false   |        `"false"`        | Set to 'true' to upload the <br>Ginkgo JSON report to GCS after <br>the test run. Requires reports-bucket and <br>workflow-file to be set.  |
-|      workflow-file      | string |  false   |                         |                 Workflow file name (e.g. e2e-ginkgo.yaml) used as <br>the GCS path segment and report <br>metadata field.                   |
+|          INPUT          |  TYPE  | REQUIRED |         DEFAULT         |                                                                                                            DESCRIPTION                                                                                                            |
+|-------------------------|--------|----------|-------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|     additional-args     | string |  false   |                         |                                                                                     Extra arguments passed to the test <br>binary (after --)                                                                                      |
+| additional-ginkgo-flags | string |  false   |                         |                                                                           Extra ginkgo CLI flags (e.g. -v, --skip-package=linters, --show-node-events)                                                                            |
+|      ginkgo-label       | string |  false   |                         |                                                                      Ginkgo label filter expression. When set, <br>adds --label-filter and -r (recursive).                                                                        |
+|      github-token       | string |  false   | `"${{ github.token }}"` |                                                                          GitHub token for the gh CLI <br>to fetch job details during report <br>upload.                                                                           |
+|          procs          | string |  false   |          `"8"`          |                                                                                                Number of parallel Ginkgo processes                                                                                                |
+|     reports-bucket      | string |  false   |                         |                                                                                    GCS bucket name for uploading the <br>Ginkgo JSON report.                                                                                      |
+|    rerun-failed-only    | string |  false   |        `"false"`        | Set to 'true' to restrict re-runs <br>(run attempt > 1) to the specs that did <br>not pass in the previous attempt. <br>Requires reports-bucket and workflow-file, and the <br>previous attempt to have uploaded its <br>report.  |
+|        test-dir         | string |  false   |      `"e2e-next"`       |                                                                                                 Directory containing test suites                                                                                                  |
+|         timeout         | string |  false   |         `"60m"`         |                                                                                                        Ginkgo test timeout                                                                                                        |
+|      upload-report      | string |  false   |        `"false"`        |                                            Set to 'true' to upload the <br>Ginkgo JSON report to GCS after <br>the test run. Requires reports-bucket and <br>workflow-file to be set.                                             |
+|      workflow-file      | string |  false   |                         |                                                            Workflow file name (e.g. e2e-ginkgo.yaml) used as <br>the GCS path segment and report <br>metadata field.                                                              |
 
 <!-- AUTO-DOC-INPUT:END -->
 
@@ -27,9 +28,10 @@ markdown summary generation.
 
 <!-- AUTO-DOC-OUTPUT:START - Do not remove or modify this section -->
 
-|     OUTPUT      |  TYPE  |               DESCRIPTION               |
-|-----------------|--------|-----------------------------------------|
-| failure-summary | string | Markdown-formatted test results summary |
+|     OUTPUT      |  TYPE  |                                  DESCRIPTION                                  |
+|-----------------|--------|-------------------------------------------------------------------------------|
+| failure-summary | string |                    Markdown-formatted test results summary                    |
+|  focused-rerun  | string | 'true' when this run was narrowed <br>to the previous attempt's failed specs  |
 
 <!-- AUTO-DOC-OUTPUT:END -->
 
@@ -43,10 +45,65 @@ markdown summary generation.
     additional-args: "--vcluster-image=ghcr.io/loft-sh/vcluster:latest --teardown=false"
 ```
 
+## Re-running only the failed specs
+
+With `rerun-failed-only: "true"`, hitting **Re-run failed jobs** in the GitHub UI
+runs only the specs that did not pass in the previous attempt, instead of the
+whole suite. The head SHA is unchanged across attempts, so the specs that passed
+in attempt 1 already passed on the exact commit under test.
+
+```yaml
+- uses: loft-sh/github-actions/.github/actions/run-ginkgo@run-ginkgo/v1
+  with:
+    test-dir: e2e
+    upload-report: "true"
+    rerun-failed-only: "true"
+    reports-bucket: ${{ vars.E2E_INSIGHTS_BUCKET }}
+    workflow-file: e2e-ginkgo.yaml
+```
+
+It reads the previous attempt's report from
+`gs://<reports-bucket>/<repo>/<workflow-file>/<run_id>/<attempt-1>/*.json`, so it
+requires `upload-report: "true"` plus an authenticated `gcloud` earlier in the job.
+Every attempt uploads its own report, so attempt 3 narrows down to what attempt 2
+left failing.
+
+The unit of the re-run is the **top-level container** of each failed spec, not the
+spec itself. `SpecReport.MarshalJSON` drops `IsInOrderedContainer`, so the report
+cannot tell whether a spec sits in an `Ordered` container, and re-running an ordered
+spec on its own would skip the siblings it depends on.
+
+Ginkgo matches `--focus` against `<SuiteDescription> <container texts> <It text>`,
+compiled with Go's `regexp`. The expression is one anchored `^…$` alternative per
+spec sharing a failed container — every spec's exact full text, escaped for RE2 and
+joined with `|`. Anchoring each spec rather than prefix-matching the container is
+what keeps `Node Profiles` from also pulling in `Node Profiles - selection precedence`.
+The `focused-rerun` output is `true` when the narrowing was applied.
+
+It falls back to a full run, with a `::notice::` explaining why, when:
+
+- this is the first attempt of the run;
+- no report from the previous attempt is in the bucket;
+- the previous attempt failed without any failed spec (build or infra failure);
+- a suite setup/teardown node (`BeforeSuite`, `AfterSuite`, …) failed, which
+  makes a spec-level focus meaningless.
+
+Note that the report and the summary of a focused re-run only cover the specs that
+were re-run. When a job fans out over a matrix, all of the previous attempt's
+reports are merged, so every matrix leg re-runs the union of the failures.
+
 ## Testing
 
 ```bash
 make test-run-ginkgo
 ```
 
-Runs the bats suites in `test/` against the shell scripts in `src/`.
+Runs the bats suites in `test/` against the shell scripts in `src/`, plus the Go
+suite in `test/focus/`.
+
+The Go suite exists because asserting on the focus regex as a string cannot catch an
+escaping or anchoring mistake. It runs `resolve-rerun-focus.sh` against a fixture,
+compiles the resulting expression with `regexp` (what Ginkgo does in
+`internal/focus.go`), and replays every spec through it to assert that the selected
+set is exactly the failed containers — no failure dropped, no neighbouring container
+pulled in.

--- a/.github/actions/run-ginkgo/action.yml
+++ b/.github/actions/run-ginkgo/action.yml
@@ -42,11 +42,18 @@ inputs:
     description: "Set to 'true' to upload the Ginkgo JSON report to GCS after the test run. Requires reports-bucket and workflow-file to be set."
     required: false
     default: "false"
+  rerun-failed-only:
+    description: "Set to 'true' to restrict re-runs (run attempt > 1) to the specs that did not pass in the previous attempt. Requires reports-bucket and workflow-file, and the previous attempt to have uploaded its report."
+    required: false
+    default: "false"
 
 outputs:
   failure-summary:
     description: "Markdown-formatted test results summary"
     value: ${{ steps.generate-summary.outputs.failure-summary }}
+  focused-rerun:
+    description: "'true' when this run was narrowed to the previous attempt's failed specs"
+    value: ${{ steps.rerun-focus.outputs.focused-rerun }}
 
 runs:
   using: "composite"
@@ -58,6 +65,16 @@ runs:
         go install github.com/onsi/ginkgo/v2/ginkgo
       env:
         TEST_DIR: ${{ inputs.test-dir }}
+
+    - name: Resolve focus for failed-only rerun
+      id: rerun-focus
+      if: inputs.rerun-failed-only == 'true'
+      shell: bash
+      env:
+        RERUN_FAILED_ONLY: ${{ inputs.rerun-failed-only }}
+        REPORTS_BUCKET: ${{ inputs.reports-bucket }}
+        WORKFLOW_FILE: ${{ inputs.workflow-file }}
+      run: ${{ github.action_path }}/src/resolve-rerun-focus.sh
 
     - name: Execute Ginkgo tests
       shell: bash

--- a/.github/actions/run-ginkgo/action.yml
+++ b/.github/actions/run-ginkgo/action.yml
@@ -43,7 +43,7 @@ inputs:
     required: false
     default: "false"
   rerun-failed-only:
-    description: "Set to 'true' to restrict re-runs (run attempt > 1) to the specs that did not pass in the previous attempt. Requires reports-bucket and workflow-file, and the previous attempt to have uploaded its report."
+    description: "Set to 'true' to narrow a re-run to the previous attempt's failures. Requires upload-report."
     required: false
     default: "false"
 
@@ -66,12 +66,13 @@ runs:
       env:
         TEST_DIR: ${{ inputs.test-dir }}
 
+    # No if: here - the script owns the guard so focused-rerun is never an empty string.
     - name: Resolve focus for failed-only rerun
       id: rerun-focus
-      if: inputs.rerun-failed-only == 'true'
       shell: bash
       env:
         RERUN_FAILED_ONLY: ${{ inputs.rerun-failed-only }}
+        UPLOAD_REPORT: ${{ inputs.upload-report }}
         REPORTS_BUCKET: ${{ inputs.reports-bucket }}
         WORKFLOW_FILE: ${{ inputs.workflow-file }}
       run: ${{ github.action_path }}/src/resolve-rerun-focus.sh
@@ -79,6 +80,7 @@ runs:
     - name: Execute Ginkgo tests
       shell: bash
       env:
+        GINKGO_FOCUS: ${{ steps.rerun-focus.outputs.focus }}
         GINKGO_LABEL: ${{ inputs.ginkgo-label }}
         TEST_DIR: ${{ inputs.test-dir }}
         TIMEOUT: ${{ inputs.timeout }}
@@ -91,6 +93,8 @@ runs:
       id: generate-summary
       if: always()
       shell: bash
+      env:
+        FOCUSED_RERUN: ${{ steps.rerun-focus.outputs.focused-rerun }}
       run: ${{ github.action_path }}/src/generate-summary.sh
 
     - name: Check GCP auth for report upload
@@ -113,5 +117,6 @@ runs:
       env:
         REPORTS_BUCKET: ${{ inputs.reports-bucket }}
         WORKFLOW_FILE: ${{ inputs.workflow-file }}
+        FOCUSED_RERUN: ${{ steps.rerun-focus.outputs.focused-rerun }}
         GH_TOKEN: ${{ inputs.github-token }}
       run: ${{ github.action_path }}/src/upload-report.sh

--- a/.github/actions/run-ginkgo/src/execute-tests.sh
+++ b/.github/actions/run-ginkgo/src/execute-tests.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Required env vars: TEST_DIR, TIMEOUT, PROCS
-# Optional env vars: GINKGO_LABEL, ADDITIONAL_ARGS, ADDITIONAL_GINKGO_FLAGS
+# Optional env vars: GINKGO_LABEL, ADDITIONAL_ARGS, ADDITIONAL_GINKGO_FLAGS, GINKGO_FOCUS
 
 WORKSPACE_ROOT="$(pwd)"
 REPORTS_DIR="${WORKSPACE_ROOT}/test-reports"
@@ -28,6 +28,11 @@ if [[ -n "${GINKGO_LABEL:-}" ]]; then
   LABEL_FILTER=$(echo "${GINKGO_LABEL}" | awk '{$1=$1; print}')
   GINKGO_ARGS+=("--label-filter=${LABEL_FILTER}")
   GINKGO_ARGS+=("-r")
+fi
+
+# Set by resolve-rerun-focus.sh to restrict the run to the previous attempt's failures
+if [[ -n "${GINKGO_FOCUS:-}" ]]; then
+  GINKGO_ARGS+=("--focus=${GINKGO_FOCUS}")
 fi
 
 echo "Working directory: ${TEST_DIR}"

--- a/.github/actions/run-ginkgo/src/generate-summary.sh
+++ b/.github/actions/run-ginkgo/src/generate-summary.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Required env vars: GITHUB_OUTPUT
-# Optional env vars: REPORT_FILE (defaults to test-reports/report.json)
+# Optional env vars: REPORT_FILE (defaults to test-reports/report.json), FOCUSED_RERUN
 
 REPORT_FILE="${REPORT_FILE:-test-reports/report.json}"
 
@@ -82,3 +82,11 @@ RUNTIME=$(echo "$STATS" | jq -r '.runtime')
 } >> "$GITHUB_OUTPUT"
 
 echo "Summary generated (Failed: ${FAILED_COUNT}, Passed: ${PASSED_COUNT})"
+
+# A focused rerun that matched nothing means the focus was built from specs this job does
+# not own (another matrix leg's report). Ginkgo exits 0 in that case, so without this the
+# job would go green having executed no specs at all.
+if [[ "${FOCUSED_RERUN:-}" == "true" && "$((PASSED_COUNT + FAILED_COUNT))" -eq 0 ]]; then
+  echo "::error::This rerun was narrowed to the previous attempt's failures but matched no specs - the focus does not belong to this job's suite"
+  exit 1
+fi

--- a/.github/actions/run-ginkgo/src/resolve-rerun-focus.sh
+++ b/.github/actions/run-ginkgo/src/resolve-rerun-focus.sh
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Exports GINKGO_FOCUS restricting the run to the previous attempt's failures.
+# Emits a Ginkgo --focus restricting the run to the previous attempt's failures.
 #
-# Required env:  GITHUB_ENV, GITHUB_OUTPUT
-# Optional env:  RERUN_FAILED_ONLY, REPORTS_BUCKET, WORKFLOW_FILE, RUNNER_TEMP,
-#                GITHUB_REPOSITORY, GITHUB_RUN_ID, GITHUB_RUN_ATTEMPT
+# Required env:  GITHUB_OUTPUT
+# Optional env:  RERUN_FAILED_ONLY, UPLOAD_REPORT, REPORTS_BUCKET, WORKFLOW_FILE,
+#                RUNNER_TEMP, GITHUB_REPOSITORY, GITHUB_RUN_ID, GITHUB_RUN_ATTEMPT
 # Test seam:     RERUN_REPORTS_DIR - read reports from here instead of GCS
+#
+# Outputs:       focus, focused-rerun ('true'/'false', never unset)
 
 skip() {
   echo "::notice::Failed-only rerun not applied: $1 - running the full suite"
@@ -14,7 +16,11 @@ skip() {
   exit 0
 }
 
-[[ "${RERUN_FAILED_ONLY:-false}" == "true" ]] || exit 0
+[[ "${RERUN_FAILED_ONLY:-false}" == "true" ]] || skip "rerun-failed-only is not enabled"
+
+if [[ -n "${UPLOAD_REPORT:-}" && "$UPLOAD_REPORT" != "true" ]]; then
+  echo "::warning::rerun-failed-only needs upload-report: 'true' - without it no attempt publishes the report this reads, so reruns can never be narrowed"
+fi
 
 ATTEMPT="${GITHUB_RUN_ATTEMPT:-1}"
 [[ "$ATTEMPT" -gt 1 ]] || skip "first attempt of this run"
@@ -26,9 +32,13 @@ if [[ -z "$REPORTS_DIR" ]]; then
 
   REPORTS_DIR="${RUNNER_TEMP:-/tmp}/ginkgo-previous-attempt"
   mkdir -p "$REPORTS_DIR"
+  # Read path for the layout upload-report.sh writes - keep the two in sync.
   SRC="gs://${REPORTS_BUCKET}/${GITHUB_REPOSITORY}/${WORKFLOW_FILE}/${GITHUB_RUN_ID}/$((ATTEMPT - 1))"
-  gcloud storage cp "${SRC}/*.json" "$REPORTS_DIR/" ||
-    skip "no report from attempt $((ATTEMPT - 1)) at ${SRC}"
+  # A degraded bucket would otherwise hang the job up to its timeout-minutes.
+  TIMEOUT=(timeout 300)
+  command -v timeout >/dev/null || TIMEOUT=()
+  "${TIMEOUT[@]}" gcloud storage cp "${SRC}/*.json" "$REPORTS_DIR/" ||
+    skip "no report from attempt $((ATTEMPT - 1)) at ${SRC} (missing, unreadable or timed out)"
 fi
 
 shopt -s nullglob
@@ -45,9 +55,17 @@ RESULT=$(jq -sr '
   def fullText: [ .suite ] + (.spec.ContainerHierarchyTexts // []) + [ .spec.LeafNodeText ]
     | map(select(. != "")) | join(" ");
 
-  [ .[] | .[]? | .SuiteDescription as $suite | (.SpecReports // [])[] | { suite: $suite, spec: . } ] as $all
+  [ .[] | .[]? ] as $suites
+  | [ $suites[] | .SuiteDescription as $suite | (.SpecReports // [])[] | { suite: $suite, spec: . } ] as $all
   | [ $all[] | select(.spec.State | IN("passed", "skipped", "pending") | not) ] as $failed
-  | if ($failed | length) == 0 then
+  | ([ $suites[] | (.SpecialSuiteFailureReasons // [])[] ] | unique) as $abortReasons
+  | if ($abortReasons | length) > 0 then
+      # An interrupted, timed out or otherwise aborted suite marks its unexecuted specs
+      # "skipped", indistinguishable from a deliberate skip, so they would never be rerun.
+      { focus: "", reason: "the previous attempt did not complete (\($abortReasons | join("; ")))" }
+    elif ($suites | any(.SuiteConfig.FailFast == true)) then
+      { focus: "", reason: "the previous attempt ran with --fail-fast, which leaves unexecuted specs marked skipped" }
+    elif ($failed | length) == 0 then
       { focus: "", reason: "no failed specs in the previous report" }
     elif ($failed | any(.spec.LeafNodeType != "It")) then
       { focus: "", reason: "a suite setup/teardown node failed" }
@@ -55,18 +73,25 @@ RESULT=$(jq -sr '
       ([ $failed[] | container ] | unique) as $containers
       | [ $all[] | select(.spec.LeafNodeType == "It" and (container | IN($containers[]))) ] as $rerun
       | { focus: ([ $rerun[] | "^" + (fullText | esc) + "$" ] | unique | join("|")),
+          containers: [ $containers[] | .[1] ],
           reason: "\($failed | length) failed spec(s), rerunning \($rerun | length) spec(s) across \($containers | length) top-level container(s)" }
     end
-' "${REPORTS[@]}")
+' "${REPORTS[@]}") || skip "could not parse the previous attempt's report(s) in ${REPORTS_DIR}"
 
 FOCUS=$(jq -r '.focus' <<<"$RESULT")
-[[ -n "$FOCUS" ]] || skip "$(jq -r '.reason' <<<"$RESULT")"
+REASON=$(jq -r '.reason' <<<"$RESULT")
+[[ -n "$FOCUS" ]] || skip "$REASON"
 
-echo "::notice::Rerunning only the specs that failed in attempt $((ATTEMPT - 1)): $(jq -r '.reason' <<<"$RESULT")"
+# esc escapes regex metacharacters, not newlines: a spec text containing one would close
+# the heredoc early and let the rest be parsed as workflow commands.
+[[ "$FOCUS" != *$'\n'* ]] || skip "the previous report contains a spec whose text spans multiple lines"
+
+echo "::notice::Rerunning only the specs that failed in attempt $((ATTEMPT - 1)): ${REASON}"
+jq -r '"Rerunning these top-level containers:", (.containers[] | "  - " + .)' <<<"$RESULT"
 echo "Focus: ${FOCUS}"
 {
-  echo "GINKGO_FOCUS<<GINKGO_FOCUS_EOF"
+  echo "focus<<GINKGO_FOCUS_EOF"
   echo "$FOCUS"
   echo "GINKGO_FOCUS_EOF"
-} >>"$GITHUB_ENV"
-echo "focused-rerun=true" >>"$GITHUB_OUTPUT"
+  echo "focused-rerun=true"
+} >>"$GITHUB_OUTPUT"

--- a/.github/actions/run-ginkgo/src/resolve-rerun-focus.sh
+++ b/.github/actions/run-ginkgo/src/resolve-rerun-focus.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Exports GINKGO_FOCUS restricting the run to the previous attempt's failures.
+#
+# Required env:  GITHUB_ENV, GITHUB_OUTPUT
+# Optional env:  RERUN_FAILED_ONLY, REPORTS_BUCKET, WORKFLOW_FILE, RUNNER_TEMP,
+#                GITHUB_REPOSITORY, GITHUB_RUN_ID, GITHUB_RUN_ATTEMPT
+# Test seam:     RERUN_REPORTS_DIR - read reports from here instead of GCS
+
+skip() {
+  echo "::notice::Failed-only rerun not applied: $1 - running the full suite"
+  echo "focused-rerun=false" >>"$GITHUB_OUTPUT"
+  exit 0
+}
+
+[[ "${RERUN_FAILED_ONLY:-false}" == "true" ]] || exit 0
+
+ATTEMPT="${GITHUB_RUN_ATTEMPT:-1}"
+[[ "$ATTEMPT" -gt 1 ]] || skip "first attempt of this run"
+
+REPORTS_DIR="${RERUN_REPORTS_DIR:-}"
+if [[ -z "$REPORTS_DIR" ]]; then
+  [[ -n "${REPORTS_BUCKET:-}" && -n "${WORKFLOW_FILE:-}" ]] ||
+    skip "reports-bucket and workflow-file are required to fetch the previous report"
+
+  REPORTS_DIR="${RUNNER_TEMP:-/tmp}/ginkgo-previous-attempt"
+  mkdir -p "$REPORTS_DIR"
+  SRC="gs://${REPORTS_BUCKET}/${GITHUB_REPOSITORY}/${WORKFLOW_FILE}/${GITHUB_RUN_ID}/$((ATTEMPT - 1))"
+  gcloud storage cp "${SRC}/*.json" "$REPORTS_DIR/" ||
+    skip "no report from attempt $((ATTEMPT - 1)) at ${SRC}"
+fi
+
+shopt -s nullglob
+REPORTS=("$REPORTS_DIR"/*.json)
+[[ ${#REPORTS[@]} -gt 0 ]] || skip "no report files in ${REPORTS_DIR}"
+
+# Rerun every spec sharing a failed spec's top-level container: the report drops
+# IsInOrderedContainer, so an Ordered spec rerun alone would skip the siblings it needs.
+# Each one is matched by its exact full text - a prefix match on the container would also
+# pull in siblings like "Node Profiles" vs "Node Profiles - selection precedence".
+RESULT=$(jq -sr '
+  def esc: gsub("(?<c>[.\\\\+*?()|\\[\\]{}^$])"; "\\\(.c)");
+  def container: [ .suite, ((.spec.ContainerHierarchyTexts // [])[0] // .spec.LeafNodeText) ];
+  def fullText: [ .suite ] + (.spec.ContainerHierarchyTexts // []) + [ .spec.LeafNodeText ]
+    | map(select(. != "")) | join(" ");
+
+  [ .[] | .[]? | .SuiteDescription as $suite | (.SpecReports // [])[] | { suite: $suite, spec: . } ] as $all
+  | [ $all[] | select(.spec.State | IN("passed", "skipped", "pending") | not) ] as $failed
+  | if ($failed | length) == 0 then
+      { focus: "", reason: "no failed specs in the previous report" }
+    elif ($failed | any(.spec.LeafNodeType != "It")) then
+      { focus: "", reason: "a suite setup/teardown node failed" }
+    else
+      ([ $failed[] | container ] | unique) as $containers
+      | [ $all[] | select(.spec.LeafNodeType == "It" and (container | IN($containers[]))) ] as $rerun
+      | { focus: ([ $rerun[] | "^" + (fullText | esc) + "$" ] | unique | join("|")),
+          reason: "\($failed | length) failed spec(s), rerunning \($rerun | length) spec(s) across \($containers | length) top-level container(s)" }
+    end
+' "${REPORTS[@]}")
+
+FOCUS=$(jq -r '.focus' <<<"$RESULT")
+[[ -n "$FOCUS" ]] || skip "$(jq -r '.reason' <<<"$RESULT")"
+
+echo "::notice::Rerunning only the specs that failed in attempt $((ATTEMPT - 1)): $(jq -r '.reason' <<<"$RESULT")"
+echo "Focus: ${FOCUS}"
+{
+  echo "GINKGO_FOCUS<<GINKGO_FOCUS_EOF"
+  echo "$FOCUS"
+  echo "GINKGO_FOCUS_EOF"
+} >>"$GITHUB_ENV"
+echo "focused-rerun=true" >>"$GITHUB_OUTPUT"

--- a/.github/actions/run-ginkgo/src/upload-report.sh
+++ b/.github/actions/run-ginkgo/src/upload-report.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 # Required env vars: REPORTS_BUCKET, WORKFLOW_FILE
+# Optional env vars: FOCUSED_RERUN - marks a report that only covers the specs a focused
+#                    rerun selected, so downstream flakiness stats can exclude it
 # Required tools:    gh (with GH_TOKEN), gcloud (authenticated), jq
 # GitHub-provided:   GITHUB_REPOSITORY, GITHUB_RUN_ID, GITHUB_RUN_ATTEMPT,
 #                    RUNNER_NAME, GITHUB_HEAD_REF, GITHUB_REF_NAME,
@@ -39,7 +41,8 @@ fi
 FINISHED_AT=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
 BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
 RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/attempts/${GITHUB_RUN_ATTEMPT}"
+# Write path for the layout resolve-rerun-focus.sh reads - keep the two in sync.
 DEST="gs://${REPORTS_BUCKET}/${GITHUB_REPOSITORY}/${WORKFLOW_FILE}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${JOB_ID}.json"
 
 gcloud storage cp test-reports/report.json "$DEST" \
-  --custom-metadata="run_url=${RUN_URL},repository=${GITHUB_REPOSITORY},branch=${BRANCH},workflow_file=${WORKFLOW_FILE},workflow_name=${GITHUB_WORKFLOW},job_id=${JOB_ID},job_name=${GITHUB_JOB},run_attempt=${GITHUB_RUN_ATTEMPT},started_at=${STARTED_AT},finished_at=${FINISHED_AT}"
+  --custom-metadata="run_url=${RUN_URL},repository=${GITHUB_REPOSITORY},branch=${BRANCH},workflow_file=${WORKFLOW_FILE},workflow_name=${GITHUB_WORKFLOW},job_id=${JOB_ID},job_name=${GITHUB_JOB},run_attempt=${GITHUB_RUN_ATTEMPT},focused_rerun=${FOCUSED_RERUN:-false},started_at=${STARTED_AT},finished_at=${FINISHED_AT}"

--- a/.github/actions/run-ginkgo/test/execute-tests.bats
+++ b/.github/actions/run-ginkgo/test/execute-tests.bats
@@ -2,38 +2,17 @@
 # Tests for execute-tests.sh argument construction.
 # Mocks `ginkgo` to capture the arguments it would receive.
 
+load helpers
+
 SCRIPT="$BATS_TEST_DIRNAME/../src/execute-tests.sh"
 
 setup() {
   MOCK_DIR=$(mktemp -d)
-  export MOCK_ARGS_FILE="$MOCK_DIR/ginkgo-args"
-
-  # Create a mock ginkgo that records arguments
-  MOCK_BIN="$MOCK_DIR/bin"
-  mkdir -p "$MOCK_BIN"
-  cat > "$MOCK_BIN/ginkgo" <<'MOCK'
-#!/usr/bin/env bash
-printf '%s\n' "$@" > "$MOCK_ARGS_FILE"
-MOCK
-  chmod +x "$MOCK_BIN/ginkgo"
-
-  # Create a fake test directory structure
-  export WORK_DIR="$MOCK_DIR/workspace"
-  mkdir -p "$WORK_DIR/e2e-next/suites/basic"
-
-  # Required env vars
-  export TEST_DIR="e2e-next"
-  export TIMEOUT="60m"
-  export PROCS="8"
-  export PATH="$MOCK_BIN:$PATH"
+  setup_ginkgo_mock
 }
 
 teardown() {
   rm -rf "$MOCK_DIR"
-}
-
-has_arg() {
-  grep -qF -- "$1" "$MOCK_ARGS_FILE"
 }
 
 # --- Label-based tests ---

--- a/.github/actions/run-ginkgo/test/execute-tests.bats
+++ b/.github/actions/run-ginkgo/test/execute-tests.bats
@@ -175,3 +175,22 @@ has_arg() {
   [ "$status" -eq 0 ]
   grep -q "\-\-json-report=$WORK_DIR/test-reports/report.json" "$MOCK_ARGS_FILE"
 }
+
+# --- Focused rerun ---
+
+@test "passes GINKGO_FOCUS through as a single --focus argument" {
+  cd "$WORK_DIR"
+  export GINKGO_LABEL="suite"
+  export GINKGO_FOCUS='^Suite Alpha syncs pods \(a\)$|^Suite Beta(?: |$)'
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  has_arg '--focus=^Suite Alpha syncs pods \(a\)$|^Suite Beta(?: |$)'
+}
+
+@test "no --focus argument when GINKGO_FOCUS is unset" {
+  cd "$WORK_DIR"
+  export GINKGO_LABEL="suite"
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  ! grep -q -- '--focus=' "$MOCK_ARGS_FILE"
+}

--- a/.github/actions/run-ginkgo/test/fixtures/rerun/all-passed/report.json
+++ b/.github/actions/run-ginkgo/test/fixtures/rerun/all-passed/report.json
@@ -1,0 +1,25 @@
+[
+  {
+    "SuiteDescription": "vCluster Platform E2E Suite",
+    "SpecReports": [
+      {
+        "State": "passed",
+        "LeafNodeType": "It",
+        "LeafNodeText": "creates a tenant cluster",
+        "ContainerHierarchyTexts": [
+          "Tenant",
+          "Lifecycle"
+        ]
+      },
+      {
+        "State": "skipped",
+        "LeafNodeType": "It",
+        "LeafNodeText": "deletes a tenant cluster",
+        "ContainerHierarchyTexts": [
+          "Tenant",
+          "Lifecycle"
+        ]
+      }
+    ]
+  }
+]

--- a/.github/actions/run-ginkgo/test/fixtures/rerun/fail-fast/report.json
+++ b/.github/actions/run-ginkgo/test/fixtures/rerun/fail-fast/report.json
@@ -1,0 +1,11 @@
+[
+  {
+    "SuiteDescription": "vCluster Platform E2E Suite",
+    "SuiteSucceeded": false,
+    "SuiteConfig": { "FailFast": true },
+    "SpecReports": [
+      { "State": "failed", "LeafNodeType": "It", "LeafNodeText": "fails first", "ContainerHierarchyTexts": ["Terraform"] },
+      { "State": "skipped", "LeafNodeType": "It", "LeafNodeText": "never ran", "ContainerHierarchyTexts": ["Auto Nodes"] }
+    ]
+  }
+]

--- a/.github/actions/run-ginkgo/test/fixtures/rerun/interrupted/report.json
+++ b/.github/actions/run-ginkgo/test/fixtures/rerun/interrupted/report.json
@@ -1,0 +1,11 @@
+[
+  {
+    "SuiteDescription": "vCluster Platform E2E Suite",
+    "SuiteSucceeded": false,
+    "SpecialSuiteFailureReasons": ["Suite Timeout Elapsed"],
+    "SpecReports": [
+      { "State": "failed", "LeafNodeType": "It", "LeafNodeText": "times out", "ContainerHierarchyTexts": ["Terraform"] },
+      { "State": "skipped", "LeafNodeType": "It", "LeafNodeText": "never ran", "ContainerHierarchyTexts": ["Auto Nodes"] }
+    ]
+  }
+]

--- a/.github/actions/run-ginkgo/test/fixtures/rerun/malformed/report.json
+++ b/.github/actions/run-ginkgo/test/fixtures/rerun/malformed/report.json
@@ -1,0 +1,1 @@
+[{"SuiteDescription": "vCluster Platform E2E Suite", "SpecReports": [{"State": "failed", "LeafNodeTy

--- a/.github/actions/run-ginkgo/test/fixtures/rerun/mixed-failures/report.json
+++ b/.github/actions/run-ginkgo/test/fixtures/rerun/mixed-failures/report.json
@@ -1,0 +1,13 @@
+[
+  {
+    "SuiteDescription": "vCluster Platform E2E Suite",
+    "SpecReports": [
+      { "State": "passed", "LeafNodeType": "It", "LeafNodeText": "creates a tenant cluster", "ContainerHierarchyTexts": ["Tenant (a)", "Lifecycle"] },
+      { "State": "failed", "LeafNodeType": "It", "LeafNodeText": "syncs pods", "ContainerHierarchyTexts": ["Tenant (a)", "Sync"] },
+      { "State": "skipped", "LeafNodeType": "It", "LeafNodeText": "deletes a tenant cluster", "ContainerHierarchyTexts": ["Sleep Mode", "Lifecycle"] },
+      { "State": "pending", "LeafNodeType": "It", "LeafNodeText": "not implemented yet", "ContainerHierarchyTexts": ["Node Profiles", "Lifecycle"] },
+      { "State": "panicked", "LeafNodeType": "It", "LeafNodeText": "renders parameters", "ContainerHierarchyTexts": ["ArgoCD v2", "template management", "parameter rendering"] },
+      { "State": "failed", "LeafNodeType": "It", "LeafNodeText": "top level spec with no container" }
+    ]
+  }
+]

--- a/.github/actions/run-ginkgo/test/fixtures/rerun/multi-suite/suite-a.json
+++ b/.github/actions/run-ginkgo/test/fixtures/rerun/multi-suite/suite-a.json
@@ -1,0 +1,19 @@
+[
+  {
+    "SuiteDescription": "Suite A",
+    "SpecReports": [
+      {
+        "State": "failed",
+        "LeafNodeType": "It",
+        "LeafNodeText": "fails here",
+        "ContainerHierarchyTexts": [
+          "Alpha"
+        ]
+      }
+    ]
+  },
+  {
+    "SuiteDescription": "Suite B",
+    "SpecReports": null
+  }
+]

--- a/.github/actions/run-ginkgo/test/fixtures/rerun/multi-suite/suite-b.json
+++ b/.github/actions/run-ginkgo/test/fixtures/rerun/multi-suite/suite-b.json
@@ -1,0 +1,23 @@
+[
+  {
+    "SuiteDescription": "Suite B",
+    "SpecReports": [
+      {
+        "State": "timedout",
+        "LeafNodeType": "It",
+        "LeafNodeText": "hangs",
+        "ContainerHierarchyTexts": [
+          "Beta"
+        ]
+      },
+      {
+        "State": "failed",
+        "LeafNodeType": "It",
+        "LeafNodeText": "hangs",
+        "ContainerHierarchyTexts": [
+          "Beta"
+        ]
+      }
+    ]
+  }
+]

--- a/.github/actions/run-ginkgo/test/fixtures/rerun/selection/report.json
+++ b/.github/actions/run-ginkgo/test/fixtures/rerun/selection/report.json
@@ -28,6 +28,9 @@
       { "State": "passed", "LeafNodeType": "It", "LeafNodeText": "is untouched", "ContainerHierarchyTexts": ["Node Profiles"] },
       { "State": "pending", "LeafNodeType": "It", "LeafNodeText": "is not implemented", "ContainerHierarchyTexts": ["Node Profiles"] },
 
+      { "State": "failed", "LeafNodeType": "It", "LeafNodeText": "escapes [ ] { } ^ $ \\ * + ? every metacharacter", "ContainerHierarchyTexts": ["Metacharacters"] },
+      { "State": "passed", "LeafNodeType": "It", "LeafNodeText": "lists instances", "ContainerHierarchyTexts": ["virtualclusterinstancesXmanagementXloftXsh/v1"] },
+
       { "State": "failed", "LeafNodeType": "It", "LeafNodeText": "runs on schedule", "ContainerHierarchyTexts": ["Auto Snapshots"] },
       { "State": "passed", "LeafNodeType": "It", "LeafNodeText": "on Azure Blob", "ContainerHierarchyTexts": ["Auto Snapshots"] },
       { "State": "passed", "LeafNodeType": "It", "LeafNodeText": "uploads the snapshot", "ContainerHierarchyTexts": ["Auto Snapshots on Azure Blob"] },

--- a/.github/actions/run-ginkgo/test/fixtures/rerun/selection/report.json
+++ b/.github/actions/run-ginkgo/test/fixtures/rerun/selection/report.json
@@ -1,0 +1,38 @@
+[
+  {
+    "SuiteDescription": "vCluster Platform E2E Suite",
+    "SpecReports": [
+      { "State": "passed", "LeafNodeType": "SynchronizedBeforeSuite", "LeafNodeText": "" },
+
+      { "State": "failed", "LeafNodeType": "It", "LeafNodeText": "installs the module", "ContainerHierarchyTexts": ["Terraform"] },
+      { "State": "passed", "LeafNodeType": "It", "LeafNodeText": "destroys the module", "ContainerHierarchyTexts": ["Terraform"] },
+      { "State": "skipped", "LeafNodeType": "It", "LeafNodeText": "imports existing state", "ContainerHierarchyTexts": ["Terraform"] },
+
+      { "State": "passed", "LeafNodeType": "It", "LeafNodeText": "boots a node", "ContainerHierarchyTexts": ["Auto Nodes"] },
+      { "State": "passed", "LeafNodeType": "It", "LeafNodeText": "drains a node", "ContainerHierarchyTexts": ["Auto Nodes"] },
+
+      { "State": "failed", "LeafNodeType": "It", "LeafNodeText": "scales to zero", "ContainerHierarchyTexts": ["Auto Nodes Extended"] },
+      { "State": "passed", "LeafNodeType": "It", "LeafNodeText": "scales back up", "ContainerHierarchyTexts": ["Auto Nodes Extended"] },
+
+      { "State": "panicked", "LeafNodeType": "It", "LeafNodeText": "renders parameters", "ContainerHierarchyTexts": ["ArgoCD v2 Integration", "template management", "parameter rendering"] },
+      { "State": "passed", "LeafNodeType": "It", "LeafNodeText": "creates the connector", "ContainerHierarchyTexts": ["ArgoCD v2 Integration", "connector management"] },
+      { "State": "passed", "LeafNodeType": "It", "LeafNodeText": "deletes the connector", "ContainerHierarchyTexts": ["ArgoCD v2 Integration", "connector management"] },
+
+      { "State": "timedout", "LeafNodeType": "It", "LeafNodeText": "lists instances", "ContainerHierarchyTexts": ["virtualclusterinstances.management.loft.sh/v1"] },
+      { "State": "passed", "LeafNodeType": "It", "LeafNodeText": "gets an instance", "ContainerHierarchyTexts": ["virtualclusterinstances.management.loft.sh/v1"] },
+
+      { "State": "failed", "LeafNodeType": "It", "LeafNodeText": "honours the annotation", "ContainerHierarchyTexts": ["Sleep Mode (a|b)", "when configured"] },
+      { "State": "passed", "LeafNodeType": "It", "LeafNodeText": "ignores user agents", "ContainerHierarchyTexts": ["Sleep Mode (a|b)", "when configured"] },
+      { "State": "passed", "LeafNodeType": "It", "LeafNodeText": "wakes on traffic", "ContainerHierarchyTexts": ["Sleep Mode (a|b) Extra"] },
+
+      { "State": "passed", "LeafNodeType": "It", "LeafNodeText": "is untouched", "ContainerHierarchyTexts": ["Node Profiles"] },
+      { "State": "pending", "LeafNodeType": "It", "LeafNodeText": "is not implemented", "ContainerHierarchyTexts": ["Node Profiles"] },
+
+      { "State": "failed", "LeafNodeType": "It", "LeafNodeText": "runs on schedule", "ContainerHierarchyTexts": ["Auto Snapshots"] },
+      { "State": "passed", "LeafNodeType": "It", "LeafNodeText": "on Azure Blob", "ContainerHierarchyTexts": ["Auto Snapshots"] },
+      { "State": "passed", "LeafNodeType": "It", "LeafNodeText": "uploads the snapshot", "ContainerHierarchyTexts": ["Auto Snapshots on Azure Blob"] },
+
+      { "State": "passed", "LeafNodeType": "ReportAfterSuite", "LeafNodeText": "" }
+    ]
+  }
+]

--- a/.github/actions/run-ginkgo/test/fixtures/rerun/setup-failure/report.json
+++ b/.github/actions/run-ginkgo/test/fixtures/rerun/setup-failure/report.json
@@ -1,0 +1,22 @@
+[
+  {
+    "SuiteDescription": "vCluster Platform E2E Suite",
+    "SpecReports": [
+      {
+        "State": "failed",
+        "LeafNodeType": "SynchronizedBeforeSuite",
+        "LeafNodeText": "",
+        "ContainerHierarchyTexts": []
+      },
+      {
+        "State": "failed",
+        "LeafNodeType": "It",
+        "LeafNodeText": "syncs pods",
+        "ContainerHierarchyTexts": [
+          "Tenant",
+          "Sync"
+        ]
+      }
+    ]
+  }
+]

--- a/.github/actions/run-ginkgo/test/fixtures/rerun/suite-collision/report.json
+++ b/.github/actions/run-ginkgo/test/fixtures/rerun/suite-collision/report.json
@@ -1,0 +1,16 @@
+[
+  {
+    "SuiteDescription": "Suite A",
+    "SpecReports": [
+      { "State": "passed", "LeafNodeType": "It", "LeafNodeText": "creates a resource", "ContainerHierarchyTexts": ["Lifecycle"] },
+      { "State": "passed", "LeafNodeType": "It", "LeafNodeText": "deletes a resource", "ContainerHierarchyTexts": ["Lifecycle"] }
+    ]
+  },
+  {
+    "SuiteDescription": "Suite B",
+    "SpecReports": [
+      { "State": "failed", "LeafNodeType": "It", "LeafNodeText": "creates a resource", "ContainerHierarchyTexts": ["Lifecycle"] },
+      { "State": "passed", "LeafNodeType": "It", "LeafNodeText": "deletes a resource", "ContainerHierarchyTexts": ["Lifecycle"] }
+    ]
+  }
+]

--- a/.github/actions/run-ginkgo/test/focus/focus_test.go
+++ b/.github/actions/run-ginkgo/test/focus/focus_test.go
@@ -1,0 +1,223 @@
+// Proves that the --focus expression produced by resolve-rerun-focus.sh selects the
+// right specs once Ginkgo applies it. Ginkgo skips a spec when the focus regex does
+// not match "<SuiteDescription> <container texts...> <It text>", compiled with Go's
+// regexp package - see ginkgo/v2/internal/focus.go ApplyFocusToSpecs. Asserting on the
+// regex text alone would not catch an escaping or anchoring mistake, so these tests
+// replay the fixture through the real matcher.
+package focus_test
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+	"testing"
+)
+
+type specReport struct {
+	State                   string
+	LeafNodeType            string
+	LeafNodeText            string
+	ContainerHierarchyTexts []string
+}
+
+type suiteReport struct {
+	SuiteDescription string
+	SpecReports      []specReport
+}
+
+// fullText mirrors internal.Spec.Text(): non-empty node texts joined by a space.
+func (s specReport) fullText() string {
+	texts := make([]string, 0, len(s.ContainerHierarchyTexts)+1)
+	for _, t := range s.ContainerHierarchyTexts {
+		if t != "" {
+			texts = append(texts, t)
+		}
+	}
+	if s.LeafNodeText != "" {
+		texts = append(texts, s.LeafNodeText)
+	}
+	return strings.Join(texts, " ")
+}
+
+func (s specReport) didNotPass() bool {
+	return !slices.Contains([]string{"passed", "skipped", "pending"}, s.State)
+}
+
+// resolveFocus runs the action's script against a fixture directory and returns the
+// GINKGO_FOCUS value it exported.
+func resolveFocus(t *testing.T, fixture string) string {
+	t.Helper()
+
+	tmp := t.TempDir()
+	envFile := filepath.Join(tmp, "github_env")
+	outFile := filepath.Join(tmp, "github_output")
+	for _, f := range []string{envFile, outFile} {
+		if err := os.WriteFile(f, nil, 0o600); err != nil {
+			t.Fatalf("create %s: %v", f, err)
+		}
+	}
+
+	script, err := filepath.Abs(filepath.Join("..", "..", "src", "resolve-rerun-focus.sh"))
+	if err != nil {
+		t.Fatalf("resolve script path: %v", err)
+	}
+	reportsDir, err := filepath.Abs(filepath.Join("..", "fixtures", "rerun", fixture))
+	if err != nil {
+		t.Fatalf("resolve fixture path: %v", err)
+	}
+
+	cmd := exec.Command("bash", script)
+	cmd.Env = append(os.Environ(),
+		"RERUN_FAILED_ONLY=true",
+		"GITHUB_RUN_ATTEMPT=2",
+		"RERUN_REPORTS_DIR="+reportsDir,
+		"GITHUB_ENV="+envFile,
+		"GITHUB_OUTPUT="+outFile,
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("resolve-rerun-focus.sh failed: %v\n%s", err, out)
+	}
+
+	contents, err := os.ReadFile(envFile)
+	if err != nil {
+		t.Fatalf("read GITHUB_ENV: %v", err)
+	}
+	lines := strings.Split(strings.TrimRight(string(contents), "\n"), "\n")
+	for i, line := range lines {
+		if line == "GINKGO_FOCUS<<GINKGO_FOCUS_EOF" && i+1 < len(lines) {
+			return lines[i+1]
+		}
+	}
+	t.Fatalf("no GINKGO_FOCUS in GITHUB_ENV:\n%s", contents)
+	return ""
+}
+
+func loadReport(t *testing.T, fixture, file string) []suiteReport {
+	t.Helper()
+
+	raw, err := os.ReadFile(filepath.Join("..", "fixtures", "rerun", fixture, file))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	var suites []suiteReport
+	if err := json.Unmarshal(raw, &suites); err != nil {
+		t.Fatalf("parse fixture: %v", err)
+	}
+	return suites
+}
+
+// selectSpecs returns the It specs the focus expression would run, keyed by full text.
+func selectSpecs(t *testing.T, focus string, suites []suiteReport) []string {
+	t.Helper()
+
+	re, err := regexp.Compile(focus)
+	if err != nil {
+		t.Fatalf("focus is not a valid Go regexp (Ginkgo would panic): %v\nfocus: %s", err, focus)
+	}
+
+	var selected []string
+	for _, suite := range suites {
+		for _, spec := range suite.SpecReports {
+			if spec.LeafNodeType != "It" {
+				continue
+			}
+			if re.MatchString(suite.SuiteDescription + " " + spec.fullText()) {
+				selected = append(selected, spec.fullText())
+			}
+		}
+	}
+	slices.Sort(selected)
+	return selected
+}
+
+func TestFocusRerunsEveryFailedSpec(t *testing.T) {
+	suites := loadReport(t, "selection", "report.json")
+	selected := selectSpecs(t, resolveFocus(t, "selection"), suites)
+
+	for _, suite := range suites {
+		for _, spec := range suite.SpecReports {
+			if spec.LeafNodeType != "It" || !spec.didNotPass() {
+				continue
+			}
+			if !slices.Contains(selected, spec.fullText()) {
+				t.Errorf("failed spec would not be rerun: %q", spec.fullText())
+			}
+		}
+	}
+}
+
+func TestFocusSelectsExactlyTheFailedTopLevelContainers(t *testing.T) {
+	suites := loadReport(t, "selection", "report.json")
+	selected := selectSpecs(t, resolveFocus(t, "selection"), suites)
+
+	// Every spec under a container that had a failure, and nothing else. The whole
+	// container runs because an Ordered spec cannot be rerun without its siblings.
+	want := []string{
+		"ArgoCD v2 Integration connector management creates the connector",
+		"ArgoCD v2 Integration connector management deletes the connector",
+		"ArgoCD v2 Integration template management parameter rendering renders parameters",
+		"Auto Nodes Extended scales back up",
+		"Auto Nodes Extended scales to zero",
+		"Auto Snapshots on Azure Blob",
+		"Auto Snapshots runs on schedule",
+		"Sleep Mode (a|b) when configured honours the annotation",
+		"Sleep Mode (a|b) when configured ignores user agents",
+		"Terraform destroys the module",
+		"Terraform imports existing state",
+		"Terraform installs the module",
+		"virtualclusterinstances.management.loft.sh/v1 gets an instance",
+		"virtualclusterinstances.management.loft.sh/v1 lists instances",
+	}
+	slices.Sort(want)
+
+	if !slices.Equal(selected, want) {
+		t.Errorf("selected specs mismatch\n got: %v\nwant: %v", selected, want)
+	}
+}
+
+func TestFocusDoesNotLeakIntoNeighbouringContainers(t *testing.T) {
+	suites := loadReport(t, "selection", "report.json")
+	selected := selectSpecs(t, resolveFocus(t, "selection"), suites)
+
+	// "Auto Nodes" and "Sleep Mode (a|b)" are prefixes of containers that did fail, and
+	// "Sleep Mode (a|b)" also carries regex metacharacters. "Auto Snapshots on Azure Blob"
+	// is a container whose name equals the full text of a spec that IS rerun, so it only
+	// stays out while each alternative is anchored at both ends.
+	for _, unwanted := range []string{
+		"Auto Nodes boots a node",
+		"Auto Nodes drains a node",
+		"Sleep Mode (a|b) Extra wakes on traffic",
+		"Node Profiles is untouched",
+		"Node Profiles is not implemented",
+		"Auto Snapshots on Azure Blob uploads the snapshot",
+	} {
+		if slices.Contains(selected, unwanted) {
+			t.Errorf("spec from a passing container would be rerun: %q", unwanted)
+		}
+	}
+}
+
+func TestFocusIsScopedToItsOwnSuite(t *testing.T) {
+	suites := loadReport(t, "multi-suite", "suite-b.json")
+	focus := resolveFocus(t, "multi-suite")
+
+	re := regexp.MustCompile(focus)
+	// With -r the focus is applied to every discovered suite, so it has to pin the suite
+	// description too: an identically named spec in another suite must not match, not even
+	// when that suite's description ends with the focused one.
+	for _, other := range []string{"Suite C Alpha fails here", "Extra Suite A Alpha fails here"} {
+		if re.MatchString(other) {
+			t.Errorf("focus matched a spec in an unrelated suite: %q\nfocus: %s", other, focus)
+		}
+	}
+	if !re.MatchString("Suite B Beta hangs") {
+		t.Errorf("focus did not match its own suite's spec\nfocus: %s", focus)
+	}
+	if len(suites) == 0 {
+		t.Fatal("fixture suite-b.json is empty")
+	}
+}

--- a/.github/actions/run-ginkgo/test/focus/focus_test.go
+++ b/.github/actions/run-ginkgo/test/focus/focus_test.go
@@ -48,17 +48,14 @@ func (s specReport) didNotPass() bool {
 }
 
 // resolveFocus runs the action's script against a fixture directory and returns the
-// GINKGO_FOCUS value it exported.
+// focus step output it emitted.
 func resolveFocus(t *testing.T, fixture string) string {
 	t.Helper()
 
 	tmp := t.TempDir()
-	envFile := filepath.Join(tmp, "github_env")
 	outFile := filepath.Join(tmp, "github_output")
-	for _, f := range []string{envFile, outFile} {
-		if err := os.WriteFile(f, nil, 0o600); err != nil {
-			t.Fatalf("create %s: %v", f, err)
-		}
+	if err := os.WriteFile(outFile, nil, 0o600); err != nil {
+		t.Fatalf("create %s: %v", outFile, err)
 	}
 
 	script, err := filepath.Abs(filepath.Join("..", "..", "src", "resolve-rerun-focus.sh"))
@@ -75,24 +72,23 @@ func resolveFocus(t *testing.T, fixture string) string {
 		"RERUN_FAILED_ONLY=true",
 		"GITHUB_RUN_ATTEMPT=2",
 		"RERUN_REPORTS_DIR="+reportsDir,
-		"GITHUB_ENV="+envFile,
 		"GITHUB_OUTPUT="+outFile,
 	)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("resolve-rerun-focus.sh failed: %v\n%s", err, out)
 	}
 
-	contents, err := os.ReadFile(envFile)
+	contents, err := os.ReadFile(outFile)
 	if err != nil {
-		t.Fatalf("read GITHUB_ENV: %v", err)
+		t.Fatalf("read GITHUB_OUTPUT: %v", err)
 	}
 	lines := strings.Split(strings.TrimRight(string(contents), "\n"), "\n")
 	for i, line := range lines {
-		if line == "GINKGO_FOCUS<<GINKGO_FOCUS_EOF" && i+1 < len(lines) {
+		if line == "focus<<GINKGO_FOCUS_EOF" && i+1 < len(lines) {
 			return lines[i+1]
 		}
 	}
-	t.Fatalf("no GINKGO_FOCUS in GITHUB_ENV:\n%s", contents)
+	t.Fatalf("no focus output:\n%s", contents)
 	return ""
 }
 
@@ -164,6 +160,7 @@ func TestFocusSelectsExactlyTheFailedTopLevelContainers(t *testing.T) {
 		"Auto Nodes Extended scales to zero",
 		"Auto Snapshots on Azure Blob",
 		"Auto Snapshots runs on schedule",
+		"Metacharacters escapes [ ] { } ^ $ \\ * + ? every metacharacter",
 		"Sleep Mode (a|b) when configured honours the annotation",
 		"Sleep Mode (a|b) when configured ignores user agents",
 		"Terraform destroys the module",
@@ -194,10 +191,34 @@ func TestFocusDoesNotLeakIntoNeighbouringContainers(t *testing.T) {
 		"Node Profiles is untouched",
 		"Node Profiles is not implemented",
 		"Auto Snapshots on Azure Blob uploads the snapshot",
+		// Differs from the dotted container only where the dots are, so an unescaped "."
+		// in esc's character class shows up as over-selection.
+		"virtualclusterinstancesXmanagementXloftXsh/v1 lists instances",
 	} {
 		if slices.Contains(selected, unwanted) {
 			t.Errorf("spec from a passing container would be rerun: %q", unwanted)
 		}
+	}
+}
+
+func TestFocusDistinguishesSameNamedContainersAcrossSuites(t *testing.T) {
+	suites := loadReport(t, "suite-collision", "report.json")
+	selected := selectSpecs(t, resolveFocus(t, "suite-collision"), suites)
+
+	// Both suites have a "Lifecycle" container with identically named specs; only the
+	// one in Suite B failed. Grouping by container name alone would rerun Suite A's too,
+	// and the two suites' specs are told apart only by the suite description prefix.
+	want := []string{"Lifecycle creates a resource", "Lifecycle deletes a resource"}
+	if !slices.Equal(selected, want) {
+		t.Errorf("selected specs mismatch\n got: %v\nwant: %v", selected, want)
+	}
+
+	re := regexp.MustCompile(resolveFocus(t, "suite-collision"))
+	if re.MatchString("Suite A Lifecycle creates a resource") {
+		t.Error("focus matched the passing suite's identically named spec")
+	}
+	if !re.MatchString("Suite B Lifecycle creates a resource") {
+		t.Error("focus did not match the failing suite's spec")
 	}
 }
 

--- a/.github/actions/run-ginkgo/test/focus/go.mod
+++ b/.github/actions/run-ginkgo/test/focus/go.mod
@@ -1,0 +1,3 @@
+module github.com/loft-sh/github-actions/run-ginkgo/focus
+
+go 1.26.4

--- a/.github/actions/run-ginkgo/test/helpers.bash
+++ b/.github/actions/run-ginkgo/test/helpers.bash
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Shared bats scaffolding for the run-ginkgo suites.
+
+# Puts a fake ginkgo on PATH that records its argv in $MOCK_ARGS_FILE, and sets the env
+# vars execute-tests.sh requires. Expects $MOCK_DIR to exist.
+# shellcheck disable=SC2153  # MOCK_DIR is set by each suite's setup()
+setup_ginkgo_mock() {
+  MOCK_BIN="$MOCK_DIR/bin"
+  mkdir -p "$MOCK_BIN"
+  export MOCK_ARGS_FILE="$MOCK_DIR/ginkgo-args"
+  cat >"$MOCK_BIN/ginkgo" <<'MOCK'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "$MOCK_ARGS_FILE"
+MOCK
+  chmod +x "$MOCK_BIN/ginkgo"
+  export PATH="$MOCK_BIN:$PATH"
+
+  export WORK_DIR="$MOCK_DIR/workspace"
+  mkdir -p "$WORK_DIR/${1:-e2e-next}/suites/basic"
+  export TEST_DIR="${1:-e2e-next}"
+  export TIMEOUT="60m"
+  export PROCS="8"
+}
+
+# Stubs the runner's $GITHUB_OUTPUT file. Expects $MOCK_DIR to exist.
+setup_github_output() {
+  export GITHUB_OUTPUT="$MOCK_DIR/output"
+  : >"$GITHUB_OUTPUT"
+}
+
+has_arg() {
+  grep -qF -- "$1" "$MOCK_ARGS_FILE"
+}

--- a/.github/actions/run-ginkgo/test/rerun-integration.bats
+++ b/.github/actions/run-ginkgo/test/rerun-integration.bats
@@ -1,0 +1,73 @@
+#!/usr/bin/env bats
+# End-to-end wiring: resolve-rerun-focus.sh exports GINKGO_FOCUS via GITHUB_ENV, the
+# runner turns that into an env var, and execute-tests.sh must hand it to ginkgo.
+# The two scripts run as separate composite steps, so nothing else covers the seam.
+
+RESOLVE="$BATS_TEST_DIRNAME/../src/resolve-rerun-focus.sh"
+EXECUTE="$BATS_TEST_DIRNAME/../src/execute-tests.sh"
+FIXTURES="$BATS_TEST_DIRNAME/fixtures/rerun"
+
+setup() {
+  MOCK_DIR=$(mktemp -d)
+  export GITHUB_ENV="$MOCK_DIR/env"
+  export GITHUB_OUTPUT="$MOCK_DIR/output"
+  touch "$GITHUB_ENV" "$GITHUB_OUTPUT"
+
+  MOCK_BIN="$MOCK_DIR/bin"
+  mkdir -p "$MOCK_BIN"
+  export MOCK_ARGS_FILE="$MOCK_DIR/ginkgo-args"
+  cat >"$MOCK_BIN/ginkgo" <<'MOCK'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "$MOCK_ARGS_FILE"
+MOCK
+  chmod +x "$MOCK_BIN/ginkgo"
+  export PATH="$MOCK_BIN:$PATH"
+
+  export WORK_DIR="$MOCK_DIR/workspace"
+  mkdir -p "$WORK_DIR/e2e"
+  export TEST_DIR="e2e"
+  export TIMEOUT="60m"
+  export PROCS="8"
+  export GINKGO_LABEL="pr"
+}
+
+teardown() {
+  rm -rf "$MOCK_DIR"
+}
+
+# Applies GITHUB_ENV the way the Actions runner does between steps.
+export_github_env() {
+  local key value
+  while IFS= read -r line; do
+    case "$line" in
+      *"<<GINKGO_FOCUS_EOF") key="${line%%<<*}"; IFS= read -r value; export "$key=$value" ;;
+    esac
+  done <"$GITHUB_ENV"
+}
+
+@test "a resolved focus reaches ginkgo intact through GITHUB_ENV" {
+  RERUN_FAILED_ONLY=true GITHUB_RUN_ATTEMPT=2 RERUN_REPORTS_DIR="$FIXTURES/mixed-failures" \
+    bash "$RESOLVE"
+  export_github_env
+  [ -n "$GINKGO_FOCUS" ]
+
+  cd "$WORK_DIR"
+  run bash "$EXECUTE"
+  [ "$status" -eq 0 ]
+
+  # One argument, byte-identical to what was resolved - no shell mangling of $, (, |
+  grep -qxF -- "--focus=$GINKGO_FOCUS" "$MOCK_ARGS_FILE"
+  grep -qxF -- "--label-filter=pr" "$MOCK_ARGS_FILE"
+}
+
+@test "no --focus reaches ginkgo when the resolve step falls back to a full run" {
+  RERUN_FAILED_ONLY=true GITHUB_RUN_ATTEMPT=2 RERUN_REPORTS_DIR="$FIXTURES/all-passed" \
+    bash "$RESOLVE"
+  export_github_env
+  [ -z "${GINKGO_FOCUS:-}" ]
+
+  cd "$WORK_DIR"
+  run bash "$EXECUTE"
+  [ "$status" -eq 0 ]
+  ! grep -q -- '--focus=' "$MOCK_ARGS_FILE"
+}

--- a/.github/actions/run-ginkgo/test/rerun-integration.bats
+++ b/.github/actions/run-ginkgo/test/rerun-integration.bats
@@ -1,33 +1,19 @@
 #!/usr/bin/env bats
-# End-to-end wiring: resolve-rerun-focus.sh exports GINKGO_FOCUS via GITHUB_ENV, the
-# runner turns that into an env var, and execute-tests.sh must hand it to ginkgo.
+# End-to-end wiring: resolve-rerun-focus.sh emits the focus as a step output, the runner
+# maps it onto GINKGO_FOCUS via action.yml, and execute-tests.sh must hand it to ginkgo.
 # The two scripts run as separate composite steps, so nothing else covers the seam.
+
+load helpers
 
 RESOLVE="$BATS_TEST_DIRNAME/../src/resolve-rerun-focus.sh"
 EXECUTE="$BATS_TEST_DIRNAME/../src/execute-tests.sh"
+SUMMARY="$BATS_TEST_DIRNAME/../src/generate-summary.sh"
 FIXTURES="$BATS_TEST_DIRNAME/fixtures/rerun"
 
 setup() {
   MOCK_DIR=$(mktemp -d)
-  export GITHUB_ENV="$MOCK_DIR/env"
-  export GITHUB_OUTPUT="$MOCK_DIR/output"
-  touch "$GITHUB_ENV" "$GITHUB_OUTPUT"
-
-  MOCK_BIN="$MOCK_DIR/bin"
-  mkdir -p "$MOCK_BIN"
-  export MOCK_ARGS_FILE="$MOCK_DIR/ginkgo-args"
-  cat >"$MOCK_BIN/ginkgo" <<'MOCK'
-#!/usr/bin/env bash
-printf '%s\n' "$@" > "$MOCK_ARGS_FILE"
-MOCK
-  chmod +x "$MOCK_BIN/ginkgo"
-  export PATH="$MOCK_BIN:$PATH"
-
-  export WORK_DIR="$MOCK_DIR/workspace"
-  mkdir -p "$WORK_DIR/e2e"
-  export TEST_DIR="e2e"
-  export TIMEOUT="60m"
-  export PROCS="8"
+  setup_github_output
+  setup_ginkgo_mock e2e
   export GINKGO_LABEL="pr"
 }
 
@@ -35,27 +21,24 @@ teardown() {
   rm -rf "$MOCK_DIR"
 }
 
-# Applies GITHUB_ENV the way the Actions runner does between steps.
-export_github_env() {
-  local key value
-  while IFS= read -r line; do
-    case "$line" in
-      *"<<GINKGO_FOCUS_EOF") key="${line%%<<*}"; IFS= read -r value; export "$key=$value" ;;
-    esac
-  done <"$GITHUB_ENV"
+# Reads the focus step output the way action.yml wires it into the execute step.
+export_resolved_focus() {
+  local value
+  value="$(sed -n '/^focus<<GINKGO_FOCUS_EOF$/,/^GINKGO_FOCUS_EOF$/{ /GINKGO_FOCUS_EOF$/d; p; }' "$GITHUB_OUTPUT")"
+  export GINKGO_FOCUS="$value"
 }
 
-@test "a resolved focus reaches ginkgo intact through GITHUB_ENV" {
+@test "a resolved focus reaches ginkgo intact as a single argument" {
   RERUN_FAILED_ONLY=true GITHUB_RUN_ATTEMPT=2 RERUN_REPORTS_DIR="$FIXTURES/mixed-failures" \
     bash "$RESOLVE"
-  export_github_env
+  export_resolved_focus
   [ -n "$GINKGO_FOCUS" ]
 
   cd "$WORK_DIR"
   run bash "$EXECUTE"
   [ "$status" -eq 0 ]
 
-  # One argument, byte-identical to what was resolved - no shell mangling of $, (, |
+  # Byte-identical to what was resolved - no shell mangling of $, (, | or backslashes
   grep -qxF -- "--focus=$GINKGO_FOCUS" "$MOCK_ARGS_FILE"
   grep -qxF -- "--label-filter=pr" "$MOCK_ARGS_FILE"
 }
@@ -63,11 +46,43 @@ export_github_env() {
 @test "no --focus reaches ginkgo when the resolve step falls back to a full run" {
   RERUN_FAILED_ONLY=true GITHUB_RUN_ATTEMPT=2 RERUN_REPORTS_DIR="$FIXTURES/all-passed" \
     bash "$RESOLVE"
-  export_github_env
-  [ -z "${GINKGO_FOCUS:-}" ]
+  export_resolved_focus
+  [ -z "$GINKGO_FOCUS" ]
 
   cd "$WORK_DIR"
   run bash "$EXECUTE"
   [ "$status" -eq 0 ]
   ! grep -q -- '--focus=' "$MOCK_ARGS_FILE"
+}
+
+# --- the zero-match guard ---
+
+@test "a focused rerun that matched no specs fails instead of reporting success" {
+  mkdir -p "$WORK_DIR/test-reports"
+  echo '[{"PreRunStats":{"TotalSpecs":40,"SpecsThatWillRun":0},"RunTime":0,"SpecReports":[]}]' \
+    >"$WORK_DIR/test-reports/report.json"
+
+  cd "$WORK_DIR"
+  REPORT_FILE=test-reports/report.json FOCUSED_RERUN=true run bash "$SUMMARY"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"matched no specs"* ]]
+}
+
+@test "an unfocused run with no specs is left alone" {
+  mkdir -p "$WORK_DIR/test-reports"
+  echo '[{"PreRunStats":{"TotalSpecs":40,"SpecsThatWillRun":0},"RunTime":0,"SpecReports":[]}]' \
+    >"$WORK_DIR/test-reports/report.json"
+
+  cd "$WORK_DIR"
+  REPORT_FILE=test-reports/report.json FOCUSED_RERUN=false run bash "$SUMMARY"
+  [ "$status" -eq 0 ]
+}
+
+@test "a focused rerun that did run specs is not flagged" {
+  mkdir -p "$WORK_DIR/test-reports"
+  cp "$FIXTURES/../with-failures.json" "$WORK_DIR/test-reports/report.json"
+
+  cd "$WORK_DIR"
+  REPORT_FILE=test-reports/report.json FOCUSED_RERUN=true run bash "$SUMMARY"
+  [ "$status" -eq 0 ]
 }

--- a/.github/actions/run-ginkgo/test/resolve-rerun-focus.bats
+++ b/.github/actions/run-ginkgo/test/resolve-rerun-focus.bats
@@ -6,9 +6,8 @@ FIXTURES="$BATS_TEST_DIRNAME/fixtures/rerun"
 
 setup() {
   MOCK_DIR=$(mktemp -d)
-  export GITHUB_ENV="$MOCK_DIR/env"
   export GITHUB_OUTPUT="$MOCK_DIR/output"
-  touch "$GITHUB_ENV" "$GITHUB_OUTPUT"
+  touch "$GITHUB_OUTPUT"
   export RERUN_FAILED_ONLY=true
   export GITHUB_RUN_ATTEMPT=2
 }
@@ -17,9 +16,9 @@ teardown() {
   rm -rf "$MOCK_DIR"
 }
 
-# Helper: extract the GINKGO_FOCUS heredoc value from GITHUB_ENV
+# Helper: extract the focus heredoc value from GITHUB_OUTPUT
 get_focus() {
-  sed -n '/^GINKGO_FOCUS<<GINKGO_FOCUS_EOF$/,/^GINKGO_FOCUS_EOF$/{ /GINKGO_FOCUS_EOF$/d; p; }' "$GITHUB_ENV"
+  sed -n '/^focus<<GINKGO_FOCUS_EOF$/,/^GINKGO_FOCUS_EOF$/{ /GINKGO_FOCUS_EOF$/d; p; }' "$GITHUB_OUTPUT"
 }
 
 run_with() {
@@ -50,11 +49,11 @@ MOCK
 
 # --- guards: fall back to a full run ---
 
-@test "does nothing when rerun-failed-only is not enabled" {
+@test "reports focused-rerun=false when the feature is not enabled" {
   RERUN_FAILED_ONLY=false run_with mixed-failures
   [ "$status" -eq 0 ]
-  [ ! -s "$GITHUB_ENV" ]
-  [ ! -s "$GITHUB_OUTPUT" ]
+  [ -z "$(get_focus)" ]
+  grep -q '^focused-rerun=false$' "$GITHUB_OUTPUT"
 }
 
 @test "falls back to a full run on the first attempt" {
@@ -94,6 +93,42 @@ MOCK
   [ "$status" -eq 0 ]
   [[ "$output" == *"reports-bucket and workflow-file are required"* ]]
   grep -q '^focused-rerun=false$' "$GITHUB_OUTPUT"
+}
+
+@test "falls back to a full run when the previous report cannot be parsed" {
+  run_with malformed
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"could not parse the previous attempt's report"* ]]
+  [ -z "$(get_focus)" ]
+  grep -q '^focused-rerun=false$' "$GITHUB_OUTPUT"
+}
+
+@test "falls back to a full run when the previous attempt was interrupted" {
+  run_with interrupted
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"did not complete (Suite Timeout Elapsed)"* ]]
+  [ -z "$(get_focus)" ]
+  grep -q '^focused-rerun=false$' "$GITHUB_OUTPUT"
+}
+
+@test "falls back to a full run when the previous attempt used --fail-fast" {
+  run_with fail-fast
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"--fail-fast"* ]]
+  [ -z "$(get_focus)" ]
+  grep -q '^focused-rerun=false$' "$GITHUB_OUTPUT"
+}
+
+@test "warns when upload-report is not enabled alongside rerun-failed-only" {
+  UPLOAD_REPORT=false run_with mixed-failures
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"::warning::rerun-failed-only needs upload-report"* ]]
+}
+
+@test "does not warn when upload-report is enabled" {
+  UPLOAD_REPORT=true run_with mixed-failures
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"::warning::"* ]]
 }
 
 # --- focus construction ---
@@ -181,5 +216,26 @@ MOCK
   [ "$status" -eq 0 ]
   [[ "$output" == *"no report from attempt 1"* ]]
   [ -z "$(get_focus)" ]
+  grep -q '^focused-rerun=false$' "$GITHUB_OUTPUT"
+}
+
+# --- diagnosability ---
+
+@test "logs the top-level containers being rerun" {
+  run_with mixed-failures
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Rerunning these top-level containers:"* ]]
+  [[ "$output" == *"  - Tenant (a)"* ]]
+  [[ "$output" == *"  - ArgoCD v2"* ]]
+}
+
+@test "rejects a focus containing a newline rather than writing a broken heredoc" {
+  local dir="$MOCK_DIR/newline"
+  mkdir -p "$dir"
+  printf '[{"SuiteDescription":"S","SpecReports":[{"State":"failed","LeafNodeType":"It","LeafNodeText":"a\\nGINKGO_FOCUS_EOF\\nINJECTED=evil","ContainerHierarchyTexts":["C"]}]}]' >"$dir/report.json"
+  RERUN_REPORTS_DIR="$dir" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"spans multiple lines"* ]]
+  ! grep -q '^INJECTED=evil$' "$GITHUB_OUTPUT"
   grep -q '^focused-rerun=false$' "$GITHUB_OUTPUT"
 }

--- a/.github/actions/run-ginkgo/test/resolve-rerun-focus.bats
+++ b/.github/actions/run-ginkgo/test/resolve-rerun-focus.bats
@@ -1,0 +1,185 @@
+#!/usr/bin/env bats
+# Tests for resolve-rerun-focus.sh
+
+SCRIPT="$BATS_TEST_DIRNAME/../src/resolve-rerun-focus.sh"
+FIXTURES="$BATS_TEST_DIRNAME/fixtures/rerun"
+
+setup() {
+  MOCK_DIR=$(mktemp -d)
+  export GITHUB_ENV="$MOCK_DIR/env"
+  export GITHUB_OUTPUT="$MOCK_DIR/output"
+  touch "$GITHUB_ENV" "$GITHUB_OUTPUT"
+  export RERUN_FAILED_ONLY=true
+  export GITHUB_RUN_ATTEMPT=2
+}
+
+teardown() {
+  rm -rf "$MOCK_DIR"
+}
+
+# Helper: extract the GINKGO_FOCUS heredoc value from GITHUB_ENV
+get_focus() {
+  sed -n '/^GINKGO_FOCUS<<GINKGO_FOCUS_EOF$/,/^GINKGO_FOCUS_EOF$/{ /GINKGO_FOCUS_EOF$/d; p; }' "$GITHUB_ENV"
+}
+
+run_with() {
+  RERUN_REPORTS_DIR="$FIXTURES/$1" run bash "$SCRIPT"
+}
+
+# Mocks gcloud to record its arguments and copy a fixture into the destination,
+# so the GCS branch can be exercised without RERUN_REPORTS_DIR.
+mock_gcloud() {
+  local fixture="$1" exit_code="${2:-0}"
+  MOCK_BIN="$MOCK_DIR/bin"
+  mkdir -p "$MOCK_BIN"
+  export MOCK_GCLOUD_ARGS="$MOCK_DIR/gcloud-args"
+  cat >"$MOCK_BIN/gcloud" <<MOCK
+#!/usr/bin/env bash
+printf '%s\n' "\$@" > "$MOCK_GCLOUD_ARGS"
+[ "$exit_code" -eq 0 ] || exit "$exit_code"
+cp "$FIXTURES/$fixture"/*.json "\${@: -1}"
+MOCK
+  chmod +x "$MOCK_BIN/gcloud"
+  export PATH="$MOCK_BIN:$PATH"
+  export RUNNER_TEMP="$MOCK_DIR/runner-temp"
+  export REPORTS_BUCKET="my-reports-bucket"
+  export WORKFLOW_FILE="e2e-ginkgo.yaml"
+  export GITHUB_REPOSITORY="loft-sh/loft-enterprise"
+  export GITHUB_RUN_ID="42"
+}
+
+# --- guards: fall back to a full run ---
+
+@test "does nothing when rerun-failed-only is not enabled" {
+  RERUN_FAILED_ONLY=false run_with mixed-failures
+  [ "$status" -eq 0 ]
+  [ ! -s "$GITHUB_ENV" ]
+  [ ! -s "$GITHUB_OUTPUT" ]
+}
+
+@test "falls back to a full run on the first attempt" {
+  GITHUB_RUN_ATTEMPT=1 run_with mixed-failures
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"first attempt"* ]]
+  [ -z "$(get_focus)" ]
+  grep -q '^focused-rerun=false$' "$GITHUB_OUTPUT"
+}
+
+@test "falls back to a full run when the previous report has no failures" {
+  run_with all-passed
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no failed specs"* ]]
+  [ -z "$(get_focus)" ]
+  grep -q '^focused-rerun=false$' "$GITHUB_OUTPUT"
+}
+
+@test "falls back to a full run when a suite setup node failed" {
+  run_with setup-failure
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"setup/teardown node failed"* ]]
+  [ -z "$(get_focus)" ]
+  grep -q '^focused-rerun=false$' "$GITHUB_OUTPUT"
+}
+
+@test "falls back to a full run when the report directory is empty" {
+  mkdir -p "$MOCK_DIR/empty"
+  RERUN_REPORTS_DIR="$MOCK_DIR/empty" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no report files"* ]]
+  grep -q '^focused-rerun=false$' "$GITHUB_OUTPUT"
+}
+
+@test "falls back to a full run when reports-bucket is missing" {
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"reports-bucket and workflow-file are required"* ]]
+  grep -q '^focused-rerun=false$' "$GITHUB_OUTPUT"
+}
+
+# --- focus construction ---
+
+@test "anchors each spec's full text and escapes regex metacharacters" {
+  run_with mixed-failures
+  [ "$status" -eq 0 ]
+  local focus
+  focus="$(get_focus)"
+  [[ "$focus" == *'^vCluster Platform E2E Suite Tenant \(a\) Sync syncs pods$'* ]]
+}
+
+@test "reruns the passing siblings sharing a failed spec's top-level container" {
+  run_with mixed-failures
+  [ "$status" -eq 0 ]
+  local focus
+  focus="$(get_focus)"
+  [[ "$focus" == *'^vCluster Platform E2E Suite Tenant \(a\) Lifecycle creates a tenant cluster$'* ]]
+}
+
+@test "keeps the full nested hierarchy of a failed spec" {
+  run_with mixed-failures
+  [ "$status" -eq 0 ]
+  local focus
+  focus="$(get_focus)"
+  [[ "$focus" == *'^vCluster Platform E2E Suite ArgoCD v2 template management parameter rendering renders parameters$'* ]]
+}
+
+@test "handles a failed spec that has no container" {
+  run_with mixed-failures
+  [ "$status" -eq 0 ]
+  local focus
+  focus="$(get_focus)"
+  [[ "$focus" == *'^vCluster Platform E2E Suite top level spec with no container$'* ]]
+}
+
+@test "excludes containers whose specs all passed, skipped or are pending" {
+  run_with mixed-failures
+  [ "$status" -eq 0 ]
+  local focus
+  focus="$(get_focus)"
+  [[ "$focus" != *"Sleep Mode"* ]]
+  [[ "$focus" != *"Node Profiles"* ]]
+}
+
+@test "reports failed, rerun and container counts, and marks the run as focused" {
+  run_with mixed-failures
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"3 failed spec(s), rerunning 4 spec(s) across 3 top-level container(s)"* ]]
+  grep -q '^focused-rerun=true$' "$GITHUB_OUTPUT"
+}
+
+@test "merges reports across files and dedupes identical specs" {
+  run_with multi-suite
+  [ "$status" -eq 0 ]
+  local focus
+  focus="$(get_focus)"
+  [[ "$focus" == *'^Suite A Alpha fails here$'* ]]
+  [[ "$focus" == *'^Suite B Beta hangs$'* ]]
+  # the same spec reported as both timedout and failed collapses into one alternative
+  [ "$(awk -F'Suite B Beta hangs' '{print NF-1}' <<<"$focus")" -eq 1 ]
+}
+
+# --- fetching the previous attempt's report from GCS ---
+
+@test "downloads the previous attempt's reports from the run's GCS prefix" {
+  mock_gcloud mixed-failures
+  GITHUB_RUN_ATTEMPT=3 run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  grep -qx 'gs://my-reports-bucket/loft-sh/loft-enterprise/e2e-ginkgo.yaml/42/2/\*.json' "$MOCK_GCLOUD_ARGS"
+  grep -qx "$RUNNER_TEMP/ginkgo-previous-attempt/" "$MOCK_GCLOUD_ARGS"
+}
+
+@test "builds the focus from the downloaded reports" {
+  mock_gcloud mixed-failures
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$(get_focus)" == *'Tenant \(a\) Sync syncs pods'* ]]
+  grep -q '^focused-rerun=true$' "$GITHUB_OUTPUT"
+}
+
+@test "falls back to a full run when the download fails" {
+  mock_gcloud mixed-failures 1
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no report from attempt 1"* ]]
+  [ -z "$(get_focus)" ]
+  grep -q '^focused-rerun=false$' "$GITHUB_OUTPUT"
+}

--- a/.github/workflows/test-run-ginkgo.yaml
+++ b/.github/workflows/test-run-ginkgo.yaml
@@ -18,3 +18,16 @@ jobs:
       - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
         with:
           tests: .github/actions/run-ginkgo/test
+
+  focus-selection:
+    name: Run focus selection tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: .github/actions/run-ginkgo/test/focus/go.mod
+      - run: go test -count=1 ./...
+        working-directory: .github/actions/run-ginkgo/test/focus

--- a/Makefile
+++ b/Makefile
@@ -138,8 +138,9 @@ test-govulncheck: ## run govulncheck bats tests
 test-go-licenses: ## run go-licenses bats tests
 	bats $(ACTIONS_DIR)/go-licenses/test/run.bats
 
-test-run-ginkgo: ## run run-ginkgo bats tests
+test-run-ginkgo: ## run run-ginkgo bats and focus selection tests
 	bats $(ACTIONS_DIR)/run-ginkgo/test/*.bats
+	cd $(ACTIONS_DIR)/run-ginkgo/test/focus && go test -count=1 ./...
 
 test-sticky-pr-comment: ## run sticky-pr-comment bats tests
 	bats $(ACTIONS_DIR)/sticky-pr-comment/test/*.bats


### PR DESCRIPTION
Adds rerun-failed-only. On run attempt > 1 the action pulls the previous attempt's JSON report from GCS and builds a --focus expression scoped to the specs that did not pass, so "Re-run failed jobs" no longer replays the whole suite.

The unit is the failed spec's top-level container, not the spec: the report drops IsInOrderedContainer (SpecReport.MarshalJSON), so it cannot tell whether a spec depends on Ordered siblings. Every spec in that container is matched by its own anchored full text - prefix-matching the container name would also pull in siblings like "Node Profiles - selection precedence".

Falls back to a full run on the first attempt, a missing report, a failure with no failed spec, or a failed suite setup node.

test/focus is a Go suite because asserting on the regex as a string cannot catch an escaping or anchoring mistake: it runs the script, compiles the expression with regexp the way ginkgo/v2/internal/focus.go does, and replays every fixture spec to check the selected set exactly.