### PR TITLE
fix(promote-release): order the promotion gates by semver, not bare sort -V

### DIFF
--- a/.github/actions/promote-release/README.md
+++ b/.github/actions/promote-release/README.md
@@ -70,7 +70,14 @@ any bare one (`v0.36.1` above `0.36.2`), and orders `1.2.3+build.1` above the
 `1.2.3` it has equal precedence with. Each one would have the gate read its
 baseline as the newer release and either withhold a correct promotion on a green
 run or move `:latest` backwards. A pre-release genuinely ahead of `version` still
-blocks it.
+blocks it. The tag-shape filters admit the same forms, since a shape a filter
+rejects is invisible to the ordering rather than merely mis-sorted.
+
+One consequence to know about: a tag that is not a version at all (`stable`,
+`nightly`) outranks every release, so flagging one Latest makes every promotion
+withhold `:latest`/`:{major}` while `:{major}.{minor}` keeps advancing. The run
+emits a `::warning::` naming the tag and stays green. **Re-running does not clear
+it** — move the Latest flag onto a released version.
 
 The paired `oss-repo` Latest pointer and Homebrew formula advance only when
 `version` passes **both** the caller-repository gate and the `oss-repo` gate.

--- a/.github/actions/promote-release/README.md
+++ b/.github/actions/promote-release/README.md
@@ -76,6 +76,13 @@ absent pointer must not be read as "nothing has ever been promoted"; that would
 let a dispatch for an older line drag `:latest` backwards. A genuinely empty
 release list still advances, which is the real first-ever promotion.
 
+Because GitHub lets a human flag *any* release Latest, that baseline can be a
+pre-release tag, so the gates compare under semver precedence rather than
+`sort -V` alone — `sort -V` ranks `v0.36.1-rc.1` above `v0.36.1`, which would
+read an rc holding the pointer as newer than the stable release it precedes and
+withhold that release's whole promotion on a green run. A pre-release that is
+genuinely ahead of `version` still blocks it.
+
 `:{major}.{minor}` is scoped to its own line and gets its own check: it advances
 only when `version` is the newest stable-shaped tag *within that
 `{major}.{minor}` line* (GitHub has no per-line equivalent of the Latest

--- a/.github/actions/promote-release/README.md
+++ b/.github/actions/promote-release/README.md
@@ -62,6 +62,16 @@ stable is already `:latest` skips `:latest`/`:{major}`, so they never move
 backwards. Re-promoting the release that is already Latest is allowed, so a
 partially failed promotion can simply be re-run.
 
+Both comparisons against that **Latest** pointer use semver precedence, not
+`sort -V` alone. Because a human can flag any release Latest, the pointer's tag
+arrives in whatever shape they created it, and `sort -V` gets all three shapes
+wrong: it ranks `v0.36.1-rc.1` above `v0.36.1`, ranks any `v`-prefixed tag above
+any bare one (`v0.36.1` above `0.36.2`), and orders `1.2.3+build.1` above the
+`1.2.3` it has equal precedence with. Each one would have the gate read its
+baseline as the newer release and either withhold a correct promotion on a green
+run or move `:latest` backwards. A pre-release genuinely ahead of `version` still
+blocks it.
+
 The paired `oss-repo` Latest pointer and Homebrew formula advance only when
 `version` passes **both** the caller-repository gate and the `oss-repo` gate.
 The caller pointer is the authoritative baseline for the coordinated Docker
@@ -75,13 +85,6 @@ release build re-asserts `make_latest: false` on the tag that holds it — so an
 absent pointer must not be read as "nothing has ever been promoted"; that would
 let a dispatch for an older line drag `:latest` backwards. A genuinely empty
 release list still advances, which is the real first-ever promotion.
-
-Because GitHub lets a human flag *any* release Latest, that baseline can be a
-pre-release tag, so the gates compare under semver precedence rather than
-`sort -V` alone — `sort -V` ranks `v0.36.1-rc.1` above `v0.36.1`, which would
-read an rc holding the pointer as newer than the stable release it precedes and
-withhold that release's whole promotion on a green run. A pre-release that is
-genuinely ahead of `version` still blocks it.
 
 `:{major}.{minor}` is scoped to its own line and gets its own check: it advances
 only when `version` is the newest stable-shaped tag *within that

--- a/.github/actions/promote-release/src/action.sh
+++ b/.github/actions/promote-release/src/action.sh
@@ -259,16 +259,28 @@ LATEST_BASELINE_NOTE=""
 # stable release it precedes and the promotion of that release was withheld -
 # :latest, :{major}, both --latest edits and the Homebrew patch - on a green run.
 #
-# Mirrors newer_version in vcluster-pro's verify-promotion.sh and version_gt in
-# platform-version-bump.sh, so the promoter and its postcondition agree on order.
+# Needs GNU coreutils: `sort -V` must rank '~' below everything, which BSD and
+# macOS sort do not. The runners are Ubuntu; running the bats suite on a Mac will
+# disagree. Same requirement resolve-versions.sh states for its sort_key.
+#
+# Mirrors newer_version in vcluster-pro's verify-promotion.sh, version_gt in
+# platform-version-bump.sh, and sort_key/is_below in this repo's
+# prerelease-setup/src/resolve-versions.sh, so the promoter and its postcondition
+# agree on order. Correcting one of them means correcting all four.
 semver_sort() {
   tr '-' '~' | sort -V | tr '~' '-'
 }
 
+# The 'v' comes off both operands first. GitHub does not require a release tag to
+# carry it, and it only takes one hand-made release for the baseline to arrive
+# bare: `sort -V` then ranks v0.36.1 above 0.36.2 - 'v' outranks a digit - so the
+# gate would read the older version as newer and move :latest BACKWARDS, the one
+# thing it exists to prevent. Stripping is also what makes the parity with
+# newer_version above real rather than approximate.
 version_at_or_after() {
   local baseline="$1"
   [ -z "${baseline}" ] && return 0
-  [ "$(printf '%s\n%s\n' "${VERSION}" "${baseline}" | semver_sort | tail -1)" = "${VERSION}" ]
+  [ "$(printf '%s\n%s\n' "${VERSION#v}" "${baseline#v}" | semver_sort | tail -1)" = "${VERSION#v}" ]
 }
 
 is_at_or_after_latest_pointer() {
@@ -283,9 +295,12 @@ is_at_or_after_latest_pointer() {
   # conservative.
   max=$(jq -r '[.[] | select(.isLatest) | .tagName][]' <<<"${releases}" | semver_sort | tail -1)
   if [[ -z "${max}" ]]; then
+    # semver_sort is a no-op while stable_shape excludes every hyphen, and is
+    # here so that stays a detail of the filter rather than something this sort
+    # depends on being true.
     max=$(jq -r '.[].tagName' <<<"${releases}" \
       | grep -E "${stable_shape}" \
-      | sort -V \
+      | semver_sort \
       | tail -1) || true
     if [[ -n "${max}" ]]; then
       LATEST_BASELINE_NOTE="newest stable tag ${max}; no release currently flagged Latest"
@@ -310,7 +325,7 @@ is_newest_in_line() {
   filter="^v${line//./\\.}\.[0-9]+$"
   max=$(jq -r '.[].tagName' <<<"${releases}" \
     | grep -E "${filter}" \
-    | sort -V \
+    | semver_sort \
     | tail -1) || true
 
   version_at_or_after "${max}"

--- a/.github/actions/promote-release/src/action.sh
+++ b/.github/actions/promote-release/src/action.sh
@@ -247,59 +247,78 @@ fetch_release_list() {
 # make_latest:false, so absence must not be mistaken for a first promotion.
 LATEST_BASELINE_NOTE=""
 
-# Semver precedence, which `sort -V` alone does not implement: it ranks
-# v9.9.9-rc.1 ABOVE v9.9.9, the reverse of semver. '~' sorts before
-# end-of-string, so translating '-' to '~' restores the order, and git forbids
-# '~' in ref names, so translating back cannot alter a tag. tr rather than
-# "${x//-/~}", which embeds a literal backslash.
+# Highest of the tags on stdin by semver precedence, printed in its ORIGINAL form.
+# One primitive for the whole file: every ordering here - the three selections and
+# the comparison below - goes through it, so there is no second normalization
+# contract for a future call site to pick the wrong one of.
 #
-# The gates below need this because their baseline is chosen by the mutable
-# isLatest flag rather than by tag shape, so a pre-release whose flag was
-# cleared by hand can hold the pointer. Unnormalized, the rc outranked the
-# stable release it precedes and the promotion of that release was withheld -
-# :latest, :{major}, both --latest edits and the Homebrew patch - on a green run.
+# `sort -V` implements none of the three rules on its own:
+#
+#   - it ranks v9.9.9-rc.1 ABOVE v9.9.9, the reverse of semver. '~' sorts before
+#     end-of-string, so mapping '-' to '~' restores it.
+#   - it ranks any v-prefixed tag above any bare one, because 'v' outranks a
+#     digit, so a flagged 10.0.0 next to a co-flagged v9.9.8 would resolve to
+#     v9.9.8 - the LOWER of the two - and let :latest move backwards past 10.0.0.
+#     GitHub does not require the v, so one hand-made release mixes the list.
+#   - it orders 1.2.3+build.1 above 1.2.3, which semver gives EQUAL precedence.
+#     Left in, promoting v1.2.3 against a Latest-flagged v1.2.3+meta reads as
+#     older than the baseline and withholds the whole promotion on a green run.
+#
+# All three are normalized into a key held in a separate field, never into the
+# output: the winner is handed to callers who need the real tag - it names the
+# release in LATEST_BASELINE_NOTE and is matched against GitHub's own tag names -
+# and a stripped or translated form would name a release that does not exist.
+#
+# awk rather than "${x//-/~}", where an unescaped '~' in the replacement is
+# tilde-expanded ('9.9.9-rc.1' becomes '9.9.9/home/youruserrc.1').
 #
 # Needs GNU coreutils: `sort -V` must rank '~' below everything, which BSD and
 # macOS sort do not. The runners are Ubuntu; running the bats suite on a Mac will
-# disagree. Same requirement resolve-versions.sh states for its sort_key.
+# disagree. resolve-versions.sh states the same requirement for its sort_key.
+# The precedence key for one tag. Every comparison and selection in this file is
+# defined in terms of this one function, so there is no second normalization for
+# a future call site to reach for by mistake - which is the shape of the bug this
+# whole gate keeps being fixed for.
 #
-# Mirrors newer_version in vcluster-pro's verify-promotion.sh, version_gt in
-# platform-version-bump.sh, and sort_key/is_below in this repo's
-# prerelease-setup/src/resolve-versions.sh, so the promoter and its postcondition
-# agree on order. Correcting one of them means correcting all four.
-semver_sort() {
-  tr '-' '~' | sort -V | tr '~' '-'
+# Two tags share a key exactly when semver gives them equal precedence, so key
+# equality is the equality test, and `sort -V` over keys is the ordering.
+semver_key() {
+  local key="${1#v}"
+  key="${key%%+*}"
+  printf '%s' "${key//-/\~}"
 }
 
-# Highest of the tags on stdin, by the same precedence, printed in its ORIGINAL
-# form. Selecting has to sort on a normalized key held in a separate field rather
-# than on the tag itself, because the winner is handed back to callers who need
-# the real tag: it names the release in LATEST_BASELINE_NOTE and is compared
-# against GitHub's own tag names. A stripped or '~'-translated form would name a
-# release that does not exist.
-#
-# Keying also covers the dimension a whole-line sort cannot. GitHub does not
-# require the leading v, so one hand-made release makes the list mixed, and `v`
-# outranks a digit: a raw sort of a Latest-flagged 10.0.0 alongside a co-flagged
-# v9.9.8 returns v9.9.8, the LOWER of the two, and the gate then lets :latest move
-# backwards past 10.0.0. Same failure the rc case has, on the v dimension.
+# Highest of the tags on stdin, printed in its ORIGINAL form. Sorts on the key in
+# a separate field rather than on the tag, because the winner goes to callers who
+# need the real tag: it names the release in LATEST_BASELINE_NOTE and is matched
+# against GitHub's own tag names, and a normalized form would name a release that
+# does not exist. The per-line subshell is bounded by the same 1000-release window
+# the callers fetch.
 semver_max() {
-  awk 'NF { key = $0; sub(/^v/, "", key); gsub(/-/, "~", key); print key "\t" $0 }' \
+  local tag
+  while IFS= read -r tag; do
+    [ -z "${tag}" ] && continue
+    printf '%s\t%s\n' "$(semver_key "${tag}")" "${tag}"
+  done \
     | sort -t"$(printf '\t')" -k1,1V \
     | tail -1 \
     | cut -f2-
 }
 
-# The 'v' comes off both operands first. GitHub does not require a release tag to
-# carry it, and it only takes one hand-made release for the baseline to arrive
-# bare: `sort -V` then ranks v0.36.1 above 0.36.2 - 'v' outranks a digit - so the
-# gate would read the older version as newer and move :latest BACKWARDS, the one
-# thing it exists to prevent. Stripping is also what makes the parity with
-# newer_version above real rather than approximate.
+# Comparing the KEYS rather than the tags is what makes equality pass, so a
+# partially failed promotion stays re-runnable: equal precedence means byte-equal
+# keys, so the sort returns that key either way and no separate equality test is
+# needed. 9.9.9, v9.9.9 and v9.9.9+meta are one release and compare as one.
+#
+# This is also why the comparison does not use semver_max: keys are already
+# normalized, so a plain `sort -V` is correct here, and there is no tag to hand
+# back. semver_max exists for the selections, which must return the real tag.
 version_at_or_after() {
-  local baseline="$1"
+  local baseline="$1" vkey bkey
   [ -z "${baseline}" ] && return 0
-  [ "$(printf '%s\n%s\n' "${VERSION#v}" "${baseline#v}" | semver_sort | tail -1)" = "${VERSION#v}" ]
+  vkey="$(semver_key "${VERSION}")"
+  bkey="$(semver_key "${baseline}")"
+  [ "$(printf '%s\n%s\n' "${vkey}" "${bkey}" | sort -V | tail -1)" = "${vkey}" ]
 }
 
 is_at_or_after_latest_pointer() {

--- a/.github/actions/promote-release/src/action.sh
+++ b/.github/actions/promote-release/src/action.sh
@@ -288,6 +288,14 @@ semver_max() {
     | cut -f2-
 }
 
+# Whether a tag is a version at all, tested on its key so the same normalization
+# decides this and the ordering. Nothing branches on it: ordering a non-version is
+# not wrong so much as meaningless, and the only use is telling an operator that
+# the baseline they flagged cannot be compared and no re-run will change that.
+is_version_shaped() {
+  [[ "$(semver_key "$1")" =~ ^[0-9]+\.[0-9]+\.[0-9]+(~.*)?$ ]]
+}
+
 # Comparing the KEYS rather than the tags is what makes equality pass, so a
 # partially failed promotion stays re-runnable: equal precedence means byte-equal
 # keys, so the sort returns that key either way and no separate equality test is
@@ -319,13 +327,14 @@ version_at_or_after() {
 LATEST_BASELINE_NOTE=""
 is_at_or_after_latest_pointer() {
   local repo="$1" releases="$2" max
-  # Optional v: these filters select which releases are CANDIDATES, so a shape
-  # they reject is invisible to the ordering below rather than merely sorted
-  # oddly. Requiring the v dropped a bare newest release out of the candidate
-  # list and handed this gate an older baseline - on the path whose whole purpose
-  # is to fail closed. semver_key ignores the prefix, so accepting both forms
-  # here is what makes the two agree on which releases exist.
-  local stable_shape='^v?[0-9]+\.[0-9]+\.[0-9]+$'
+  # These filters select which releases are CANDIDATES, so a shape they reject is
+  # invisible to the ordering below rather than merely sorted oddly: it drops a
+  # newest release out of the list and hands this gate an older baseline, on the
+  # path whose whole purpose is to fail closed. So the filter has to admit
+  # everything semver_key normalizes away - the optional v and build metadata -
+  # or the two disagree about which releases exist. It stays stricter in the one
+  # way that matters: no pre-release component.
+  local stable_shape='^v?[0-9]+\.[0-9]+\.[0-9]+(\+[0-9A-Za-z.-]+)?$'
 
   # Whatever GitHub flags Latest is the baseline, even when its tag is not a
   # stable release shape. Selecting the highest also makes a corrupt multi-Latest
@@ -348,6 +357,14 @@ is_at_or_after_latest_pointer() {
     fi
   else
     LATEST_BASELINE_NOTE="Latest-flagged release ${max}"
+    # A warning rather than a notice, and rather than an error: the run below is
+    # otherwise correct and still moves :{major}.{minor}, so failing would block a
+    # promotion that partly succeeds. But a non-version baseline outranks every
+    # release, so this repo withholds :latest/:{major} on every promotion from now
+    # on, and re-running is the one thing that cannot fix it.
+    if ! is_version_shaped "${max}"; then
+      echo "::warning::the release flagged Latest on ${repo} is tagged '${max}', which is not a version, so nothing can be ordered against it. :latest/:${MAJOR} will be withheld on every promotion until the Latest flag is moved to a released version - a re-run will not clear this."
+    fi
   fi
 
   version_at_or_after "${max}"
@@ -360,11 +377,11 @@ is_at_or_after_latest_pointer() {
 # hide a newer sibling and allow the line tag to move backwards.
 is_newest_in_line() {
   local line="$1" releases="$2" filter max
-  # Optional v for the same reason as stable_shape above, and it bites harder
-  # here: an empty result is read as "first release in line" and advances, so a
-  # bare newer patch the filter could not see let :{major}.{minor} move backwards
-  # onto an older one while every other gate behaved correctly.
-  filter="^v?${line//./\\.}\.[0-9]+$"
+  # Same shapes as stable_shape above, and the gap bites harder here: an empty
+  # result is read as "first release in line" and advances, so a newer patch this
+  # filter could not see let :{major}.{minor} move backwards onto an older one
+  # while every other gate behaved correctly.
+  filter="^v?${line//./\\.}\.[0-9]+(\+[0-9A-Za-z.-]+)?$"
   max=$(jq -r '.[].tagName' <<<"${releases}" \
     | grep -E "${filter}" \
     | semver_max) || true

--- a/.github/actions/promote-release/src/action.sh
+++ b/.github/actions/promote-release/src/action.sh
@@ -246,10 +246,29 @@ fetch_release_list() {
 # stable-shaped tag. A build re-run can clear that flag by re-applying
 # make_latest:false, so absence must not be mistaken for a first promotion.
 LATEST_BASELINE_NOTE=""
+
+# Semver precedence, which `sort -V` alone does not implement: it ranks
+# v9.9.9-rc.1 ABOVE v9.9.9, the reverse of semver. '~' sorts before
+# end-of-string, so translating '-' to '~' restores the order, and git forbids
+# '~' in ref names, so translating back cannot alter a tag. tr rather than
+# "${x//-/~}", which embeds a literal backslash.
+#
+# The gates below need this because their baseline is chosen by the mutable
+# isLatest flag rather than by tag shape, so a pre-release whose flag was
+# cleared by hand can hold the pointer. Unnormalized, the rc outranked the
+# stable release it precedes and the promotion of that release was withheld -
+# :latest, :{major}, both --latest edits and the Homebrew patch - on a green run.
+#
+# Mirrors newer_version in vcluster-pro's verify-promotion.sh and version_gt in
+# platform-version-bump.sh, so the promoter and its postcondition agree on order.
+semver_sort() {
+  tr '-' '~' | sort -V | tr '~' '-'
+}
+
 version_at_or_after() {
   local baseline="$1"
   [ -z "${baseline}" ] && return 0
-  [ "$(printf '%s\n%s\n' "${VERSION}" "${baseline}" | sort -V | tail -1)" = "${VERSION}" ]
+  [ "$(printf '%s\n%s\n' "${VERSION}" "${baseline}" | semver_sort | tail -1)" = "${VERSION}" ]
 }
 
 is_at_or_after_latest_pointer() {
@@ -258,8 +277,11 @@ is_at_or_after_latest_pointer() {
 
   # Whatever GitHub flags Latest is the baseline, even when its tag is not a
   # stable release shape. Sorting also makes a corrupt multi-Latest response
-  # conservative and deterministic by selecting the newest flagged tag.
-  max=$(jq -r '[.[] | select(.isLatest) | .tagName][]' <<<"${releases}" | sort -V | tail -1)
+  # conservative and deterministic by selecting the newest flagged tag - which
+  # needs semver order too: a bare sort would pick v10.0.0-rc.1 over a
+  # co-flagged v10.0.0 and hand the gate the LOWER of the two, the opposite of
+  # conservative.
+  max=$(jq -r '[.[] | select(.isLatest) | .tagName][]' <<<"${releases}" | semver_sort | tail -1)
   if [[ -z "${max}" ]]; then
     max=$(jq -r '.[].tagName' <<<"${releases}" \
       | grep -E "${stable_shape}" \

--- a/.github/actions/promote-release/src/action.sh
+++ b/.github/actions/promote-release/src/action.sh
@@ -271,6 +271,25 @@ semver_sort() {
   tr '-' '~' | sort -V | tr '~' '-'
 }
 
+# Highest of the tags on stdin, by the same precedence, printed in its ORIGINAL
+# form. Selecting has to sort on a normalized key held in a separate field rather
+# than on the tag itself, because the winner is handed back to callers who need
+# the real tag: it names the release in LATEST_BASELINE_NOTE and is compared
+# against GitHub's own tag names. A stripped or '~'-translated form would name a
+# release that does not exist.
+#
+# Keying also covers the dimension a whole-line sort cannot. GitHub does not
+# require the leading v, so one hand-made release makes the list mixed, and `v`
+# outranks a digit: a raw sort of a Latest-flagged 10.0.0 alongside a co-flagged
+# v9.9.8 returns v9.9.8, the LOWER of the two, and the gate then lets :latest move
+# backwards past 10.0.0. Same failure the rc case has, on the v dimension.
+semver_max() {
+  awk 'NF { key = $0; sub(/^v/, "", key); gsub(/-/, "~", key); print key "\t" $0 }' \
+    | sort -t"$(printf '\t')" -k1,1V \
+    | tail -1 \
+    | cut -f2-
+}
+
 # The 'v' comes off both operands first. GitHub does not require a release tag to
 # carry it, and it only takes one hand-made release for the baseline to arrive
 # bare: `sort -V` then ranks v0.36.1 above 0.36.2 - 'v' outranks a digit - so the
@@ -288,20 +307,19 @@ is_at_or_after_latest_pointer() {
   local stable_shape='^v[0-9]+\.[0-9]+\.[0-9]+$'
 
   # Whatever GitHub flags Latest is the baseline, even when its tag is not a
-  # stable release shape. Sorting also makes a corrupt multi-Latest response
-  # conservative and deterministic by selecting the newest flagged tag - which
-  # needs semver order too: a bare sort would pick v10.0.0-rc.1 over a
-  # co-flagged v10.0.0 and hand the gate the LOWER of the two, the opposite of
-  # conservative.
-  max=$(jq -r '[.[] | select(.isLatest) | .tagName][]' <<<"${releases}" | semver_sort | tail -1)
+  # stable release shape. Selecting the highest also makes a corrupt multi-Latest
+  # response conservative and deterministic - which needs semver_max rather than
+  # any whole-line sort: this list is the one place tags arrive exactly as a human
+  # created them, so it is where both a co-flagged rc and a co-flagged bare tag
+  # can hand the gate the LOWER of the two.
+  max=$(jq -r '[.[] | select(.isLatest) | .tagName][]' <<<"${releases}" | semver_max)
   if [[ -z "${max}" ]]; then
-    # semver_sort is a no-op while stable_shape excludes every hyphen, and is
-    # here so that stays a detail of the filter rather than something this sort
-    # depends on being true.
+    # semver_max's normalization is inert while stable_shape excludes every
+    # hyphen and requires the v, and is here so that stays a detail of the filter
+    # rather than something this selection depends on being true.
     max=$(jq -r '.[].tagName' <<<"${releases}" \
       | grep -E "${stable_shape}" \
-      | semver_sort \
-      | tail -1) || true
+      | semver_max) || true
     if [[ -n "${max}" ]]; then
       LATEST_BASELINE_NOTE="newest stable tag ${max}; no release currently flagged Latest"
       echo "::notice::no release on ${repo} carries the Latest flag; using the newest stable tag (${max}) as the conservative promotion baseline. This is expected after a release-build re-run; promote the version that should be Latest to restore the pointer."
@@ -325,8 +343,7 @@ is_newest_in_line() {
   filter="^v${line//./\\.}\.[0-9]+$"
   max=$(jq -r '.[].tagName' <<<"${releases}" \
     | grep -E "${filter}" \
-    | semver_sort \
-    | tail -1) || true
+    | semver_max) || true
 
   version_at_or_after "${max}"
 }

--- a/.github/actions/promote-release/src/action.sh
+++ b/.github/actions/promote-release/src/action.sh
@@ -233,58 +233,41 @@ fetch_release_list() {
   exit 1
 }
 
-# True if VERSION is at or after the GitHub Latest pointer in $1, using the
-# release-list JSON snapshot in $2. This gates :latest, :{major}, and the
-# repository's GitHub Latest pointer.
+# The precedence key for one tag. Every comparison and selection in this file is
+# defined in terms of this one function, so there is no second normalization for a
+# future call site to reach for by mistake - which is the shape of the bug this
+# gate keeps being fixed for. Two tags share a key exactly when semver gives them
+# equal precedence, so key equality IS the equality test and `sort -V` over keys
+# is the ordering.
 #
-# The baseline is the release currently flagged isLatest: the last release a
-# human actually promoted. It cannot be "newest non-prerelease", because with
-# release.prerelease:auto an un-promoted stable cut already has isPrerelease
-# false. Equality passes so a partially failed promotion is re-runnable.
-#
-# If the mutable Latest flag is absent, fall back conservatively to the newest
-# stable-shaped tag. A build re-run can clear that flag by re-applying
-# make_latest:false, so absence must not be mistaken for a first promotion.
-LATEST_BASELINE_NOTE=""
-
-# Highest of the tags on stdin by semver precedence, printed in its ORIGINAL form.
-# One primitive for the whole file: every ordering here - the three selections and
-# the comparison below - goes through it, so there is no second normalization
-# contract for a future call site to pick the wrong one of.
-#
-# `sort -V` implements none of the three rules on its own:
+# `sort -V` gets all three of these wrong on the raw tag:
 #
 #   - it ranks v9.9.9-rc.1 ABOVE v9.9.9, the reverse of semver. '~' sorts before
 #     end-of-string, so mapping '-' to '~' restores it.
 #   - it ranks any v-prefixed tag above any bare one, because 'v' outranks a
-#     digit, so a flagged 10.0.0 next to a co-flagged v9.9.8 would resolve to
-#     v9.9.8 - the LOWER of the two - and let :latest move backwards past 10.0.0.
-#     GitHub does not require the v, so one hand-made release mixes the list.
+#     digit, so a flagged 10.0.0 next to a co-flagged v9.9.8 resolves to v9.9.8 -
+#     the LOWER of the two - and lets :latest move backwards past 10.0.0. GitHub
+#     does not require the v, so one hand-made release mixes the list.
 #   - it orders 1.2.3+build.1 above 1.2.3, which semver gives EQUAL precedence.
 #     Left in, promoting v1.2.3 against a Latest-flagged v1.2.3+meta reads as
 #     older than the baseline and withholds the whole promotion on a green run.
 #
-# All three are normalized into a key held in a separate field, never into the
-# output: the winner is handed to callers who need the real tag - it names the
-# release in LATEST_BASELINE_NOTE and is matched against GitHub's own tag names -
-# and a stripped or translated form would name a release that does not exist.
-#
-# awk rather than "${x//-/~}", where an unescaped '~' in the replacement is
-# tilde-expanded ('9.9.9-rc.1' becomes '9.9.9/home/youruserrc.1').
-#
 # Needs GNU coreutils: `sort -V` must rank '~' below everything, which BSD and
 # macOS sort do not. The runners are Ubuntu; running the bats suite on a Mac will
 # disagree. resolve-versions.sh states the same requirement for its sort_key.
-# The precedence key for one tag. Every comparison and selection in this file is
-# defined in terms of this one function, so there is no second normalization for
-# a future call site to reach for by mistake - which is the shape of the bug this
-# whole gate keeps being fixed for.
 #
-# Two tags share a key exactly when semver gives them equal precedence, so key
-# equality is the equality test, and `sort -V` over keys is the ordering.
+# One caveat this creates: dropping the v means a Latest-flagged tag that is not a
+# version at all ('stable', 'nightly') now sorts ABOVE any release, since its
+# first character beats a digit, where the prefixed form sorted below. Every
+# promotion then withholds :latest/:{major} until the flag is moved. That is the
+# conservative direction and the notice names the baseline, but no re-run clears
+# it - moving the flag is the only remedy.
 semver_key() {
   local key="${1#v}"
   key="${key%%+*}"
+  # The backslash is load-bearing: an unescaped '~' in the replacement is
+  # tilde-expanded, turning '9.9.9-rc.1' into '9.9.9/home/youruserrc.1', which
+  # sorts ABOVE 9.9.9 and reinstates the original bug.
   printf '%s' "${key//-/\~}"
 }
 
@@ -321,9 +304,28 @@ version_at_or_after() {
   [ "$(printf '%s\n%s\n' "${vkey}" "${bkey}" | sort -V | tail -1)" = "${vkey}" ]
 }
 
+# True if VERSION is at or after the GitHub Latest pointer in $1, using the
+# release-list JSON snapshot in $2. This gates :latest, :{major}, and the
+# repository's GitHub Latest pointer.
+#
+# The baseline is the release currently flagged isLatest: the last release a
+# human actually promoted. It cannot be "newest non-prerelease", because with
+# release.prerelease:auto an un-promoted stable cut already has isPrerelease
+# false. Equality passes so a partially failed promotion is re-runnable.
+#
+# If the mutable Latest flag is absent, fall back conservatively to the newest
+# stable-shaped tag. A build re-run can clear that flag by re-applying
+# make_latest:false, so absence must not be mistaken for a first promotion.
+LATEST_BASELINE_NOTE=""
 is_at_or_after_latest_pointer() {
   local repo="$1" releases="$2" max
-  local stable_shape='^v[0-9]+\.[0-9]+\.[0-9]+$'
+  # Optional v: these filters select which releases are CANDIDATES, so a shape
+  # they reject is invisible to the ordering below rather than merely sorted
+  # oddly. Requiring the v dropped a bare newest release out of the candidate
+  # list and handed this gate an older baseline - on the path whose whole purpose
+  # is to fail closed. semver_key ignores the prefix, so accepting both forms
+  # here is what makes the two agree on which releases exist.
+  local stable_shape='^v?[0-9]+\.[0-9]+\.[0-9]+$'
 
   # Whatever GitHub flags Latest is the baseline, even when its tag is not a
   # stable release shape. Selecting the highest also makes a corrupt multi-Latest
@@ -333,9 +335,8 @@ is_at_or_after_latest_pointer() {
   # can hand the gate the LOWER of the two.
   max=$(jq -r '[.[] | select(.isLatest) | .tagName][]' <<<"${releases}" | semver_max)
   if [[ -z "${max}" ]]; then
-    # semver_max's normalization is inert while stable_shape excludes every
-    # hyphen and requires the v, and is here so that stays a detail of the filter
-    # rather than something this selection depends on being true.
+    # stable_shape admits both prefixes now, so this selection does the ordering
+    # that the filter no longer implies: 10.0.0 and v9.9.8 both reach it.
     max=$(jq -r '.[].tagName' <<<"${releases}" \
       | grep -E "${stable_shape}" \
       | semver_max) || true
@@ -359,7 +360,11 @@ is_at_or_after_latest_pointer() {
 # hide a newer sibling and allow the line tag to move backwards.
 is_newest_in_line() {
   local line="$1" releases="$2" filter max
-  filter="^v${line//./\\.}\.[0-9]+$"
+  # Optional v for the same reason as stable_shape above, and it bites harder
+  # here: an empty result is read as "first release in line" and advances, so a
+  # bare newer patch the filter could not see let :{major}.{minor} move backwards
+  # onto an older one while every other gate behaved correctly.
+  filter="^v?${line//./\\.}\.[0-9]+$"
   max=$(jq -r '.[].tagName' <<<"${releases}" \
     | grep -E "${filter}" \
     | semver_max) || true

--- a/.github/actions/promote-release/test/action.bats
+++ b/.github/actions/promote-release/test/action.bats
@@ -321,6 +321,34 @@ teardown() {
   [ "$(grep -c '^CREATE ' "$CRANE_MOCK_CALLS")" -eq 6 ]
 }
 
+@test "a bare newer patch in the same line still blocks :{major}.{minor}" {
+  # The line filter is the last place the v was still required. A bare 9.9.10
+  # doesn't match ^v9\.9\.[0-9]+$, so max comes back empty, which this gate reads
+  # as "first release in line" and advances - regressing :9.9 from 9.9.10 to
+  # 9.9.9. The unscoped gate catches the same tag correctly, so nothing else
+  # moves and the run is green: exactly the shape this whole fix is about.
+  set_release_list "$GITHUB_REPOSITORY" '[{"tagName":"9.9.10","isPrerelease":false,"isLatest":true}]'
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  run ! grep -qF ':9.9 ' "$CRANE_MOCK_CALLS"
+  [ "$(grep -c '^CREATE ' "$CRANE_MOCK_CALLS")" -eq 0 ]
+}
+
+@test "the no-Latest-flag fallback sees a bare newest release" {
+  # The fallback exists to stop an older dispatch advancing when the flag has been
+  # cleared. Requiring the v let a bare 10.0.0 be filtered out of the candidate
+  # list entirely, so the baseline resolved to v9.9.8 and :latest advanced onto
+  # 9.9.9 - past 10.0.0 - on the one path built to fail closed.
+  set_release_list "$GITHUB_REPOSITORY" '[{"tagName":"v9.9.8","isPrerelease":false,"isLatest":false},{"tagName":"10.0.0","isPrerelease":false,"isLatest":false}]'
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"newest stable tag 10.0.0;"* ]]
+  run ! grep -qF ':latest ' "$CRANE_MOCK_CALLS"
+  run ! grep -qF ':9 ' "$CRANE_MOCK_CALLS"
+  # 9.9.9 IS the newest in its own 9.9 line, so the line tag still advances.
+  grep -qF ':9.9 ' "$CRANE_MOCK_CALLS"
+}
+
 @test "multiple Latest flags conservatively use the newest flagged tag" {
   set_release_list "$GITHUB_REPOSITORY" '[{"tagName":"v9.9.8","isLatest":true},{"tagName":"v10.0.0","isLatest":true}]'
   run "$SCRIPT"

--- a/.github/actions/promote-release/test/action.bats
+++ b/.github/actions/promote-release/test/action.bats
@@ -1307,6 +1307,21 @@ teardown() {
   grep -qF 'version "9.9.9"' "$put_out"
 }
 
+@test "a bare tag co-flagged Latest with a v-prefixed one is ordered by version, not by prefix" {
+  # The Latest-flagged list is the one place tags arrive exactly as a human made
+  # them, so it is where the two dimensions meet: 'v' outranks a digit, so a
+  # whole-line sort of a flagged 10.0.0 next to a co-flagged v9.9.8 returns
+  # v9.9.8. The gate then reads the dispatched v9.9.9 as newer than its baseline
+  # and advances :latest/:9 - backwards past the flagged 10.0.0. Stripping inside
+  # version_at_or_after cannot catch this; by then the wrong tag has been picked.
+  set_release_list "$GITHUB_REPOSITORY" '[{"tagName":"10.0.0","isLatest":true},{"tagName":"v9.9.8","isLatest":true}]'
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Latest-flagged release 10.0.0)"* ]]
+  run ! grep -qF ':latest ' "$CRANE_MOCK_CALLS"
+  run ! grep -qF ':9 ' "$CRANE_MOCK_CALLS"
+}
+
 @test "homebrew-tap-repo without oss-repo -> fails fast" {
   export INPUT_OSS_REPO=""
   export INPUT_HOMEBREW_TAP_REPO="example-org/example-tap"

--- a/.github/actions/promote-release/test/action.bats
+++ b/.github/actions/promote-release/test/action.bats
@@ -290,6 +290,20 @@ teardown() {
   grep -qF -- 'EDIT example-org/example-repo v9.9.9 --prerelease=false --latest' "$GH_MOCK_CALLS"
 }
 
+@test "a newer baseline tagged without the v prefix still blocks :latest" {
+  # GitHub does not require the v, and one hand-made release is enough for the
+  # baseline to arrive bare. `sort -V` ranks v9.9.9 above 10.0.0 because 'v'
+  # outranks a digit, so without stripping it the gate reads the OLDER version as
+  # newer and moves :latest BACKWARDS - the failure it exists to prevent, and the
+  # opposite direction from the rc bug above.
+  set_release_list "$GITHUB_REPOSITORY" '[{"tagName":"10.0.0","isPrerelease":false,"isLatest":true}]'
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"older than the promotion baseline"* ]]
+  run ! grep -qF ':latest ' "$CRANE_MOCK_CALLS"
+  run ! grep -qF ':9 ' "$CRANE_MOCK_CALLS"
+}
+
 @test "multiple Latest flags conservatively use the newest flagged tag" {
   set_release_list "$GITHUB_REPOSITORY" '[{"tagName":"v9.9.8","isLatest":true},{"tagName":"v10.0.0","isLatest":true}]'
   run "$SCRIPT"
@@ -1265,6 +1279,32 @@ teardown() {
   run ! grep -q '^DOWNLOAD \|^API ' "$GH_MOCK_CALLS"
   grep -qF -- 'EDIT example-org/example-repo v9.9.9 --prerelease=false' "$GH_MOCK_CALLS"
   run ! grep -qF -- 'EDIT example-org/example-repo v9.9.9 --prerelease=false --latest' "$GH_MOCK_CALLS"
+}
+
+@test "homebrew tap -> an rc holding Latest on BOTH repos still promotes the tap" {
+  # The OSS gate and the tap are the half of the DEVOPS-1319 regression that the
+  # caller-side tests cannot see: is_at_or_after_latest_pointer runs a second time
+  # against OSS_REPO, and its verdict is what decides OSS_IS_LATEST and therefore
+  # whether the formula is patched at all. With an rc holding Latest on both
+  # repos, a bare sort withheld --latest from the OSS release AND skipped the tap
+  # entirely, on a green run. Pinned here so a regression on either gate fails
+  # rather than passing quietly through the caller-side assertions.
+  export INPUT_HOMEBREW_TAP_REPO="example-org/example-tap"
+  export INPUT_HOMEBREW_FORMULA_PATHS='["Formula/vcluster.rb"]'
+  set_release_list "$GITHUB_REPOSITORY" '[{"tagName":"v9.9.9-rc.1","isLatest":true}]'
+  set_release_list "$INPUT_OSS_REPO" '[{"tagName":"v9.9.9-rc.1","isLatest":true}]'
+  set_checksums_fixture "example-org/example-repo" "$FIXTURES_DIR/checksums.txt"
+  set_contents_fixture "repos/example-org/example-tap/contents/Formula/vcluster.rb" "$FIXTURES_DIR/vcluster.rb"
+
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"skipping Homebrew tap promotion entirely"* ]]
+  [[ "$output" != *"older than the promotion baseline"* ]]
+
+  grep -qF -- 'EDIT example-org/example-repo v9.9.9 --prerelease=false --latest' "$GH_MOCK_CALLS"
+  grep -qF 'API PUT repos/example-org/example-tap/contents/Formula/vcluster.rb sha=fakesha' "$GH_MOCK_CALLS"
+  put_out="$(put_output_path 'repos/example-org/example-tap/contents/Formula/vcluster.rb')"
+  grep -qF 'version "9.9.9"' "$put_out"
 }
 
 @test "homebrew-tap-repo without oss-repo -> fails fast" {

--- a/.github/actions/promote-release/test/action.bats
+++ b/.github/actions/promote-release/test/action.bats
@@ -321,6 +321,46 @@ teardown() {
   [ "$(grep -c '^CREATE ' "$CRANE_MOCK_CALLS")" -eq 6 ]
 }
 
+@test "a newer patch carrying build metadata still blocks :{major}.{minor}" {
+  # semver_key strips '+meta', so the filters have to admit it or they disagree
+  # with the ordering about which releases exist. Rejected, v9.9.10+build.1 is
+  # invisible to the line gate, the empty result reads as "first release in line",
+  # and :9.9 advances onto the older 9.9.9 - the bare-tag failure, one shape over.
+  set_release_list "$GITHUB_REPOSITORY" '[{"tagName":"v9.9.10+build.1","isPrerelease":false,"isLatest":true}]'
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  run ! grep -qF ':9.9 ' "$CRANE_MOCK_CALLS"
+  [ "$(grep -c '^CREATE ' "$CRANE_MOCK_CALLS")" -eq 0 ]
+}
+
+@test "the no-Latest-flag fallback sees a newest release carrying build metadata" {
+  # Same disagreement on the fallback path: dropping v10.0.0+build.7 from the
+  # candidate list hands the gate v9.9.8 and advances :latest past the newer
+  # release. The verdict flipped on whether a human had set the flag, since the
+  # flagged path orders through semver_key and this one filtered first.
+  set_release_list "$GITHUB_REPOSITORY" '[{"tagName":"v9.9.8","isPrerelease":false,"isLatest":false},{"tagName":"v10.0.0+build.7","isPrerelease":false,"isLatest":false}]'
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"newest stable tag v10.0.0+build.7;"* ]]
+  run ! grep -qF ':latest ' "$CRANE_MOCK_CALLS"
+  run ! grep -qF ':9 ' "$CRANE_MOCK_CALLS"
+}
+
+@test "a Latest flag on a tag that is not a version warns and withholds" {
+  # Dropping the v means a non-version tag sorts above every release, so this
+  # withholds forever and no re-run clears it: the operator has to move the flag.
+  # A notice buries that, and the run is otherwise green and ships without :latest.
+  # Pinned so a later change to semver_key cannot flip it to fail-open unseen.
+  set_release_list "$GITHUB_REPOSITORY" '[{"tagName":"stable","isLatest":true}]'
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"::warning::"*"tagged 'stable', which is not a version"* ]]
+  run ! grep -qF ':latest ' "$CRANE_MOCK_CALLS"
+  run ! grep -qF ':9 ' "$CRANE_MOCK_CALLS"
+  # No 9.9.x sibling exists, so 9.9.9 is trivially newest in its own line.
+  grep -qF ':9.9 ' "$CRANE_MOCK_CALLS"
+}
+
 @test "a bare newer patch in the same line still blocks :{major}.{minor}" {
   # The line filter is the last place the v was still required. A bare 9.9.10
   # doesn't match ^v9\.9\.[0-9]+$, so max comes back empty, which this gate reads

--- a/.github/actions/promote-release/test/action.bats
+++ b/.github/actions/promote-release/test/action.bats
@@ -260,21 +260,56 @@ teardown() {
 
 @test "a prerelease-shaped tag flagged Latest remains the overall baseline" {
   # GitHub permits a human to flag any release Latest. The overall gate must
-  # respect that pointer even when its immutable tag is not stable-shaped.
-  set_release_list "$GITHUB_REPOSITORY" '[{"tagName":"v9.9.9-rc.1","isLatest":true}]'
+  # respect that pointer even when its immutable tag is not stable-shaped. The
+  # rc here belongs to a LATER line than VERSION, so respecting it and ordering
+  # it correctly both say the same thing: withhold.
+  set_release_list "$GITHUB_REPOSITORY" '[{"tagName":"v10.0.0-rc.1","isLatest":true}]'
   run "$SCRIPT"
   [ "$status" -eq 0 ]
-  [[ "$output" == *"Latest-flagged release v9.9.9-rc.1"* ]]
+  [[ "$output" == *"Latest-flagged release v10.0.0-rc.1)"* ]]
   run ! grep -qF ':latest ' "$CRANE_MOCK_CALLS"
   run ! grep -qF ':9 ' "$CRANE_MOCK_CALLS"
   grep -qF ':9.9 ' "$CRANE_MOCK_CALLS"
+}
+
+@test "an rc flagged Latest does not outrank the stable release it precedes" {
+  # `sort -V` ranks v9.9.9-rc.1 above v9.9.9, so unnormalized this state - which
+  # any hand-cleared prerelease flag on an rc produces - read the baseline as
+  # newer than the version being promoted and withheld :latest, :{major}, both
+  # --latest edits and the Homebrew patch while still exiting 0. Only
+  # :{major}.{minor} moved, on its own line-scoped gate. Semver puts the final
+  # release above its own rc, so this promotion has to complete.
+  set_release_list "$GITHUB_REPOSITORY" '[{"tagName":"v9.9.9-rc.1","isLatest":true}]'
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"older than the promotion baseline"* ]]
+
+  grep -qF 'CREATE ghcr.io/example-org/example-image:latest ghcr.io/example-org/example-image:9.9.9' "$CRANE_MOCK_CALLS"
+  grep -qF 'CREATE ghcr.io/example-org/example-image:9 ghcr.io/example-org/example-image:9.9.9' "$CRANE_MOCK_CALLS"
+  [ "$(grep -c '^CREATE ' "$CRANE_MOCK_CALLS")" -eq 6 ]
+  grep -qF -- 'EDIT example-org/example-repo v9.9.9 --prerelease=false --latest' "$GH_MOCK_CALLS"
 }
 
 @test "multiple Latest flags conservatively use the newest flagged tag" {
   set_release_list "$GITHUB_REPOSITORY" '[{"tagName":"v9.9.8","isLatest":true},{"tagName":"v10.0.0","isLatest":true}]'
   run "$SCRIPT"
   [ "$status" -eq 0 ]
-  [[ "$output" == *"Latest-flagged release v10.0.0"* ]]
+  [[ "$output" == *"Latest-flagged release v10.0.0)"* ]]
+  run ! grep -qF ':latest ' "$CRANE_MOCK_CALLS"
+}
+
+@test "a release co-flagged Latest with its own rc uses the final release, not the rc" {
+  # Conservative means the HIGHER of the flagged tags. Under a bare sort the rc
+  # won, which is the lower of the two, so the selection itself leaked
+  # permissiveness into the gate independently of version_at_or_after.
+  #
+  # Anchored on the notice's closing paren: "release v10.0.0" is a substring of
+  # "release v10.0.0-rc.1", so an unanchored match passes on the wrong pick and
+  # this test can't fail.
+  set_release_list "$GITHUB_REPOSITORY" '[{"tagName":"v10.0.0-rc.1","isLatest":true},{"tagName":"v10.0.0","isLatest":true}]'
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Latest-flagged release v10.0.0)"* ]]
   run ! grep -qF ':latest ' "$CRANE_MOCK_CALLS"
 }
 

--- a/.github/actions/promote-release/test/action.bats
+++ b/.github/actions/promote-release/test/action.bats
@@ -302,6 +302,23 @@ teardown() {
   [[ "$output" == *"older than the promotion baseline"* ]]
   run ! grep -qF ':latest ' "$CRANE_MOCK_CALLS"
   run ! grep -qF ':9 ' "$CRANE_MOCK_CALLS"
+  # Withholding is scoped to the two unscoped tags. Without this the test cannot
+  # tell a correct withhold from the script short-circuiting after the gate.
+  grep -qF ':9.9 ' "$CRANE_MOCK_CALLS"
+}
+
+@test "build metadata on the baseline has equal precedence, so the promotion proceeds" {
+  # Semver gives 1.2.3 and 1.2.3+build.1 EQUAL precedence; `sort -V` ranks the
+  # metadata form higher. Left in, promoting v9.9.9 against a Latest-flagged
+  # v9.9.9+meta reads as older than its own baseline and withholds :latest,
+  # :{major}, both --latest edits and the Homebrew patch on a green run. git
+  # permits '+' in a tag name, and the baseline is whatever a human flagged.
+  set_release_list "$GITHUB_REPOSITORY" '[{"tagName":"v9.9.9+meta","isLatest":true}]'
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"older than the promotion baseline"* ]]
+  grep -qF 'CREATE ghcr.io/example-org/example-image:latest ghcr.io/example-org/example-image:9.9.9' "$CRANE_MOCK_CALLS"
+  [ "$(grep -c '^CREATE ' "$CRANE_MOCK_CALLS")" -eq 6 ]
 }
 
 @test "multiple Latest flags conservatively use the newest flagged tag" {
@@ -1320,6 +1337,7 @@ teardown() {
   [[ "$output" == *"Latest-flagged release 10.0.0)"* ]]
   run ! grep -qF ':latest ' "$CRANE_MOCK_CALLS"
   run ! grep -qF ':9 ' "$CRANE_MOCK_CALLS"
+  grep -qF ':9.9 ' "$CRANE_MOCK_CALLS"
 }
 
 @test "homebrew-tap-repo without oss-repo -> fails fast" {


### PR DESCRIPTION
`version_at_or_after` compared with a bare `sort -V`, which ranks `v0.36.1-rc.1`
above `v0.36.1`. When a pre-release holds the Latest flag, reachable any time
someone clears an rc's prerelease flag by hand, the gate read the baseline as
newer than the dispatched stable version and withheld `:latest`, `:{major}`, both
`--latest` edits and the Homebrew patch, then exited 0.

Four review passes turned up seven more ways these gates disagreed with semver.
All are reachable through the same door, since the baseline is whatever tag a
human flagged Latest, and all end in one of two outcomes: a correct promotion
withheld on a green run, or a public pointer moved backwards.

**One key.** `semver_key` is the single precedence key every comparison and
selection is defined in terms of. It drops the leading `v` (GitHub does not
require it, and `v` outranks a digit, so `v0.36.1` sorted above `0.36.2`), drops
build metadata (`1.2.3+meta` has *equal* precedence to `1.2.3`, not higher), and
maps `-` to `~` (so a final release outranks its own rc). Equal precedence means
byte-equal keys, so equality needs no separate test.

**Selections return the real tag.** `semver_max` sorts on that key in a separate
field, because the winner names a release in operator messages and is matched
against GitHub's tag names.

**The filters had to agree.** They decide which releases are *candidates*, so a
shape they reject is invisible to the ordering rather than mis-sorted, and an
empty candidate list reads as "first release in line" and advances. Requiring the
`v`, then rejecting `+meta`, each let a newer release vanish and a pointer move
backwards.

Closes DEVOPS-1319

## Test plan

- `bats .github/actions/promote-release/test/action.bats` — 106 pass
- every rule mutation-checked: reverting the `+` strip, the `~` mapping, the `v`
  strip, keyed selection, either filter's optional `v`, either filter's `+meta`,
  or the non-version warning each fails at least one test, and the six filter and
  warning fixes are each pinned by exactly one
- all new tests confirmed failing against `main`'s `src/action.sh`
- the existing "prerelease-shaped tag flagged Latest" test rewritten onto a
  baseline from a later line, so it still guards a genuinely-ahead pre-release
- coverage added for the OSS-repo gate and the Homebrew tap, which run
  `is_at_or_after_latest_pointer` a second time and had none
- `shellcheck src/action.sh` clean

## Known caveat

A tag that is not a version at all (`stable`, `nightly`) outranks every release,
so flagging one Latest withholds `:latest`/`:{major}` on every promotion and no
re-run clears it. The run now emits a `::warning::` naming the tag, a test pins
the direction, and the README carries the remedy: move the flag.

## Follow-up

DEVOPS-1335 extends the `semver-validation` node action, which already depends on
npm `semver`, to expose ordering and stability. That removes the bash comparator
rather than making it correct, which is the deeper fix; `promote-release` migrates
to it under a separate issue. This PR is the fix for the live bug.