### PR TITLE
feat(commitlint): add reusable action for commit message linting

### DIFF
--- a/.github/actions/commitlint/README.md
+++ b/.github/actions/commitlint/README.md
@@ -1,0 +1,247 @@
+# Commitlint
+
+Lints commit messages and pull request titles against the calling repository's
+own [commitlint](https://commitlint.js.org/) config.
+
+Two independent checks, both optional:
+
+- **`pr-title`** lints a single message. On a squash-merged repository the pull
+  request title is what actually lands on the default branch, so this is the
+  check that protects history.
+- **`from`/`to`** lints every commit in a range. Merge commits and reverts are
+  skipped by commitlint's own default ignores. The caller must check out with
+  `fetch-depth: 0`, since a shallow clone cannot walk the range.
+
+Both run to completion even when the first one fails, so a contributor sees
+every problem in one run rather than one per push.
+
+The config always comes from the calling repository, never from this action.
+This action decides *what* gets linted and *when to skip*; the repository
+decides what the rules are.
+
+## Trust model
+
+Read this before treating a green check as a guarantee.
+
+The config, and any `node_modules/.bin/commitlint`, are read from the checkout.
+On a pull request from a fork that checkout is the merge result, whose contents
+the pull request author controls. A fork can therefore weaken
+`commitlint.config.js`, or commit an executable `node_modules/.bin/commitlint`
+that exits 0, and this action will report `pass`.
+
+So the check is a **contributor-facing aid on fork pull requests, not an
+enforcement boundary**. What it does enforce is the non-fork case: branches in
+the repository itself, which is where release automation, backports and the
+`sync-from-oss` branches live, and where a squash-merged title is what lands on
+the default branch.
+
+`skip-branches` is guarded against the fork case (see below) because a branch
+*name* is the one thing a fork controls that this action would otherwise read
+before looking at any repository content. That guard closes a bypass that
+needed no commit at all; it does not make the fork case trustworthy.
+
+If you need enforcement against forks, lint the squash-merge title in a
+separate job that resolves the config from the base ref rather than the
+checkout, or enforce at merge time.
+
+## Commitlint version
+
+When the calling repository's `package.json` mentions `commitlint`, its
+dependencies are installed and the local binary is used, so CI runs exactly
+what contributors run locally. That covers `@commitlint/*`,
+`@your-scope/commitlint-config` and `commitlint-config-*` alike. If the install
+fails the action warns and falls back rather than failing the check on an npm
+problem.
+
+Otherwise `commitlint-version` is fetched on the fly with `npx`. **That path
+brings the CLI only.** A config that `extends` a shared package such as
+`@commitlint/config-conventional` must declare it in a `package.json` whose
+text contains `commitlint`, or nothing is installed and commitlint cannot
+resolve the config. Without `fail-on-warnings` that exits 1, which is
+indistinguishable from a lint failure and is reported as `fail`; with
+`fail-on-warnings: true` it is distinguishable and reported as `error`. A
+self-contained config with no `extends` works fine on the `npx` path.
+
+The known gap is a package that the config depends on but whose name contains
+no `commitlint` at all: a `parserPreset` such as
+`conventional-changelog-conventionalcommits`. Declaring any `@commitlint/`
+dependency alongside it is enough to trigger the install.
+
+Installs run with `--ignore-scripts`, since on a fork pull request the manifest
+being installed comes from the fork and commitlint needs no lifecycle scripts.
+
+## Inputs
+
+<!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
+
+|       INPUT        |  TYPE  | REQUIRED |  DEFAULT   |                                                                                                                                                               DESCRIPTION                                                                                                                                                               |
+|--------------------|--------|----------|------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|       branch       | string |  false   |            |                                                                                                                  Branch name matched against skip-branches. Pass <br>the github.event.pull_request.head.ref context.                                                                                                                    |
+| commitlint-version | string |  false   | `"19.8.1"` |                                                                                                                      Version of @commitlint/cli used when the <br>calling repository does not pin one <br>itself.                                                                                                                       |
+|    config-path     | string |  false   |            |                                                                                                   Path to the commitlint config. Empty <br>lets commitlint discover it, which finds <br>commitlint.config.js at the repository root.                                                                                                    |
+|  fail-on-warnings  | string |  false   | `"false"`  |                                                                                                                                                 Treat commitlint warnings as failures.                                                                                                                                                  |
+|        from        | string |  false   |            |                                                                                     Range start for per-commit linting. Pass <br>the github.event.pull_request.base.sha context. Requires to as <br>well; leave both empty to skip <br>the check.                                                                                       |
+|  head-repository   | string |  false   |            | Repository the branch lives on. Pass <br>the github.event.pull_request.head.repo.full_name context. When this is <br>set and differs from github.repository the <br>pull request comes from a fork, <br>where the branch name is chosen <br>by its author, and skip-branches is <br>ignored. Always pass this alongside skip-branches.  |
+|      pr-title      | string |  false   |            |                                                                                            Message to lint on its own. <br>Pass the pull request title, the <br>github.event.pull_request.title context. Leave empty to skip <br>the check.                                                                                             |
+|   skip-branches    | string |  false   |            |                Comma-separated glob patterns. When branch matches <br>one of them the action exits <br>successfully without linting anything. Intended for <br>branches carrying commits that cannot be <br>rewritten, such as the rebase-merged sync-from-oss <br>branches that replay community authorship verbatim.                  |
+|         to         | string |  false   |  `"HEAD"`  |                                                                                                                                          Range end for per-commit linting, normally <br>HEAD.                                                                                                                                           |
+| working-directory  | string |  false   |   `"."`    |                                                                                                                                      Directory to run in. Must contain <br>the commitlint config.                                                                                                                                       |
+
+<!-- AUTO-DOC-INPUT:END -->
+
+## Outputs
+
+<!-- AUTO-DOC-OUTPUT:START - Do not remove or modify this section -->
+
+|     OUTPUT      |  TYPE  |                                                  DESCRIPTION                                                   |
+|-----------------|--------|----------------------------------------------------------------------------------------------------------------|
+| commits-result  | string | pass, fail, skipped, or error when <br>commitlint itself could not run and <br>the commits were never judged.  |
+| pr-title-result | string | pass, fail, skipped, or error when <br>commitlint itself could not run and <br>the message was never judged.   |
+|     skipped     | string |                          true when skip-branches matched and nothing <br>was linted.                           |
+
+<!-- AUTO-DOC-OUTPUT:END -->
+
+## Usage
+
+Lint the pull request title and every commit on the branch:
+
+```yaml
+name: Commitlint
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: loft-sh/github-actions/.github/actions/commitlint@commitlint/v1
+        with:
+          pr-title: ${{ github.event.pull_request.title }}
+          from: ${{ github.event.pull_request.base.sha }}
+          to: ${{ github.event.pull_request.head.sha }}
+          branch: ${{ github.event.pull_request.head.ref }}
+          head-repository: ${{ github.event.pull_request.head.repo.full_name }}
+          skip-branches: 'sync-from-oss/*'
+```
+
+### Linting the title only
+
+For a repository that squash-merges and does not care about the shape of
+intermediate commits:
+
+```yaml
+      - uses: loft-sh/github-actions/.github/actions/commitlint@commitlint/v1
+        with:
+          pr-title: ${{ github.event.pull_request.title }}
+```
+
+`fetch-depth: 0` is unnecessary in this mode.
+
+### Exempting branches
+
+`skip-branches` takes comma-separated globs matched against `branch`. A match
+exits the action successfully without linting anything.
+
+This exists for branches carrying commits that cannot be rewritten. The
+`sync-from-oss` branches are the motivating case: they are rebase-merged to
+preserve external authorship, so community subjects land verbatim and no
+amount of CI can change them.
+
+```yaml
+        with:
+          branch: ${{ github.event.pull_request.head.ref }}
+          head-repository: ${{ github.event.pull_request.head.repo.full_name }}
+          skip-branches: 'sync-from-oss/*, backport/*'
+```
+
+**Always pass `head-repository` alongside `skip-branches`.** On a fork pull
+request the branch name is chosen by the pull request author, so without it
+anyone could opt out of linting by naming their branch after an exempt
+pattern. When `head-repository` differs from `github.repository` the skip list
+is ignored and a warning is logged.
+
+Patterns are globs rather than regexes, so `sync-from-oss/*` reads the way an
+author expects and does not match `feat/sync-from-oss-docs`.
+
+### Warnings
+
+Warnings are reported but do not fail the check. A repository rolling out a
+rule gradually can keep it at warning level in its own config; set
+`fail-on-warnings: true` to promote every warning to a failure.
+
+## Reading the outputs
+
+The outputs exist to tell `error` (commitlint could not run) apart from `fail`
+(commitlint ran and rejected a message). That distinction only matters on a run
+where the action fails, and a failing step skips every later step in the job,
+so consuming an output requires `continue-on-error: true` on the action step
+plus an explicit final gate:
+
+```yaml
+      - id: commitlint
+        continue-on-error: true
+        uses: loft-sh/github-actions/.github/actions/commitlint@commitlint/v1
+        with:
+          pr-title: ${{ github.event.pull_request.title }}
+
+      - if: steps.commitlint.outputs.pr-title-result == 'error'
+        run: echo "::warning::Commit linting could not run. This is a CI problem, not your commit message."
+
+      # Anything that is not a clean pass fails the job, an exempt branch
+      # aside. `error` covers a transient outage AND permanent caller
+      # misconfiguration - a working-directory that no longer exists, for
+      # instance - so gating only on `fail` would turn a broken setup into a
+      # permanently green check that lints nothing.
+      - if: >-
+          steps.commitlint.outputs.skipped != 'true' &&
+          steps.commitlint.outputs.pr-title-result != 'pass'
+        run: exit 1
+```
+
+Read the exemption off the `skipped` output, not off a result being `skipped`.
+A result is also `skipped` when the input wired into that check resolved to an
+empty string, meaning that check linted nothing, so a gate accepting `skipped`
+results is green on exactly the mis-wiring you want to hear about. The
+`skipped` output is `true` only when `skip-branches` matched.
+
+Gate each result separately, and only the ones you requested: a check the
+caller never asked for reports `skipped` too, so a gate on `commits-result` in
+the title-only example above would fail every run.
+
+Without `continue-on-error`, the action still fails the job on a bad message,
+which is the normal wiring and needs none of the above.
+
+One caveat if you wrap this action inside a composite action of your own rather
+than calling it from a workflow: `continue-on-error` on a *composite* step must
+be a literal boolean, because an expression is evaluated in the composite's own
+context, resolves empty, and halts the run with `Unexpected value ''`
+([actions/runner#2418][coe], still open). Workflow job steps, as in the example
+above, take expressions normally.
+
+[coe]: https://github.com/actions/runner/issues/2418
+
+## Permissions
+
+`contents: read` is enough. The action makes no API calls and needs no token.
+
+Run it on `pull_request`, not `pull_request_target`. On a fork pull request the
+action checks out and installs from the fork's own manifest; `pull_request`
+grants no secrets and a read-only token, which is what makes that safe.
+`pull_request_target` runs with the base repository's secrets and would turn
+the same install into a credential-exfiltration path.
+
+## Testing
+
+```bash
+make test-commitlint
+```

--- a/.github/actions/commitlint/action.yml
+++ b/.github/actions/commitlint/action.yml
@@ -1,0 +1,129 @@
+# No literal ${{ }} anywhere in this file outside the expression fields at the
+# bottom - not in this description, not in an input's. The runner parses
+# expressions across the whole manifest and rejects the `github` context in
+# these positions ("Unrecognized named-value"), failing the action load for
+# every caller. Name the contexts in prose; the README carries the exact caller
+# expressions.
+name: Commitlint
+description: |
+  Lints commit messages and pull request titles against the calling
+  repository's own commitlint config.
+
+  Two independent checks, both optional:
+
+  - pr-title: lints a single message, normally the pull request title. This
+    is what protects history on a squash-merged repo, where the title is what
+    lands on the default branch.
+  - from/to: lints every commit in a range. Merge commits and reverts are
+    skipped by commitlint's own default ignores. Needs the caller to check out
+    with fetch-depth: 0, since a shallow clone cannot walk the range.
+
+  Both checks run even when the first one fails, so a contributor sees every
+  problem in one go rather than one per push.
+
+  The commitlint config comes from the calling repository, never from this
+  action. When that repository's package.json mentions commitlint, its
+  dependencies are installed and the local binary is used; otherwise
+  commitlint-version is fetched on the fly, which brings the CLI only.
+
+inputs:
+  pr-title:
+    description: |
+      Message to lint on its own. Pass the pull request title, the
+      github.event.pull_request.title context. Leave empty to skip the check.
+    required: false
+    default: ''
+  from:
+    description: |
+      Range start for per-commit linting. Pass the
+      github.event.pull_request.base.sha context. Requires to as well; leave
+      both empty to skip the check.
+    required: false
+    default: ''
+  to:
+    description: 'Range end for per-commit linting, normally HEAD.'
+    required: false
+    default: 'HEAD'
+  skip-branches:
+    description: |
+      Comma-separated glob patterns. When branch matches one of them the
+      action exits successfully without linting anything. Intended for
+      branches carrying commits that cannot be rewritten, such as the
+      rebase-merged sync-from-oss branches that replay community authorship
+      verbatim.
+    required: false
+    default: ''
+  branch:
+    description: |
+      Branch name matched against skip-branches. Pass the
+      github.event.pull_request.head.ref context.
+    required: false
+    default: ''
+  head-repository:
+    description: |
+      Repository the branch lives on. Pass the
+      github.event.pull_request.head.repo.full_name context. When this is set
+      and differs from github.repository the pull request comes from a fork,
+      where the branch name is chosen by its author, and skip-branches is
+      ignored. Always pass this alongside skip-branches.
+    required: false
+    default: ''
+  config-path:
+    description: |
+      Path to the commitlint config. Empty lets commitlint discover it, which
+      finds commitlint.config.js at the repository root.
+    required: false
+    default: ''
+  working-directory:
+    description: 'Directory to run in. Must contain the commitlint config.'
+    required: false
+    default: '.'
+  commitlint-version:
+    description: |
+      Version of @commitlint/cli used when the calling repository does not pin
+      one itself.
+    required: false
+    # renovate: datasource=npm depName=@commitlint/cli
+    default: 19.8.1
+  fail-on-warnings:
+    description: 'Treat commitlint warnings as failures.'
+    required: false
+    default: 'false'
+
+outputs:
+  skipped:
+    description: 'true when skip-branches matched and nothing was linted.'
+    value: ${{ steps.run.outputs.skipped }}
+  pr-title-result:
+    description: |
+      pass, fail, skipped, or error when commitlint itself could not run and
+      the message was never judged.
+    value: ${{ steps.run.outputs.pr-title-result }}
+  commits-result:
+    description: |
+      pass, fail, skipped, or error when commitlint itself could not run and
+      the commits were never judged.
+    value: ${{ steps.run.outputs.commits-result }}
+
+runs:
+  using: composite
+  steps:
+    - name: Lint commit messages
+      id: run
+      shell: bash
+      env:
+        INPUT_PR_TITLE: ${{ inputs.pr-title }}
+        INPUT_FROM: ${{ inputs.from }}
+        INPUT_TO: ${{ inputs.to }}
+        INPUT_SKIP_BRANCHES: ${{ inputs.skip-branches }}
+        INPUT_BRANCH: ${{ inputs.branch }}
+        INPUT_HEAD_REPOSITORY: ${{ inputs.head-repository }}
+        INPUT_CONFIG_PATH: ${{ inputs.config-path }}
+        INPUT_WORKING_DIRECTORY: ${{ inputs.working-directory }}
+        INPUT_COMMITLINT_VERSION: ${{ inputs.commitlint-version }}
+        INPUT_FAIL_ON_WARNINGS: ${{ inputs.fail-on-warnings }}
+      run: ${{ github.action_path }}/src/action.sh
+
+branding:
+  icon: 'check-square'
+  color: 'orange'

--- a/.github/actions/commitlint/src/action.sh
+++ b/.github/actions/commitlint/src/action.sh
@@ -1,0 +1,503 @@
+#!/usr/bin/env bash
+# Lint commit messages and pull request titles with commitlint.
+#
+# The config always comes from the calling repository, never from here: this
+# action decides *what* to lint and *when to skip*, the repository decides what
+# the rules are.
+#
+# Trust model: the config, and any node_modules/.bin/commitlint, are read from
+# the checkout, which on a fork pull request the author controls. A fork can
+# weaken the config and get a pass. This is a contributor-facing aid on fork
+# PRs, not an enforcement boundary; it enforces on branches in the repository
+# itself. See the README.
+#
+# Both checks run to completion before the script fails, so a contributor gets
+# every problem in one run rather than discovering the second one after fixing
+# the first.
+#
+# Env:
+#   INPUT_PR_TITLE            Message to lint on its own. Empty skips.
+#   INPUT_FROM, INPUT_TO      Commit range to lint. Empty INPUT_FROM skips;
+#                             empty INPUT_TO warns and falls back to HEAD.
+#   INPUT_SKIP_BRANCHES       Comma-separated globs; a match exits 0 early.
+#   INPUT_BRANCH              Branch name matched against INPUT_SKIP_BRANCHES.
+#   INPUT_HEAD_REPOSITORY     Repo the branch lives on; a fork disables skipping.
+#   INPUT_CONFIG_PATH         Config path; empty uses commitlint discovery.
+#   INPUT_WORKING_DIRECTORY   Directory to run in. Default ".".
+#   INPUT_COMMITLINT_VERSION  Version used when the repo pins none.
+#   INPUT_FAIL_ON_WARNINGS    "true" treats warnings as failures.
+
+set -euo pipefail
+
+PR_TITLE="${INPUT_PR_TITLE:-}"
+FROM="${INPUT_FROM:-}"
+TO="${INPUT_TO-HEAD}"
+SKIP_BRANCHES="${INPUT_SKIP_BRANCHES:-}"
+BRANCH="${INPUT_BRANCH:-}"
+HEAD_REPOSITORY="${INPUT_HEAD_REPOSITORY:-}"
+CONFIG_PATH="${INPUT_CONFIG_PATH:-}"
+WORKING_DIRECTORY="${INPUT_WORKING_DIRECTORY:-.}"
+# No literal fallback here on purpose. action.yml carries the pin and is the
+# copy Renovate keeps current; a second one in this file would be the version
+# that actually runs whenever the input resolves to empty, and it would sit a
+# bump behind with nothing to notice. An empty value is handled where it is
+# used, in resolve_commitlint.
+COMMITLINT_VERSION="${INPUT_COMMITLINT_VERSION:-}"
+# "-" rather than ":-": the composite always exports this variable, and the
+# runner does not apply an input's default to an input that was passed as an
+# empty string. So an empty value here is a caller expression that resolved to
+# nothing, which is precisely what warn_unless_boolean has to surface, and
+# ":-" would rewrite it to "false" before the warning could see it.
+FAIL_ON_WARNINGS="${INPUT_FAIL_ON_WARNINGS-false}"
+
+# Resolved by resolve_commitlint into the argv of a runnable commitlint.
+COMMITLINT_CMD=()
+
+log() { printf '%s\n' "$*"; }
+
+# Every externally-controlled string printed by this script goes through here.
+# The hostile channels are the pull request title, the branch name, the fork's
+# repository name, and commitlint's own stdout, which echoes the message back.
+#
+# The runner ends a log line on CR as well as LF, so a raw CR inside a title
+# splits the output and a following "::" starts a workflow command at column 0.
+# It also trims leading whitespace before matching "::", so indenting untrusted
+# text is not a defence on its own - a title that merely starts with "::" is
+# parsed straight off an indented line.
+#
+# So: strip the characters that can split a line, then prefix every line with a
+# non-whitespace marker, which is what actually makes a leading "::" unparseable.
+#
+# The companion rule, enforced by inspection: no untrusted value is ever
+# interpolated into a "::" annotation line, because those are percent-decoded
+# and would need escaping as well. Untrusted values go on their own plain line.
+#
+# LC_ALL=C so an inherited locale cannot defeat the class matching, and -cd
+# rather than -d so everything outside printable ASCII plus LF is dropped. That
+# also covers NEL, U+2028 and U+2029, which a runner or terminal may treat as
+# breaks. This mirrors auto-approve-bot-prs/src/lib/log.sh, which states the
+# repository's rule; the logic is duplicated rather than shared because actions
+# here are versioned independently and that lib is action-local.
+print_untrusted() {
+  printf '%s\n' "$1" | LC_ALL=C tr -cd '\040-\176\012' | sed 's/^/| /'
+}
+
+# For untrusted text interpolated into the job summary, which is markdown rather
+# than a log stream. Strips what would break out of a code span or open a tag.
+scrub() {
+  printf '%s' "$1" | LC_ALL=C tr -cd '\040-\176' | tr -d '`<>'
+}
+
+emit_output() {
+  local name="$1" value="$2"
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    printf '%s=%s\n' "$name" "$value" >>"$GITHUB_OUTPUT"
+  fi
+}
+
+# Every exit path that runs after a child process could have started writes all
+# three outputs through here, and nothing writes them earlier.
+#
+# $GITHUB_OUTPUT is a path in the environment, the file is append-only, and the
+# runner resolves a repeated key to its last occurrence. Every child inherits
+# it: commitlint, npm, npx, and on a repository that pins its own, a
+# node_modules/.bin/commitlint that came from the checkout. So an output written
+# before those run can be appended over by them, and "skipped" is the one worth
+# forging - the gate this action's README recommends waves a run through on it.
+# Writing last is what makes the script's value the one that survives.
+emit_results() {
+  emit_output skipped "$1"
+  emit_output pr-title-result "$2"
+  emit_output commits-result "$3"
+}
+
+emit_summary() {
+  if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    printf '%s\n' "$*" >>"$GITHUB_STEP_SUMMARY"
+  fi
+}
+
+# True when $BRANCH matches any comma-separated glob in $SKIP_BRANCHES.
+# Patterns are globs, not regexes, so "sync-from-oss/*" reads the way an
+# author expects.
+#
+# A branch name on a fork PR is chosen freely by the pull request author, so
+# honouring the skip list there would let anyone opt out of linting by naming
+# their branch after an exempt pattern. When head-repository is supplied and
+# is not this repository, the skip list is ignored.
+branch_matches_skip_list() {
+  # printf must emit a trailing newline: without it `read` hits EOF on the
+  # last pattern and the loop body never sees it.
+  local pattern
+  while IFS= read -r pattern; do
+    [ -n "$pattern" ] || continue
+    # shellcheck disable=SC2254  # the pattern is meant to glob
+    case "$BRANCH" in
+      $pattern) return 0 ;;
+    esac
+  done < <(printf '%s\n' "$SKIP_BRANCHES" | tr ',' '\n' | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')
+
+  return 1
+}
+
+branch_is_skipped() {
+  [ -n "$BRANCH" ] && [ -n "$SKIP_BRANCHES" ] || return 1
+
+  # Match first, so the warnings below only fire when the skip list would
+  # actually have exempted something. Warning on every fork pull request to a
+  # repo that merely configures skip-branches is noise on an action whose
+  # audience is contributors.
+  branch_matches_skip_list || return 1
+
+  if [ -z "$HEAD_REPOSITORY" ]; then
+    log "::warning::This branch matches skip-branches and was not linted, but head-repository is not set. On a fork pull request the branch name is chosen by its author, so the skip list can be used to opt out of linting. Pass head-repository to close that."
+    return 0
+  fi
+
+  # No guard on GITHUB_REPOSITORY being set: an unset one compares unequal and
+  # so ignores the skip list, which is the safe direction to fail.
+  if [ "$HEAD_REPOSITORY" != "${GITHUB_REPOSITORY:-}" ]; then
+    log "::warning::Ignoring skip-branches: this branch lives on a fork, whose branch names are chosen by the pull request author."
+    print_untrusted "fork: ${HEAD_REPOSITORY}"
+    print_untrusted "branch: ${BRANCH}"
+    return 1
+  fi
+
+  return 0
+}
+
+# Prefer a commitlint the calling repository already pins: running a different
+# version than the repo's own contributors run locally would produce results
+# nobody can reproduce.
+resolve_commitlint() {
+  if [ -x node_modules/.bin/commitlint ]; then
+    log "Using commitlint from node_modules"
+    COMMITLINT_CMD=(node_modules/.bin/commitlint)
+    return
+  fi
+
+  # Match any commitlint-related dependency, not just the CLI: a config that
+  # extends a shared package needs that package present, and the npx fallback
+  # below only ever brings the CLI. This catches @commitlint/*, @scope/commitlint
+  # -config and commitlint-config-* alike. A parser preset whose package name
+  # contains no "commitlint" at all is the known gap, documented in the README.
+  if [ -f package.json ] && grep -qi 'commitlint' package.json; then
+    log "Repository declares a commitlint dependency; installing it"
+    # --ignore-scripts: on a fork pull request this installs the fork's own
+    # package.json, and commitlint needs no lifecycle scripts to run.
+    #
+    # A broken install must not take the check down with it - fall through to
+    # the pinned fallback version below and still lint something.
+    # npm's output is untrusted too: on a fork pull request it is parsing the
+    # fork's manifest and echoes strings from it back on failure.
+    local install_out install_status=0
+    if [ -f package-lock.json ]; then
+      install_out=$(npm ci --no-audit --no-fund --ignore-scripts 2>&1) || install_status=$?
+    else
+      install_out=$(npm install --no-audit --no-fund --ignore-scripts 2>&1) || install_status=$?
+    fi
+    [ -n "$install_out" ] && print_untrusted "$install_out"
+    if [ "$install_status" -ne 0 ]; then
+      log "::warning::The commitlint install failed; falling back to the pinned version."
+      print_untrusted "fallback version: ${COMMITLINT_VERSION}"
+    fi
+
+    if [ -x node_modules/.bin/commitlint ]; then
+      COMMITLINT_CMD=(node_modules/.bin/commitlint)
+      return
+    fi
+  fi
+
+  # Only reachable when a caller passed the input as an empty string, since
+  # action.yml always supplies a value otherwise. Fetching "@commitlint/cli@"
+  # would fail with a message about the package rather than about the wiring.
+  if [ -z "$COMMITLINT_VERSION" ]; then
+    log "::warning::commitlint-version resolved to an empty value; using the latest published @commitlint/cli. Check the expression wired into it."
+    COMMITLINT_CMD=(npx --yes "@commitlint/cli")
+    return
+  fi
+
+  log "Using @commitlint/cli, version:"
+  print_untrusted "${COMMITLINT_VERSION}"
+  COMMITLINT_CMD=(npx --yes "@commitlint/cli@${COMMITLINT_VERSION}")
+}
+
+# Only the exact string "true" turns warnings into failures, and anything else
+# both drops --strict and flips the exit-code classifier below to its non-strict
+# table. So "True", "yes" or a mis-wired expression gives a caller who believes
+# warnings are fatal a green run, with no sign anywhere that the input was read
+# differently than they wrote it. Warn rather than fail: the check itself is
+# still doing useful work, and taking it down over this input would be worse.
+warn_unless_boolean() {
+  case "$FAIL_ON_WARNINGS" in
+    true | false) return 0 ;;
+  esac
+
+  log '::warning::fail-on-warnings is neither "true" nor "false", so warnings will not fail the check. An empty value means the expression wired into it resolved to nothing.'
+  print_untrusted "fail-on-warnings: ${FAIL_ON_WARNINGS}"
+}
+
+# Every invocation shares the config and strictness flags.
+run_commitlint() {
+  local flags=()
+  [ -n "$CONFIG_PATH" ] && flags+=(--config "$CONFIG_PATH")
+  [ "$FAIL_ON_WARNINGS" = "true" ] && flags+=(--strict)
+
+  "${COMMITLINT_CMD[@]}" ${flags[@]+"${flags[@]}"} "$@"
+}
+
+# Telling a contributor their commit message is wrong because npm was down
+# would send them chasing a problem they do not have, so a commitlint that
+# never ran is reported differently from one that ran and found problems.
+#
+# Which exit codes mean "the message has problems" depends on --strict: without
+# it commitlint returns 1, with it 2 for warnings and 3 for errors and never 1.
+#
+# So exit 1 under --strict means commitlint never got as far as judging a
+# message, and is deliberately not in the strict list. Measured against 19.8.1
+# the cases are an unresolvable `extends`, and a message the CLI reads as no
+# input at all - which is why a whitespace-only pr-title is rejected in main()
+# before it can get here and be reported as a CI problem. A --from revision
+# missing from a shallow clone exits 1 too, but range_is_reachable catches that
+# one first, so it never reaches this classifier.
+#
+# Without --strict the same setup failures are indistinguishable from a bad
+# message, since both exit 1. That case is a genuine heuristic gap.
+message_problem_exit_codes() {
+  if [ "$FAIL_ON_WARNINGS" = "true" ]; then
+    printf '2 3'
+  else
+    printf '1'
+  fi
+}
+
+is_infrastructure_failure() {
+  local status="$1" code
+  [ "$status" -eq 0 ] && return 1
+
+  for code in $(message_problem_exit_codes); do
+    [ "$status" -eq "$code" ] && return 1
+  done
+
+  return 0
+}
+
+# Fail fast on a commitlint that cannot run at all, so the per-message results
+# below only ever report on messages.
+verify_commitlint_runs() {
+  local status=0
+  "${COMMITLINT_CMD[@]}" --version >/dev/null 2>&1 || status=$?
+
+  if [ "$status" -ne 0 ]; then
+    log "::error::commitlint could not be run (exit ${status}). This is a CI or network problem, not a problem with the commit messages."
+    emit_summary "### Commitlint could not run"
+    emit_summary ""
+    emit_summary "commitlint failed to start (exit \`${status}\`). This is a CI or network problem, not a problem with the commit messages."
+    return 1
+  fi
+}
+
+lint_pr_title() {
+  log "::group::Linting pull request title"
+  print_untrusted "$PR_TITLE"
+
+  # commitlint echoes the message back on its own stdout, so its output is just
+  # as attacker-controlled as the title. Capture it and print it through
+  # print_untrusted rather than letting the child write to the log directly.
+  local status=0 out
+  out=$(printf '%s' "$PR_TITLE" | run_commitlint 2>&1) || status=$?
+  [ -n "$out" ] && print_untrusted "$out"
+  log "::endgroup::"
+
+  return "$status"
+}
+
+# Forgetting fetch-depth: 0 is the likeliest caller mistake with range linting,
+# and commitlint exits 1 for an unreachable revision - indistinguishable from a
+# rejected message without --strict. Check reachability first so it is reported
+# as the setup failure it is.
+#
+# The code must sit outside every message-problem set - 1 non-strict, 2 and 3
+# under --strict - or the classifier would read it back as a bad message in one
+# of the two modes.
+UNREACHABLE_RANGE_EXIT=64
+
+range_is_reachable() {
+  local rev err
+  for rev in "$FROM" "$TO"; do
+    if ! err=$(git cat-file -e "${rev}^{commit}" 2>&1); then
+      log "::error::A revision in the range could not be resolved. Usually this means the history is shallow - check out with fetch-depth: 0. If git reports something else below, that is the real cause."
+      print_untrusted "unresolved revision: ${rev}"
+      [ -n "$err" ] && print_untrusted "git: ${err}"
+      return 1
+    fi
+  done
+}
+
+lint_range() {
+  log "::group::Linting commits"
+  print_untrusted "${FROM}..${TO}"
+
+  if ! range_is_reachable; then
+    log "::endgroup::"
+    return "$UNREACHABLE_RANGE_EXIT"
+  fi
+
+  local status=0 out
+  out=$(run_commitlint --from "$FROM" --to "$TO" 2>&1) || status=$?
+  [ -n "$out" ] && print_untrusted "$out"
+  log "::endgroup::"
+
+  return "$status"
+}
+
+main() {
+  # The skip decision reads only inputs, so it comes before the cd. An exempt
+  # branch must not be failed by a working-directory that happens not to exist
+  # on it - that is exactly the branch whose commits cannot be rewritten.
+  if branch_is_skipped; then
+    log "Branch matches skip-branches; nothing linted."
+    print_untrusted "branch: ${BRANCH}"
+    print_untrusted "skip-branches: ${SKIP_BRANCHES}"
+    emit_results true skipped skipped
+    emit_summary "Commitlint skipped: branch \`$(scrub "$BRANCH")\` is exempt."
+    return 0
+  fi
+  warn_unless_boolean
+
+  local title_result=skipped commits_result=skipped failed=0 infrastructure=0
+
+  if ! cd "$WORKING_DIRECTORY" 2>/dev/null; then
+    log "::error::working-directory does not exist or is not a directory."
+    print_untrusted "working-directory: ${WORKING_DIRECTORY}"
+    # "error" means a requested check could not run. A check the caller never
+    # asked for stays "skipped", or a caller reports on work it never wanted.
+    [ -n "$PR_TITLE" ] && title_result=error
+    [ -n "$FROM" ] && commits_result=error
+    emit_results false "$title_result" "$commits_result"
+    return 1
+  fi
+
+  # The reason `to` is expanded with "-" rather than ":-": an expression that
+  # resolved to nothing would otherwise be rewritten to HEAD in silence, and the
+  # range linted would not be the range the caller asked for. HEAD is still the
+  # right thing to fall back to - an empty revision fails the reachability check
+  # as if the clone were shallow, which is a worse answer than a warning.
+  #
+  # What to say about it depends on `from`: with `from` empty as well, no range
+  # is linted at all, and claiming a run up to HEAD would describe work that
+  # never happened. The rewrite also has to come after both, since it is what
+  # makes an empty `to` indistinguishable from an unset one further down.
+  if [ -z "$TO" ]; then
+    if [ -n "$FROM" ]; then
+      log "::warning::'to' resolved to an empty value; linting up to HEAD instead. Check the expression wired into 'to'."
+    else
+      log "::warning::'to' resolved to an empty value and 'from' is empty too, so no commits were linted. Check the expressions wired into them."
+    fi
+    TO=HEAD
+  fi
+
+  # `to` defaults to HEAD, so a non-default `to` with an empty `from` is a
+  # caller whose `from` expression resolved to nothing - a green run that linted
+  # no commits at all.
+  if [ -z "$FROM" ] && [ "$TO" != "HEAD" ]; then
+    log "::warning::'to' is set but 'from' is empty, so no commits were linted. Check the expression wired into 'from'."
+  fi
+
+  if [ -z "$PR_TITLE" ] && [ -z "$FROM" ]; then
+    log "::error::Nothing to lint: set pr-title, or from and to, or both."
+    emit_results false "$title_result" "$commits_result"
+    return 1
+  fi
+
+  resolve_commitlint
+
+  if ! verify_commitlint_runs; then
+    # The requested checks were never judged. Report that as "error", the value
+    # action.yml documents for a commitlint that could not run, rather than
+    # "skipped", which a caller cannot tell from "never asked for".
+    [ -n "$PR_TITLE" ] && title_result=error
+    [ -n "$FROM" ] && commits_result=error
+    emit_results false "$title_result" "$commits_result"
+    return 1
+  fi
+
+  local status
+  if [ -n "${PR_TITLE//[[:space:]]/}" ]; then
+    status=0
+    lint_pr_title || status=$?
+    if [ "$status" -eq 0 ]; then
+      title_result=pass
+    elif is_infrastructure_failure "$status"; then
+      # Not "fail": the message was never judged, and a caller branching on
+      # this output must not tell the author their message is wrong.
+      title_result=error
+      failed=1
+      infrastructure=1
+    else
+      title_result=fail
+      failed=1
+    fi
+  elif [ -n "$PR_TITLE" ]; then
+    # commitlint reads a whitespace-only message as no input at all: it prints
+    # its usage and exits 1, which under --strict falls outside the
+    # message-problem set and would be reported as a CI outage the contributor
+    # cannot act on. The message really is blank, which is a problem with the
+    # message, so say that rather than handing it to commitlint.
+    log "::error::pr-title is whitespace only, so there is no message to lint."
+    print_untrusted "pr-title: ${PR_TITLE}"
+    title_result=fail
+    failed=1
+  fi
+
+  if [ -n "$FROM" ]; then
+    status=0
+    lint_range || status=$?
+    if [ "$status" -eq 0 ]; then
+      commits_result=pass
+    elif is_infrastructure_failure "$status"; then
+      commits_result=error
+      failed=1
+      infrastructure=1
+    else
+      commits_result=fail
+      failed=1
+    fi
+  fi
+
+  emit_results false "$title_result" "$commits_result"
+
+  if [ "$failed" -eq 1 ]; then
+    # One table covering both checks: a run where one check found a real problem
+    # and the other crashed has to report both, or the contributor is told "this
+    # is a CI problem" while a genuine message problem sits in the outputs.
+    emit_summary "### Commitlint failed"
+    emit_summary ""
+    emit_summary "| check | result |"
+    emit_summary "| --- | --- |"
+    emit_summary "| pull request title | ${title_result} |"
+    emit_summary "| commits | ${commits_result} |"
+    emit_summary ""
+
+    if [ "$infrastructure" -eq 1 ]; then
+      emit_summary "\`error\` means commitlint could not run for that check. That is a CI problem, not a problem with the commit messages."
+      log "::error::commitlint could not run for at least one check (title: ${title_result}, commits: ${commits_result})"
+    fi
+
+    if [ "$title_result" = "fail" ] || [ "$commits_result" = "fail" ]; then
+      emit_summary "\`fail\` means commitlint ran and rejected a message. See the step log for the offending messages."
+      log "::error::commitlint found problems (title: ${title_result}, commits: ${commits_result})"
+    fi
+
+    return 1
+  fi
+
+  emit_summary "Commitlint passed (title: ${title_result}, commits: ${commits_result})."
+  log "commitlint passed (title: ${title_result}, commits: ${commits_result})"
+  return 0
+}
+
+# Only run when executed, so the tests can source this file for unit checks.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  main "$@"
+fi

--- a/.github/actions/commitlint/test/action.bats
+++ b/.github/actions/commitlint/test/action.bats
@@ -1,0 +1,889 @@
+#!/usr/bin/env bats
+# Tests for action.sh.
+#
+# commitlint itself is mocked: what matters here is which checks run, which are
+# skipped, and how exit codes and outputs are reported. The rules themselves are
+# the calling repository's business and are tested there.
+
+bats_require_minimum_version 1.5.0
+
+SCRIPT="$BATS_TEST_DIRNAME/../src/action.sh"
+
+load commitlint_mock
+
+setup() {
+  setup_mocks
+
+  WORKDIR="$BATS_TEST_TMPDIR/repo"
+  mkdir -p "$WORKDIR"
+  cd "$WORKDIR"
+
+  # Range linting checks that its revisions exist, so the fixture is a real
+  # repository rather than a bare directory.
+  git init -q .
+  git -c user.email=t@example.invalid -c user.name=t commit -q --allow-empty -m "chore: base"
+  BASE_SHA=$(git rev-parse HEAD)
+  git -c user.email=t@example.invalid -c user.name=t commit -q --allow-empty -m "chore: head"
+  HEAD_SHA=$(git rev-parse HEAD)
+  export BASE_SHA HEAD_SHA
+
+  GITHUB_OUTPUT="$BATS_TEST_TMPDIR/output.txt"
+  GITHUB_STEP_SUMMARY="$BATS_TEST_TMPDIR/summary.md"
+  : >"$GITHUB_OUTPUT"
+  : >"$GITHUB_STEP_SUMMARY"
+  export GITHUB_OUTPUT GITHUB_STEP_SUMMARY
+
+  export INPUT_WORKING_DIRECTORY="$WORKDIR"
+  export INPUT_PR_TITLE=""
+  export INPUT_FROM=""
+  export INPUT_TO="HEAD"
+  export INPUT_SKIP_BRANCHES=""
+  export INPUT_BRANCH=""
+  export INPUT_HEAD_REPOSITORY=""
+  export GITHUB_REPOSITORY=""
+  export INPUT_CONFIG_PATH=""
+  export INPUT_COMMITLINT_VERSION="19.8.1"
+  export INPUT_FAIL_ON_WARNINGS="false"
+}
+
+output_value() {
+  grep "^$1=" "$GITHUB_OUTPUT" | tail -1 | cut -d= -f2-
+}
+
+# No line of output may be parseable by the runner as a workflow command other
+# than the ones this action emits itself. The runner ends a line on CR as well
+# as LF and trims leading whitespace before matching "::", so both have to be
+# covered - anchoring on '^::' alone would miss an indented payload.
+FORGEABLE='stop-commands|add-mask|set-env|set-output|save-state|echo'
+
+assert_no_forged_commands() {
+  local normalised
+  # Treat CR as a line break, exactly as the runner does.
+  normalised=$(printf '%s\n' "$output" | tr '\r' '\n')
+
+  if printf '%s\n' "$normalised" | grep -E "^[[:space:]]*::(${FORGEABLE})" ; then
+    echo "forged workflow command found above" >&2
+    return 1
+  fi
+}
+
+# The companion invariant, and the one assert_no_forged_commands cannot see: an
+# untrusted value sitting on a legitimate ::warning:: or ::group:: is percent-
+# decoded into that annotation, so it arrives carrying whatever line breaks it
+# encoded while the raw log still looks like one tidy line. Assert the value
+# never reaches such a line at all, which is the rule action.sh states.
+assert_not_on_command_line() {
+  local normalised
+  # Same CR normalisation as above: a value carried onto an annotation line by a
+  # preceding CR is on a command line as far as the runner is concerned, even
+  # though the raw output shows one harmless-looking line.
+  normalised=$(printf '%s\n' "$output" | tr '\r' '\n')
+
+  if printf '%s\n' "$normalised" | grep -E '^[[:space:]]*::' | grep -qF -- "$1"; then
+    echo "untrusted value '$1' reached a workflow-command line" >&2
+    return 1
+  fi
+}
+
+# A bare `! cmd` is exempt from errexit, so bats reports it only when it is the
+# test's last statement; anywhere else it is inert and the assertion holds
+# nothing. Every negative assertion goes through one of these instead, which
+# fail the test wherever they appear - including after a line is added below
+# them, which is how the inert ones got there.
+assert_summary_lacks() {
+  if grep -qF -- "$1" "$GITHUB_STEP_SUMMARY"; then
+    echo "job summary contains '$1'" >&2
+    return 1
+  fi
+}
+
+assert_no_call_matching() {
+  if calls | grep -q -e "$1"; then
+    echo "unexpected invocation matching '$1'" >&2
+    return 1
+  fi
+}
+
+# "commitlint never ran at all" is the wrong invariant to assert anywhere after
+# resolve_commitlint, because verify_commitlint_runs probes the binary with
+# --version first and that probe is logged like any other call. What callers
+# care about is that nothing was handed a message to judge.
+assert_nothing_was_linted() {
+  if calls | grep -Ev -- '--version' | grep -qE '^(commitlint|npx)'; then
+    echo "commitlint was invoked to lint something" >&2
+    return 1
+  fi
+}
+
+@test "lints the pr title and passes" {
+  export INPUT_PR_TITLE="fix(cli): stop leaking the kubeconfig"
+
+  run -0 "$SCRIPT"
+
+  [ "$(output_value pr-title-result)" = "pass" ]
+  [ "$(output_value commits-result)" = "skipped" ]
+  [ "$(output_value skipped)" = "false" ]
+}
+
+@test "fails when the pr title is rejected" {
+  export INPUT_PR_TITLE="bugfix: nope"
+  export COMMITLINT_MOCK_TITLE_EXIT=1
+
+  run -1 "$SCRIPT"
+
+  [ "$(output_value pr-title-result)" = "fail" ]
+  grep -q "Commitlint failed" "$GITHUB_STEP_SUMMARY"
+}
+
+@test "lints a commit range" {
+  export INPUT_FROM="$BASE_SHA"
+  export INPUT_TO="$HEAD_SHA"
+
+  run -0 "$SCRIPT"
+
+  [ "$(output_value commits-result)" = "pass" ]
+  [ "$(output_value pr-title-result)" = "skipped" ]
+  calls | grep -q -- "--from $BASE_SHA --to $HEAD_SHA"
+}
+
+@test "fails when a commit in the range is rejected" {
+  export INPUT_FROM="$BASE_SHA"
+  export COMMITLINT_MOCK_RANGE_EXIT=1
+
+  run -1 "$SCRIPT"
+
+  [ "$(output_value commits-result)" = "fail" ]
+}
+
+@test "runs both checks even when the title check fails" {
+  export INPUT_PR_TITLE="bugfix: nope"
+  export INPUT_FROM="$BASE_SHA"
+  export COMMITLINT_MOCK_TITLE_EXIT=1
+
+  run -1 "$SCRIPT"
+
+  # The range check must still have run, so one push surfaces both problems.
+  [ "$(output_value commits-result)" = "pass" ]
+  [ "$(output_value pr-title-result)" = "fail" ]
+  calls | grep -q -- "--from $BASE_SHA"
+}
+
+@test "skips everything when the branch matches skip-branches" {
+  export INPUT_BRANCH="sync-from-oss/main"
+  export INPUT_SKIP_BRANCHES="sync-from-oss/*"
+  export INPUT_PR_TITLE="whatever, this is never linted"
+  export COMMITLINT_MOCK_EXIT=1
+
+  run -0 "$SCRIPT"
+
+  [ "$(output_value skipped)" = "true" ]
+  [ "$(output_value pr-title-result)" = "skipped" ]
+  [ ! -s "$CALL_LOG" ]
+}
+
+@test "matches any pattern in a comma-separated skip list" {
+  export INPUT_BRANCH="backport/v0.36"
+  export INPUT_SKIP_BRANCHES="sync-from-oss/*, backport/*"
+  export INPUT_PR_TITLE="anything"
+
+  run -0 "$SCRIPT"
+
+  [ "$(output_value skipped)" = "true" ]
+}
+
+@test "does not skip a branch that only resembles the pattern" {
+  export INPUT_BRANCH="feat/sync-from-oss-docs"
+  export INPUT_SKIP_BRANCHES="sync-from-oss/*"
+  export INPUT_PR_TITLE="feat(docs): describe the sync"
+
+  run -0 "$SCRIPT"
+
+  [ "$(output_value skipped)" = "false" ]
+  calls | grep -q "commitlint"
+}
+
+@test "fails when given nothing to lint" {
+  run -1 "$SCRIPT"
+
+  [[ "$output" == *"Nothing to lint"* ]]
+  # Every declared output must be written on every exit path, or a caller
+  # branching on them reads an empty string.
+  [ "$(output_value pr-title-result)" = "skipped" ]
+  [ "$(output_value commits-result)" = "skipped" ]
+}
+
+@test "ignores skip-branches when the branch belongs to a fork" {
+  # A fork's branch name is chosen by the PR author, so honouring the skip list
+  # there would let anyone opt out of linting.
+  export INPUT_BRANCH="sync-from-oss/main"
+  export INPUT_SKIP_BRANCHES="sync-from-oss/*"
+  export INPUT_HEAD_REPOSITORY="a-contributor/vcluster-pro"
+  export GITHUB_REPOSITORY="loft-sh/vcluster-pro"
+  export INPUT_PR_TITLE="bugfix: sneaking this past the linter"
+  export COMMITLINT_MOCK_TITLE_EXIT=1
+
+  run -1 "$SCRIPT"
+
+  [ "$(output_value skipped)" = "false" ]
+  [ "$(output_value pr-title-result)" = "fail" ]
+  [[ "$output" == *"Ignoring skip-branches"* ]]
+}
+
+@test "still skips when the branch belongs to the repository itself" {
+  export INPUT_BRANCH="sync-from-oss/main"
+  export INPUT_SKIP_BRANCHES="sync-from-oss/*"
+  export INPUT_HEAD_REPOSITORY="loft-sh/vcluster-pro"
+  export GITHUB_REPOSITORY="loft-sh/vcluster-pro"
+  export INPUT_PR_TITLE="anything"
+
+  run -0 "$SCRIPT"
+
+  [ "$(output_value skipped)" = "true" ]
+}
+
+@test "reports a commitlint that cannot start as a CI problem" {
+  export INPUT_PR_TITLE="fix: something"
+  export COMMITLINT_MOCK_VERSION_EXIT=127
+
+  run -1 "$SCRIPT"
+
+  # Not "your commit message is wrong" - the message was never linted.
+  [[ "$output" == *"not a problem with the commit messages"* ]]
+  # "error", not "skipped": a caller must be able to tell "could not run" from
+  # "no title check was requested".
+  [ "$(output_value pr-title-result)" = "error" ]
+  grep -q "could not run" "$GITHUB_STEP_SUMMARY"
+}
+
+@test "distinguishes a commitlint crash from a rejected message" {
+  export INPUT_PR_TITLE="fix: something"
+  export COMMITLINT_MOCK_TITLE_EXIT=127
+
+  run -1 "$SCRIPT"
+
+  grep -q "not a problem with the commit messages" "$GITHUB_STEP_SUMMARY"
+  # The output must not say "fail", or a caller acting on it contradicts the log.
+  [ "$(output_value pr-title-result)" = "error" ]
+}
+
+# --strict changes commitlint's exit contract to 2 for warnings and 3 for
+# errors, never 1. Treating those as crashes would report every real problem
+# as a CI outage, which is the opposite of what fail-on-warnings is for.
+@test "treats strict-mode warning exit 2 as a message problem" {
+  export INPUT_FAIL_ON_WARNINGS="true"
+  export INPUT_PR_TITLE="fix(unknown-scope): something"
+  export COMMITLINT_MOCK_TITLE_EXIT=2
+
+  run -1 "$SCRIPT"
+
+  [ "$(output_value pr-title-result)" = "fail" ]
+  [[ "$output" != *"not a problem with the commit messages"* ]]
+  grep -q "Commitlint failed" "$GITHUB_STEP_SUMMARY"
+}
+
+@test "treats strict-mode error exit 3 as a message problem" {
+  export INPUT_FAIL_ON_WARNINGS="true"
+  export INPUT_PR_TITLE="bugfix: nope"
+  export COMMITLINT_MOCK_TITLE_EXIT=3
+
+  run -1 "$SCRIPT"
+
+  [ "$(output_value pr-title-result)" = "fail" ]
+  grep -q "Commitlint failed" "$GITHUB_STEP_SUMMARY"
+}
+
+@test "still treats a crash as a crash in strict mode" {
+  export INPUT_FAIL_ON_WARNINGS="true"
+  export INPUT_PR_TITLE="fix: something"
+  export COMMITLINT_MOCK_TITLE_EXIT=127
+
+  run -1 "$SCRIPT"
+
+  [ "$(output_value pr-title-result)" = "error" ]
+  grep -q "not a problem with the commit messages" "$GITHUB_STEP_SUMMARY"
+}
+
+@test "exit 2 is a crash when not in strict mode" {
+  # Without --strict commitlint never returns 2, so it means something else.
+  export INPUT_PR_TITLE="fix: something"
+  export COMMITLINT_MOCK_TITLE_EXIT=2
+
+  run -1 "$SCRIPT"
+
+  [ "$(output_value pr-title-result)" = "error" ]
+}
+
+@test "treats strict-mode exit 1 as a crash, not a message problem" {
+  # --strict never returns 1 for a message problem, so 1 there is unambiguously
+  # a setup failure: an unresolvable extends, or a --from missing from a shallow
+  # clone. Both were measured at exit 1 against commitlint 19.8.1.
+  export INPUT_FAIL_ON_WARNINGS="true"
+  export INPUT_PR_TITLE="fix: a perfectly fine subject"
+  export COMMITLINT_MOCK_TITLE_EXIT=1
+
+  run -1 "$SCRIPT"
+
+  [ "$(output_value pr-title-result)" = "error" ]
+  grep -q "not a problem with the commit messages" "$GITHUB_STEP_SUMMARY"
+}
+
+@test "reports both a real problem and a crash in the same run" {
+  # Otherwise the contributor reads "this is a CI problem" while a genuine
+  # message problem sits unreported in the outputs.
+  export INPUT_PR_TITLE="bugfix: a real problem"
+  export INPUT_FROM="$BASE_SHA"
+  export COMMITLINT_MOCK_TITLE_EXIT=1
+  export COMMITLINT_MOCK_RANGE_EXIT=127
+
+  run -1 "$SCRIPT"
+
+  [ "$(output_value pr-title-result)" = "fail" ]
+  [ "$(output_value commits-result)" = "error" ]
+  grep -q "rejected a message" "$GITHUB_STEP_SUMMARY"
+  grep -q "not a problem with the commit messages" "$GITHUB_STEP_SUMMARY"
+}
+
+@test "honours the skip list only for this repository when GITHUB_REPOSITORY is unset" {
+  # An unset GITHUB_REPOSITORY must fail closed, not silently disable the guard.
+  export INPUT_BRANCH="sync-from-oss/main"
+  export INPUT_SKIP_BRANCHES="sync-from-oss/*"
+  export INPUT_HEAD_REPOSITORY="a-contributor/vcluster-pro"
+  unset GITHUB_REPOSITORY
+  export INPUT_PR_TITLE="fix: something"
+
+  run -0 "$SCRIPT"
+
+  [ "$(output_value skipped)" = "false" ]
+}
+
+# Two payloads, one rule. A CR splits the line at the runner, so a value printed
+# raw forges a command outright. A %0A does not - the runner decodes an
+# annotation's data for the annotation, it does not feed it back through command
+# parsing - but the decoded break still tears the annotation's text out of the
+# shape the raw log implies. Hence the conservative rule action.sh states and
+# assert_not_on_command_line pins: untrusted values never share a line with a
+# "::" command, they go on their own plain line.
+PERCENT_PAYLOAD='%0A::add-mask::pwn'
+
+@test "a CR in the pr title cannot forge a workflow command" {
+  export INPUT_PR_TITLE=$'feat: x\r::stop-commands::abc'"$PERCENT_PAYLOAD"
+
+  run -0 "$SCRIPT"
+
+  assert_no_forged_commands
+  assert_not_on_command_line "$PERCENT_PAYLOAD"
+  # Every forgery test needs this: "no forged command appeared" is trivially
+  # true of a value that was never printed, so deleting the print_untrusted
+  # call would satisfy the two assertions above and the defence they guard
+  # would have no coverage at all.
+  [[ "$output" == *'feat: x'* ]]
+}
+
+@test "a pr title starting with :: cannot forge a workflow command" {
+  # The runner trims leading whitespace before matching "::", so indenting the
+  # value is not enough on its own.
+  export INPUT_PR_TITLE='::add-mask::0'
+
+  run -0 "$SCRIPT"
+
+  assert_no_forged_commands
+  assert_not_on_command_line '::add-mask::0'
+  [[ "$output" == *'::add-mask::0'* ]]
+}
+
+@test "commitlint's own echo of the title cannot forge a workflow command" {
+  # commitlint prints the message back, so its stdout is as hostile as the input.
+  export INPUT_PR_TITLE="fix: something"
+  export COMMITLINT_MOCK_STDOUT=$'validating\r::stop-commands::abc'"$PERCENT_PAYLOAD"
+
+  run -0 "$SCRIPT"
+
+  assert_no_forged_commands
+  assert_not_on_command_line "$PERCENT_PAYLOAD"
+  [[ "$output" == *'validating'* ]]
+}
+
+@test "commitlint's range report cannot forge a workflow command" {
+  # A commit body carrying a CR reaches the log through the range report, which
+  # test 23 does not cover - it only exercises the title path.
+  export INPUT_FROM="$BASE_SHA"
+  export COMMITLINT_MOCK_STDOUT=$'linting\r::stop-commands::pwn'"$PERCENT_PAYLOAD"
+
+  run -0 "$SCRIPT"
+
+  assert_no_forged_commands
+  assert_not_on_command_line "$PERCENT_PAYLOAD"
+  [[ "$output" == *'linting'* ]]
+}
+
+@test "shows commitlint's range report" {
+  # Without this, dropping the report entirely would be invisible: the
+  # contributor would see an empty group and no reason for the failure.
+  export INPUT_FROM="$BASE_SHA"
+  export COMMITLINT_MOCK_STDOUT="subject may not be empty"
+  export COMMITLINT_MOCK_RANGE_EXIT=1
+
+  run -1 "$SCRIPT"
+
+  [[ "$output" == *"subject may not be empty"* ]]
+}
+
+@test "reports an unreachable range as a setup problem, not a bad message" {
+  # Forgetting fetch-depth: 0 is the likeliest caller mistake here, and
+  # commitlint exits 1 for it, which would otherwise read as a rejected message.
+  export INPUT_FROM="0000000000000000000000000000000000000000"
+  export INPUT_TO="HEAD"
+
+  run -1 "$SCRIPT"
+
+  [ "$(output_value commits-result)" = "error" ]
+  [[ "$output" == *"fetch-depth: 0"* ]]
+  # commitlint must never have been invoked for the range.
+  assert_no_call_matching "--from"
+}
+
+@test "an unreachable range is still a setup problem in strict mode" {
+  # Exit 2 would be a warning under --strict, so the sentinel must sit outside
+  # every message-problem set.
+  export INPUT_FAIL_ON_WARNINGS="true"
+  export INPUT_FROM="0000000000000000000000000000000000000000"
+
+  run -1 "$SCRIPT"
+
+  [ "$(output_value commits-result)" = "error" ]
+}
+
+@test "writes every output when working-directory does not exist" {
+  export INPUT_WORKING_DIRECTORY="$BATS_TEST_TMPDIR/nope"
+  export INPUT_PR_TITLE="fix: something"
+
+  run -1 "$SCRIPT"
+
+  [ "$(output_value skipped)" = "false" ]
+  [ "$(output_value pr-title-result)" = "error" ]
+  # Not requested, so not "error".
+  [ "$(output_value commits-result)" = "skipped" ]
+}
+
+@test "a CR in the branch name cannot forge a command on the skip path" {
+  # The fork-ignore path routed the branch name correctly while the skip path
+  # printed it raw, so the existing coverage gave false assurance.
+  export INPUT_BRANCH=$'sync-from-oss/x\r::stop-commands::pwn'
+  export INPUT_SKIP_BRANCHES="sync-from-oss/*"
+  export INPUT_HEAD_REPOSITORY="loft-sh/repo"
+  export GITHUB_REPOSITORY="loft-sh/repo"
+  export INPUT_PR_TITLE="fix: something"
+
+  run -0 "$SCRIPT"
+
+  [ "$(output_value skipped)" = "true" ]
+  assert_no_forged_commands
+  [[ "$output" == *'sync-from-oss/x'* ]]
+}
+
+# The fork's repository name is the fourth channel action.sh's header calls
+# hostile, and it reaches the log whenever the skip list is declined.
+@test "an untrusted fork repository name cannot forge a workflow command" {
+  export INPUT_BRANCH="sync-from-oss/main"
+  export INPUT_SKIP_BRANCHES="sync-from-oss/*"
+  export INPUT_HEAD_REPOSITORY=$'evil/repo\r::stop-commands::pwn'"$PERCENT_PAYLOAD"
+  export GITHUB_REPOSITORY="loft-sh/repo"
+  export INPUT_PR_TITLE="fix: something"
+
+  run -0 "$SCRIPT"
+
+  assert_no_forged_commands
+  assert_not_on_command_line "$PERCENT_PAYLOAD"
+  [[ "$output" == *'evil/repo'* ]]
+}
+
+@test "a branch name cannot break out of the job summary code span" {
+  export INPUT_BRANCH='x`</code>**pwned**'
+  export INPUT_SKIP_BRANCHES="x*"
+  export INPUT_HEAD_REPOSITORY="loft-sh/repo"
+  export GITHUB_REPOSITORY="loft-sh/repo"
+  export INPUT_PR_TITLE="fix: something"
+
+  run -0 "$SCRIPT"
+
+  assert_summary_lacks '</code>'
+  assert_summary_lacks '`x`'
+  # The summary line has to exist, or both assertions above hold on an empty file.
+  grep -q 'is exempt' "$GITHUB_STEP_SUMMARY"
+}
+
+@test "npm output cannot forge a workflow command" {
+  # On a fork pull request npm is parsing the fork's own manifest.
+  echo '{"devDependencies":{"@commitlint/cli":"19.8.1"}}' >package.json
+  echo '{}' >package-lock.json
+  export NPM_MOCK_STDOUT=$'npm error notarget\r::stop-commands::pwn'"$PERCENT_PAYLOAD"
+  export INPUT_PR_TITLE="fix: something"
+
+  run -0 "$SCRIPT"
+
+  assert_no_forged_commands
+  assert_not_on_command_line "$PERCENT_PAYLOAD"
+  [[ "$output" == *'npm error notarget'* ]]
+}
+
+@test "keeps a non-ascii line separator out of the log" {
+  # NEL, U+2028 and U+2029 are dropped, matching lib/log.sh.
+  export INPUT_PR_TITLE=$'fix: x\u0085::stop-commands::pwn'
+
+  run -0 "$SCRIPT"
+
+  [[ "$output" != *$'\u0085'* ]]
+  [[ "$output" == *'fix: x'* ]]
+}
+
+@test "does not claim a check errored when it was never requested" {
+  # Range-only linting with a bad working-directory must not report on a title
+  # check the caller never asked for.
+  export INPUT_WORKING_DIRECTORY="$BATS_TEST_TMPDIR/nope"
+  export INPUT_FROM="abc123"
+
+  run -1 "$SCRIPT"
+
+  [ "$(output_value commits-result)" = "error" ]
+  [ "$(output_value pr-title-result)" = "skipped" ]
+}
+
+# The mirror of "warns when to is wired but from is empty": a `to` expression
+# that resolved to nothing must not quietly become HEAD, or the range linted is
+# not the range requested.
+@test "warns when to resolves to an empty value" {
+  export INPUT_FROM="$BASE_SHA"
+  export INPUT_TO=""
+
+  run -0 "$SCRIPT"
+
+  [[ "$output" == *"'to' resolved to an empty value; linting up to HEAD"* ]]
+  [ "$(output_value commits-result)" = "pass" ]
+  calls | grep -q -- "--from $BASE_SHA --to HEAD"
+}
+
+# With no `from` either there is no range to lint, so the warning must not claim
+# a run up to HEAD that never happened.
+@test "reports an empty to and an empty from as no commits linted" {
+  export INPUT_TO=""
+  export INPUT_PR_TITLE="fix: something"
+
+  run -0 "$SCRIPT"
+
+  [[ "$output" == *"so no commits were linted"* ]]
+  [[ "$output" != *"linting up to HEAD"* ]]
+  [ "$(output_value commits-result)" = "skipped" ]
+}
+
+# `to` is a plausible carrier for a fork-chosen ref, and an unresolvable one
+# takes the reachability path, which prints the revision back.
+@test "an untrusted to cannot forge a workflow command" {
+  export INPUT_FROM="$BASE_SHA"
+  export INPUT_TO='x%0A::add-mask::secret'
+
+  run -1 "$SCRIPT"
+
+  assert_no_forged_commands
+  assert_not_on_command_line 'x%0A'
+  # The revision must still be reported, or the caller cannot see which one.
+  [[ "$output" == *'x%0A'* ]]
+}
+
+@test "warns when to is wired but from is empty" {
+  # A green run that linted no commits at all is worse than a failure.
+  export INPUT_TO="$HEAD_SHA"
+  export INPUT_PR_TITLE="fix: something"
+
+  run -0 "$SCRIPT"
+
+  [[ "$output" == *"'to' is set but 'from' is empty"* ]]
+  [ "$(output_value commits-result)" = "skipped" ]
+}
+
+@test "an exempt branch is skipped even when working-directory is missing" {
+  # The branch whose commits cannot be rewritten must not be failed by a
+  # directory that happens not to exist on it.
+  export INPUT_BRANCH="sync-from-oss/main"
+  export INPUT_SKIP_BRANCHES="sync-from-oss/*"
+  export INPUT_HEAD_REPOSITORY="loft-sh/repo"
+  export GITHUB_REPOSITORY="loft-sh/repo"
+  export INPUT_WORKING_DIRECTORY="$BATS_TEST_TMPDIR/nope"
+  export INPUT_PR_TITLE="fix: something"
+
+  run -0 "$SCRIPT"
+
+  [ "$(output_value skipped)" = "true" ]
+}
+
+@test "does not warn about forks when the branch matches no skip pattern" {
+  # Otherwise every outside pull request to a repo that merely configures
+  # skip-branches collects a spurious annotation.
+  export INPUT_BRANCH="feat/some-contribution"
+  export INPUT_SKIP_BRANCHES="sync-from-oss/*"
+  export INPUT_HEAD_REPOSITORY="a-contributor/repo"
+  export GITHUB_REPOSITORY="loft-sh/repo"
+  export INPUT_PR_TITLE="fix: something"
+
+  run -0 "$SCRIPT"
+
+  [ "$(output_value skipped)" = "false" ]
+  [[ "$output" != *"Ignoring skip-branches"* ]]
+}
+
+@test "reports git's own error instead of blaming fetch-depth" {
+  # A container job with a dubious-ownership checkout fails the revision check
+  # for a reason that has nothing to do with clone depth.
+  export INPUT_FROM="$BASE_SHA"
+  export INPUT_WORKING_DIRECTORY="$BATS_TEST_TMPDIR"
+  mkdir -p "$BATS_TEST_TMPDIR/notarepo"
+  export INPUT_WORKING_DIRECTORY="$BATS_TEST_TMPDIR/notarepo"
+
+  run -1 "$SCRIPT"
+
+  [ "$(output_value commits-result)" = "error" ]
+  [[ "$output" == *"git:"* ]]
+}
+
+@test "warns when skip-branches is set without head-repository" {
+  # Otherwise a caller silently reinstates the fork bypass.
+  export INPUT_BRANCH="sync-from-oss/main"
+  export INPUT_SKIP_BRANCHES="sync-from-oss/*"
+  export INPUT_PR_TITLE="anything"
+
+  run -0 "$SCRIPT"
+
+  [[ "$output" == *"head-repository is not"* ]]
+  [ "$(output_value skipped)" = "true" ]
+}
+
+@test "keeps an untrusted branch name off the workflow-command line" {
+  # The runner percent-decodes ::warning:: lines and a ref may contain '%'.
+  export INPUT_BRANCH='sync-from-oss/x%0A::add-mask::secret'
+  export INPUT_SKIP_BRANCHES="sync-from-oss/*"
+  export INPUT_HEAD_REPOSITORY="outsider/repo"
+  export GITHUB_REPOSITORY="loft-sh/repo"
+  export INPUT_PR_TITLE="fix: something"
+
+  run -0 "$SCRIPT"
+
+  assert_no_forged_commands
+  assert_not_on_command_line 'sync-from-oss/x%0A'
+  # The branch name must still be reported.
+  [[ "$output" == *'sync-from-oss/x%0A'* ]]
+}
+
+# Real commitlint 19.8.1 reads a whitespace-only message as no input, prints its
+# usage and exits 1 - which under --strict the classifier would call a CI
+# problem, sending a contributor after an outage over a blank title.
+@test "reports a whitespace-only title as a message problem, not a CI problem" {
+  export INPUT_PR_TITLE="   "
+  export INPUT_FAIL_ON_WARNINGS="true"
+
+  run -1 "$SCRIPT"
+
+  [ "$(output_value pr-title-result)" = "fail" ]
+  [[ "$output" == *"whitespace only"* ]]
+  # commitlint must never be handed the message, or its usage-exit lands back in
+  # the classifier. The --version probe still runs, and is not a lint.
+  assert_nothing_was_linted
+}
+
+@test "reports exit 1 as a genuine message problem" {
+  export INPUT_PR_TITLE="bugfix: nope"
+  export COMMITLINT_MOCK_TITLE_EXIT=1
+
+  run -1 "$SCRIPT"
+
+  [[ "$output" != *"not a problem with the commit messages"* ]]
+  grep -q "Commitlint failed" "$GITHUB_STEP_SUMMARY"
+}
+
+# The gate the README recommends reads `skipped`, so that is the output worth
+# forging: a rejected title reported correctly still waves the run through if a
+# child got the last word on it.
+@test "a commitlint from the checkout cannot forge the skipped output" {
+  install_output_forging_commitlint
+  export INPUT_PR_TITLE="bugfix: nope"
+  export COMMITLINT_MOCK_TITLE_EXIT=1
+
+  run -1 "$SCRIPT"
+
+  # output_value takes the last occurrence, which is how the runner resolves a
+  # repeated key, so this fails if the script does not write after the child.
+  [ "$(output_value skipped)" = "false" ]
+  [ "$(output_value pr-title-result)" = "fail" ]
+  # The forged line must really be in the file, or the test proves nothing.
+  grep -qx 'skipped=true' "$GITHUB_OUTPUT"
+}
+
+@test "prefers a commitlint already present in node_modules" {
+  install_local_commitlint
+  export INPUT_PR_TITLE="fix: something"
+
+  run -0 "$SCRIPT"
+
+  [[ "$output" == *"Using commitlint from node_modules"* ]]
+  assert_no_call_matching "^npm "
+  assert_no_call_matching "^npx "
+}
+
+@test "installs from the lockfile when the repo pins commitlint" {
+  echo '{"devDependencies":{"@commitlint/cli":"19.8.1"}}' >package.json
+  echo '{}' >package-lock.json
+  export INPUT_PR_TITLE="fix: something"
+
+  run -0 "$SCRIPT"
+
+  calls | grep -q "^npm ci"
+  [[ "$output" == *"commitlint dependency"* ]]
+}
+
+@test "installs a shared config package the npx fallback could not provide" {
+  # A config extending @commitlint/config-conventional needs that package
+  # present; npx only ever brings the CLI, so commitlint would die on
+  # MODULE_NOT_FOUND and the contributor would be told their message is bad.
+  echo '{"devDependencies":{"@commitlint/config-conventional":"19.8.1"}}' >package.json
+  echo '{}' >package-lock.json
+  export INPUT_PR_TITLE="fix: something"
+
+  run -0 "$SCRIPT"
+
+  calls | grep -q "^npm ci"
+}
+
+@test "does not run lifecycle scripts when installing from a lockfile" {
+  # On a fork pull request this installs the fork's own package.json.
+  echo '{"devDependencies":{"@commitlint/cli":"19.8.1"}}' >package.json
+  echo '{}' >package-lock.json
+  export INPUT_PR_TITLE="fix: something"
+
+  run -0 "$SCRIPT"
+
+  calls | grep "^npm ci" | grep -q -- "--ignore-scripts"
+}
+
+@test "does not run lifecycle scripts when installing without a lockfile" {
+  # The no-lockfile branch is the one a fork can reach just by omitting the
+  # lockfile, so it needs the same guarantee as the npm ci branch.
+  echo '{"devDependencies":{"@commitlint/cli":"19.8.1"}}' >package.json
+  export INPUT_PR_TITLE="fix: something"
+
+  run -0 "$SCRIPT"
+
+  calls | grep "^npm install" | grep -q -- "--ignore-scripts"
+}
+
+@test "uses npm install when the repo pins commitlint without a lockfile" {
+  echo '{"devDependencies":{"@commitlint/cli":"19.8.1"}}' >package.json
+  export INPUT_PR_TITLE="fix: something"
+
+  run -0 "$SCRIPT"
+
+  calls | grep -q "^npm install"
+}
+
+@test "falls back to npx when the repo pins nothing" {
+  export INPUT_PR_TITLE="fix: something"
+
+  run -0 "$SCRIPT"
+
+  calls | grep -q "^npx --yes @commitlint/cli@19.8.1"
+}
+
+@test "falls back to npx when the pinned install produces no binary" {
+  echo '{"devDependencies":{"@commitlint/cli":"19.8.1"}}' >package.json
+  echo '{}' >package-lock.json
+  export NPM_MOCK_FAIL=1
+  export INPUT_PR_TITLE="fix: something"
+
+  # A broken lockfile must not take the whole check down with it.
+  run -0 "$SCRIPT"
+
+  calls | grep -q "^npx --yes @commitlint/cli@19.8.1"
+}
+
+@test "honours a custom commitlint version" {
+  export INPUT_COMMITLINT_VERSION="20.1.0"
+  export INPUT_PR_TITLE="fix: something"
+
+  run -0 "$SCRIPT"
+
+  calls | grep -q "^npx --yes @commitlint/cli@20.1.0"
+}
+
+@test "passes the config path through" {
+  export INPUT_CONFIG_PATH="ci/commitlint.config.js"
+  export INPUT_PR_TITLE="fix: something"
+
+  run -0 "$SCRIPT"
+
+  calls | grep -q -- "--config ci/commitlint.config.js"
+}
+
+@test "passes --strict when warnings should fail" {
+  export INPUT_FAIL_ON_WARNINGS="true"
+  export INPUT_PR_TITLE="fix: something"
+
+  run -0 "$SCRIPT"
+
+  calls | grep -q -- "--strict"
+}
+
+@test "does not pass --strict by default" {
+  export INPUT_PR_TITLE="fix: something"
+
+  run -0 "$SCRIPT"
+
+  assert_no_call_matching "--strict"
+}
+
+# "True" is the plausible typo, and without the warning it reads as a green run
+# to a caller who believes warnings are fatal.
+@test "warns when fail-on-warnings is neither true nor false" {
+  export INPUT_FAIL_ON_WARNINGS="True"
+  export INPUT_PR_TITLE="fix: something"
+
+  run -0 "$SCRIPT"
+
+  [[ "$output" == *"fail-on-warnings is neither"* ]]
+  [[ "$output" == *"fail-on-warnings: True"* ]]
+  assert_no_call_matching "--strict"
+}
+
+# An expression that resolves to nothing is the mis-wiring most likely to reach
+# this input, and the runner keeps a supplied-but-empty input empty rather than
+# falling back to the manifest default - so the script has to warn about it too.
+@test "warns when fail-on-warnings is passed as an empty value" {
+  export INPUT_FAIL_ON_WARNINGS=""
+  export INPUT_PR_TITLE="fix: something"
+
+  run -0 "$SCRIPT"
+
+  [[ "$output" == *"fail-on-warnings is neither"* ]]
+  assert_no_call_matching "--strict"
+}
+
+@test "stays quiet about fail-on-warnings when it is a boolean" {
+  local value
+  for value in true false; do
+    : >"$GITHUB_OUTPUT"
+    export INPUT_FAIL_ON_WARNINGS="$value"
+    export INPUT_PR_TITLE="fix: something"
+
+    run -0 "$SCRIPT"
+
+    [[ "$output" != *"fail-on-warnings is neither"* ]]
+  done
+}
+
+@test "keeps a malformed fail-on-warnings off the workflow-command line" {
+  export INPUT_FAIL_ON_WARNINGS='yes%0A::add-mask::secret'
+  export INPUT_PR_TITLE="fix: something"
+
+  run -0 "$SCRIPT"
+
+  assert_no_forged_commands
+  assert_not_on_command_line 'yes%0A'
+  # The value must still be reported somewhere, or the warning is useless.
+  [[ "$output" == *'yes%0A'* ]]
+}

--- a/.github/actions/commitlint/test/commitlint_mock.bash
+++ b/.github/actions/commitlint/test/commitlint_mock.bash
@@ -1,0 +1,127 @@
+# Mocks for the external commands action.sh shells out to.
+#
+# Each mock is a real executable on PATH, so the script under test runs as a
+# child process with faithful `set -e` semantics rather than being sourced into
+# the harness.
+#
+# Behaviour is driven by env vars the tests set:
+#   COMMITLINT_MOCK_EXIT          exit code for every commitlint invocation
+#   COMMITLINT_MOCK_TITLE_EXIT    exit code when linting a message on stdin
+#   COMMITLINT_MOCK_RANGE_EXIT    exit code when linting a --from/--to range
+#   COMMITLINT_MOCK_VERSION_EXIT  exit code for the --version probe
+#   COMMITLINT_MOCK_STDOUT        text the mock prints on stdout
+#   NPM_MOCK_STDOUT               text the npm mock prints on stdout
+#   NPM_MOCK_FAIL                 non-empty makes `npm ci` / `npm install` fail
+#
+# Every invocation is appended to $CALL_LOG, one line per call, so tests can
+# assert on which binary ran and with which arguments.
+
+setup_mocks() {
+  MOCK_BIN="$BATS_TEST_TMPDIR/bin"
+  CALL_LOG="$BATS_TEST_TMPDIR/calls.log"
+  mkdir -p "$MOCK_BIN"
+  : >"$CALL_LOG"
+  export MOCK_BIN CALL_LOG
+  export PATH="$MOCK_BIN:$PATH"
+
+  _write_commitlint "$MOCK_BIN/commitlint"
+
+  cat >"$MOCK_BIN/npx" <<'EOF'
+#!/usr/bin/env bash
+echo "npx $*" >>"$CALL_LOG"
+# Drop the leading `--yes @commitlint/cli@<version>` so the remaining argv
+# matches what a locally installed binary would receive.
+shift 2 2>/dev/null || true
+exec commitlint "$@"
+EOF
+  chmod +x "$MOCK_BIN/npx"
+
+  cat >"$MOCK_BIN/npm" <<'EOF'
+#!/usr/bin/env bash
+echo "npm $*" >>"$CALL_LOG"
+if [ -n "${NPM_MOCK_STDOUT:-}" ]; then
+  printf '%s\n' "$NPM_MOCK_STDOUT"
+fi
+if [ -n "${NPM_MOCK_FAIL:-}" ]; then
+  echo "npm mock: forced failure" >&2
+  exit 1
+fi
+# Materialise the binary the real npm would have installed.
+mkdir -p node_modules/.bin
+cp "$MOCK_BIN/commitlint" node_modules/.bin/commitlint
+EOF
+  chmod +x "$MOCK_BIN/npm"
+}
+
+# A commitlint stand-in that records its argv and honours the *_EXIT vars.
+_write_commitlint() {
+  cat >"$1" <<'EOF'
+#!/usr/bin/env bash
+echo "commitlint $*" >>"$CALL_LOG"
+
+# The action smoke-tests the binary before linting anything. Answering here
+# without touching stdin keeps that probe separate from the lint calls.
+for arg in "$@"; do
+  if [ "$arg" = "--version" ]; then
+    if [ -n "${COMMITLINT_MOCK_VERSION_EXIT:-}" ]; then
+      exit "$COMMITLINT_MOCK_VERSION_EXIT"
+    fi
+    echo "19.8.1"
+    exit 0
+  fi
+done
+
+is_range=false
+for arg in "$@"; do
+  if [ "$arg" = "--from" ]; then
+    is_range=true
+    break
+  fi
+done
+
+if [ "$is_range" = true ]; then
+  if [ -n "${COMMITLINT_MOCK_STDOUT:-}" ]; then
+    printf '%s\n' "$COMMITLINT_MOCK_STDOUT"
+  fi
+  exit "${COMMITLINT_MOCK_RANGE_EXIT:-${COMMITLINT_MOCK_EXIT:-0}}"
+fi
+
+cat >/dev/null   # drain the message on stdin
+if [ -n "${COMMITLINT_MOCK_STDOUT:-}" ]; then
+  printf '%s\n' "$COMMITLINT_MOCK_STDOUT"
+fi
+exit "${COMMITLINT_MOCK_TITLE_EXIT:-${COMMITLINT_MOCK_EXIT:-0}}"
+EOF
+  chmod +x "$1"
+}
+
+# Installs a local node_modules/.bin/commitlint in the current directory, as a
+# repository that has already run `npm ci` would have.
+install_local_commitlint() {
+  mkdir -p node_modules/.bin
+  _write_commitlint node_modules/.bin/commitlint
+}
+
+# The same, except the binary also appends to $GITHUB_OUTPUT, which it inherits
+# like any other child. This is what a compromised dependency in the calling
+# repository's own lockfile can do, so every output the script writes has to
+# land after it or the runner resolves the forged value instead.
+install_output_forging_commitlint() {
+  mkdir -p node_modules/.bin
+  cat >node_modules/.bin/commitlint <<'EOF'
+#!/usr/bin/env bash
+echo "commitlint $*" >>"$CALL_LOG"
+for arg in "$@"; do
+  if [ "$arg" = "--version" ]; then
+    echo "19.8.1"
+    exit 0
+  fi
+done
+cat >/dev/null
+printf 'skipped=true\n' >>"$GITHUB_OUTPUT"
+exit "${COMMITLINT_MOCK_TITLE_EXIT:-0}"
+EOF
+  chmod +x node_modules/.bin/commitlint
+}
+
+calls() { cat "$CALL_LOG"; }

--- a/.github/actions/commitlint/test/fixture/commitlint.config.js
+++ b/.github/actions/commitlint/test/fixture/commitlint.config.js
@@ -1,0 +1,11 @@
+// Fixture for the composite smoke job. Deliberately self-contained - no
+// `extends` - so the npx path can resolve it with only the CLI installed.
+//
+// CommonJS because this repository has no package.json, so `.js` is not ESM.
+module.exports = {
+  rules: {
+    'type-empty': [2, 'never'],
+    'type-enum': [2, 'always', ['chore', 'ci', 'feat', 'fix']],
+    'subject-empty': [2, 'never'],
+  },
+};

--- a/.github/actions/commitlint/test/fixture/strict.config.js
+++ b/.github/actions/commitlint/test/fixture/strict.config.js
@@ -1,0 +1,12 @@
+// Second fixture for the config-path smoke scenario. It has to reject what
+// commitlint.config.js accepts, or a scenario pointing at it could not tell
+// "the input reached the script" from "commitlint discovered the other file",
+// which is what a broken config-path mapping silently falls back to.
+//
+// CommonJS for the same reason as its sibling: this repository has no
+// package.json, so `.js` is not ESM.
+module.exports = {
+  rules: {
+    'scope-empty': [2, 'always'],
+  },
+};

--- a/.github/workflows/test-commitlint.yaml
+++ b/.github/workflows/test-commitlint.yaml
@@ -1,0 +1,190 @@
+name: Test commitlint
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/test-commitlint.yaml'
+      - '.github/actions/commitlint/**'
+
+permissions:
+  contents: read
+
+jobs:
+  bats:
+    name: Run bats tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      # This action installs bats, it does not run anything. It has no `tests`
+      # input, and an unknown input is a warning rather than an error, so a job
+      # that only calls it passes without executing a single test.
+      - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
+        with:
+          support-install: false
+          assert-install: false
+          detik-install: false
+          file-install: false
+      - name: Run commitlint tests
+        run: bats .github/actions/commitlint/test/*.bats
+
+  smoke:
+    name: Exercise the composite wiring
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # The range scenario below resolves HEAD~1, which the default
+          # single-commit checkout does not have.
+          fetch-depth: 2
+          persist-credentials: false
+
+      # The bats suite calls src/action.sh directly with hand-exported INPUT_*,
+      # so it cannot reach the `inputs:` -> `env:` mapping or the `outputs:`
+      # block in action.yml. A typo in either is invisible to every one of those
+      # tests: an input silently becomes empty, so a check quietly does not run,
+      # or an output silently becomes '' for every caller's gate.
+      - name: A conforming title passes
+        id: pass
+        uses: ./.github/actions/commitlint
+        with:
+          pr-title: 'fix(smoke): a conforming subject'
+          working-directory: .github/actions/commitlint/test/fixture
+
+      - name: Verify the pass result reached the caller
+        env:
+          RESULT: ${{ steps.pass.outputs.pr-title-result }}
+          SKIPPED: ${{ steps.pass.outputs.skipped }}
+          COMMITS: ${{ steps.pass.outputs.commits-result }}
+        run: |
+          test "$RESULT" = pass
+          test "$SKIPPED" = false
+          test "$COMMITS" = skipped
+
+      - name: Produce an expression that resolves to nothing
+        id: nothing
+        run: echo "value=" >>"$GITHUB_OUTPUT"
+
+      # The README tells callers to read the outputs behind
+      # `continue-on-error: true` to tell `error` from `fail`. That only works
+      # if a composite's `outputs:` block is still evaluated when its inner step
+      # exits non-zero, which is not documented anywhere. Pin it here, or the
+      # whole error-vs-fail contract rests on an assumption.
+      #
+      # `fail-on-warnings` rides along carrying an expression that resolved to
+      # nothing, which src/action.sh treats differently from an input nobody
+      # passed - it expands that input and `to` with `-` rather than `:-` so it
+      # can warn about the difference. The only thing observable from a later
+      # step is that such a caller still gets a working run; the warning is an
+      # annotation, and a step cannot read another's, so its text is the bats
+      # suite's to cover. It rides on this step because this one is expected to
+      # annotate: the conforming-title step above is green, and a permanent
+      # warning there is one every future reader rediscovers as deliberate.
+      - name: A non-conforming title fails
+        id: fail
+        continue-on-error: true
+        uses: ./.github/actions/commitlint
+        with:
+          pr-title: 'bugfix(smoke): not a permitted type'
+          fail-on-warnings: ${{ steps.nothing.outputs.value }}
+          working-directory: .github/actions/commitlint/test/fixture
+
+      - name: Verify the outputs survive a failing run
+        env:
+          OUTCOME: ${{ steps.fail.outcome }}
+          RESULT: ${{ steps.fail.outputs.pr-title-result }}
+        run: |
+          test "$OUTCOME" = failure
+          test "$RESULT" = fail
+
+      # skip-branches is the one input whose whole purpose is to stop the action
+      # doing anything, so a wiring typo on it reads as a green pass.
+      - name: An exempt branch is skipped
+        id: skip
+        uses: ./.github/actions/commitlint
+        with:
+          pr-title: 'bugfix(smoke): never linted'
+          branch: sync-from-oss/main
+          skip-branches: 'sync-from-oss/*'
+          head-repository: ${{ github.repository }}
+          working-directory: .github/actions/commitlint/test/fixture
+
+      - name: Verify the skip reached the caller
+        env:
+          SKIPPED: ${{ steps.skip.outputs.skipped }}
+          RESULT: ${{ steps.skip.outputs.pr-title-result }}
+        run: |
+          test "$SKIPPED" = true
+          test "$RESULT" = skipped
+
+      # `from`/`to` is the other check the action advertises, and a mapping typo
+      # on it does not fail: the input arrives empty, the script reports
+      # commits-result=skipped and exits zero. That is the green run that linted
+      # no commits which the warnings in main() exist to prevent, except none of
+      # them fires either, because from the script's side the caller simply did
+      # not ask for range linting.
+      - name: Resolve a real commit range
+        id: range
+        run: |
+          {
+            echo "from=$(git rev-parse HEAD~1)"
+            echo "to=$(git rev-parse HEAD)"
+          } >>"$GITHUB_OUTPUT"
+
+      - name: A commit range is linted
+        id: range-lint
+        continue-on-error: true
+        uses: ./.github/actions/commitlint
+        with:
+          from: ${{ steps.range.outputs.from }}
+          to: ${{ steps.range.outputs.to }}
+          working-directory: .github/actions/commitlint/test/fixture
+
+      # Either verdict proves the range was wired and walked; which one depends
+      # on whichever commit subjects happen to be in range, so asserting a
+      # specific one would make this scenario fail on unrelated history. What it
+      # must never be is `skipped`, the value a mis-wired `from` produces.
+      - name: Verify the range result reached the caller
+        env:
+          RESULT: ${{ steps.range-lint.outputs.commits-result }}
+        run: test "$RESULT" = pass || test "$RESULT" = fail
+
+      # A broken config-path mapping does not fail either: the flag is dropped
+      # and commitlint discovers the config in the working directory, which for
+      # every scenario here is the fixture. So the scenario has to point at a
+      # config that disagrees with the discoverable one and assert the verdict
+      # follows the input rather than the fallback. strict.config.js rejects a
+      # scope, which commitlint.config.js accepts.
+      - name: A non-default config-path is honoured
+        id: cfg
+        continue-on-error: true
+        uses: ./.github/actions/commitlint
+        with:
+          pr-title: 'fix(smoke): a conforming subject'
+          config-path: strict.config.js
+          working-directory: .github/actions/commitlint/test/fixture
+
+      - name: Verify the custom config was the one applied
+        env:
+          RESULT: ${{ steps.cfg.outputs.pr-title-result }}
+        run: test "$RESULT" = fail
+
+      # Same shape for commitlint-version: the script's own fallback restores
+      # the manifest default, so a broken mapping silently ignores the caller's
+      # pin. A version that cannot exist is the only value whose effect is
+      # visible from out here, and it doubles as coverage of the path where
+      # commitlint never starts.
+      - name: A commitlint-version that cannot be fetched is a CI problem
+        id: version
+        continue-on-error: true
+        uses: ./.github/actions/commitlint
+        with:
+          pr-title: 'fix(smoke): a conforming subject'
+          commitlint-version: 0.0.0-does-not-exist
+          working-directory: .github/actions/commitlint/test/fixture
+
+      - name: Verify the pinned version was the one used
+        env:
+          RESULT: ${{ steps.version.outputs.pr-title-result }}
+        run: test "$RESULT" = error

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-semver-validation test-linear-pr-commenter test-link-backport-prs test-release-notification test-linear-release-sync test-aws-test-infra test-cleanup-head-charts test-ci-test-notify test-auto-approve-bot-prs test-ai-pr-review test-ai-step test-publish-helm-chart test-govulncheck test-go-licenses test-run-ginkgo test-sticky-pr-comment test-repository-dispatch test-parse-label-filter test-release-branch-freeze test-prerelease-setup test-vcluster-release test-subtree-mirror test-oss-commit-sync test-backport-legacy-allowlist test-backport-legacy-split test-promote-release test-wait-for-release test-cve-scan build-linear-release-sync lint install-auto-doc generate-docs check-docs help
+.PHONY: test test-semver-validation test-linear-pr-commenter test-link-backport-prs test-release-notification test-linear-release-sync test-aws-test-infra test-cleanup-head-charts test-ci-test-notify test-auto-approve-bot-prs test-ai-pr-review test-ai-step test-publish-helm-chart test-govulncheck test-go-licenses test-run-ginkgo test-sticky-pr-comment test-repository-dispatch test-parse-label-filter test-release-branch-freeze test-prerelease-setup test-vcluster-release test-subtree-mirror test-oss-commit-sync test-backport-legacy-allowlist test-backport-legacy-split test-promote-release test-wait-for-release test-cve-scan test-commitlint build-linear-release-sync lint install-auto-doc generate-docs check-docs help
 
 ACTIONS_DIR := .github/actions
 WORKFLOWS_DIR := .github/workflows
@@ -93,7 +93,7 @@ check-docs: generate-docs ## verify docs are up to date (fails if drift detected
 help: ## show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-30s %s\n", $$1, $$2}'
 
-test: test-semver-validation test-linear-pr-commenter test-link-backport-prs test-release-notification test-linear-release-sync test-aws-test-infra test-cleanup-head-charts test-auto-approve-bot-prs test-ai-pr-review test-ai-step test-ci-test-notify test-go-licenses test-publish-helm-chart test-govulncheck test-run-ginkgo test-sticky-pr-comment test-repository-dispatch test-parse-label-filter test-release-branch-freeze test-prerelease-setup test-vcluster-release test-subtree-mirror test-oss-commit-sync test-backport-legacy-allowlist test-backport-legacy-split test-promote-release test-wait-for-release test-cve-scan ## run all action tests
+test: test-semver-validation test-linear-pr-commenter test-link-backport-prs test-release-notification test-linear-release-sync test-aws-test-infra test-cleanup-head-charts test-auto-approve-bot-prs test-ai-pr-review test-ai-step test-ci-test-notify test-go-licenses test-publish-helm-chart test-govulncheck test-run-ginkgo test-sticky-pr-comment test-repository-dispatch test-parse-label-filter test-release-branch-freeze test-prerelease-setup test-vcluster-release test-subtree-mirror test-oss-commit-sync test-backport-legacy-allowlist test-backport-legacy-split test-promote-release test-wait-for-release test-cve-scan test-commitlitn ## run all action tests
 
 test-semver-validation: ## run semver-validation unit tests
 	cd $(ACTIONS_DIR)/semver-validation && npm ci --silent && NODE_OPTIONS=--experimental-vm-modules npx jest --ci --coverage --watchAll=false
@@ -180,6 +180,9 @@ test-backport-legacy-split: ## run backport-legacy-split bats tests
 
 test-wait-for-release: ## run wait-for-release bats tests
 	bats $(ACTIONS_DIR)/wait-for-release/test/*.bats
+
+test-commitlint: ## run commitlint bats tests
+	bats $(ACTIONS_DIR)/commitlint/test/*.bats
 
 build-linear-release-sync: ## build linear-release-sync binary (linux/amd64)
 	cd $(ACTIONS_DIR)/linear-release-sync/src && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-s -w" -o ../linear-release-sync-linux-amd64 .

--- a/README.md
+++ b/README.md
@@ -459,6 +459,53 @@ Blocks until a GitHub Release for a version exists in another repository, for pi
 
 See [wait-for-release README](./.github/actions/wait-for-release/README.md) for the full behaviour table.
 
+### Commitlint
+
+Lints commit messages and pull request titles against the calling repository's own [commitlint](https://commitlint.js.org/) config. The config always comes from the caller: this action decides what gets linted and when to skip, the repository decides what the rules are. Note the trust model in the action README - the config is read from the checkout, so on a fork pull request it is a contributor-facing aid rather than an enforcement boundary. On a squash-merged repository the pull request title is what lands on the default branch, so linting the title is the check that actually protects history; per-commit range linting is the secondary one. When the calling repository's `package.json` mentions `commitlint`, its dependencies are installed and the local binary is used, so CI runs exactly what contributors run locally; otherwise the CLI alone is fetched with `npx`.
+
+**Location:** `.github/actions/commitlint`
+
+**Usage:**
+
+```yaml
+- uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+  with:
+    fetch-depth: 0
+    persist-credentials: false
+
+- uses: loft-sh/github-actions/.github/actions/commitlint@commitlint/v1
+  with:
+    pr-title: ${{ github.event.pull_request.title }}
+    from: ${{ github.event.pull_request.base.sha }}
+    to: ${{ github.event.pull_request.head.sha }}
+    branch: ${{ github.event.pull_request.head.ref }}
+    head-repository: ${{ github.event.pull_request.head.repo.full_name }}
+    skip-branches: 'sync-from-oss/*'
+```
+
+**Inputs:**
+
+- `pr-title` (optional): Message to lint on its own. Empty skips the check.
+- `from` (optional): Range start for per-commit linting. Empty skips the check. Needs `fetch-depth: 0`.
+- `to` (optional, default `HEAD`): Range end for per-commit linting.
+- `branch` (optional): Branch name matched against `skip-branches`.
+- `head-repository` (optional): Repository the branch lives on. Pass this whenever `skip-branches` is set: on a fork PR the branch name is author-chosen, so the skip list is ignored when this differs from `github.repository`.
+- `skip-branches` (optional): Comma-separated globs; a match exits successfully without linting. For branches whose commits cannot be rewritten, such as the rebase-merged `sync-from-oss` branches.
+- `config-path` (optional): Config path. Empty uses commitlint's own discovery.
+- `working-directory` (optional, default `.`): Directory to run in.
+- `commitlint-version` (optional): Version used when the caller pins none. The default lives in `action.yml`, which is the copy Renovate keeps current.
+- `fail-on-warnings` (optional, default `false`): Treat warnings as failures.
+
+**Outputs:**
+
+- `skipped`: `true` when `skip-branches` matched and nothing was linted.
+- `pr-title-result`: `pass`, `fail`, `skipped`, or `error` when commitlint could not run.
+- `commits-result`: `pass`, `fail`, `skipped`, or `error` when commitlint could not run.
+
+Reading an output requires `continue-on-error: true` on the step, since a failing step skips the rest of the job. See the action README for the full pattern.
+
+See [commitlint README](./.github/actions/commitlint/README.md) for detailed documentation.
+
 ## Available Reusable Workflows
 
 ### Validate Renovate Config


### PR DESCRIPTION
Adds a `commitlint` composite action. First consumer is vcluster-pro (DEVOPS-1219).

The caller owns the rules: the commitlint config always comes from the calling repository, the action only decides what gets linted and when to skip. Two independent checks, `pr-title` and a `from`/`to` range, both optional and both run to completion so one push surfaces every problem.

When the calling repo pins `@commitlint/cli` in its `package.json`, that version is installed and used, so CI runs what contributors run locally.

`skip-branches` exists for branches whose commits cannot be rewritten, notably the rebase-merged `sync-from-oss` branches that replay community authorship verbatim. It is matched against `head-repository` as well as `branch`, because a fork PR branch name is chosen by its author and would otherwise be a way to opt out of linting entirely.

`test-commitlint.yaml` also runs a smoke job against the composite itself. The bats suite calls `src/action.sh` with hand-exported `INPUT_*`, so it cannot reach the `inputs:` to `env:` mapping or the `outputs:` block, where a typo is silently green.

Closes DEVOPS-1012

## Test plan

- `make test-commitlint` - 62 bats tests pass
- `shellcheck` clean on `src/action.sh` and the test mock
- `actionlint` clean, `zizmor` reports no findings
- `make check-docs` passes
- Mutation-checked each guard against a green baseline, with the harness asserting every mutation actually applied: 12 mutations, each reddens a specific test and none is a no-op
- Ran the action against vcluster-pro's real commitlint config: good title passes, a title carrying a Linear ID fails, a real commit range passes, a `sync-from-oss/*` branch skips, and the same branch name from a fork is linted rather than skipped

