### PR TITLE
fix(run-ginkgo): stay silent when rerun-failed-only is off

### DIFF
--- a/.github/actions/run-ginkgo/src/resolve-rerun-focus.sh
+++ b/.github/actions/run-ginkgo/src/resolve-rerun-focus.sh
@@ -16,7 +16,12 @@ skip() {
   exit 0
 }
 
-[[ "${RERUN_FAILED_ONLY:-false}" == "true" ]] || skip "rerun-failed-only is not enabled"
+# The step has no if:, so focused-rerun is never empty. Callers that never opted in must
+# not collect an annotation on every run.
+if [[ "${RERUN_FAILED_ONLY:-false}" != "true" ]]; then
+  echo "focused-rerun=false" >>"$GITHUB_OUTPUT"
+  exit 0
+fi
 
 if [[ -n "${UPLOAD_REPORT:-}" && "$UPLOAD_REPORT" != "true" ]]; then
   echo "::warning::rerun-failed-only needs upload-report: 'true' - without it no attempt publishes the report this reads, so reruns can never be narrowed"

--- a/.github/actions/run-ginkgo/test/resolve-rerun-focus.bats
+++ b/.github/actions/run-ginkgo/test/resolve-rerun-focus.bats
@@ -56,6 +56,20 @@ MOCK
   grep -q '^focused-rerun=false$' "$GITHUB_OUTPUT"
 }
 
+@test "annotates nothing when the feature is not enabled" {
+  # The step runs for every caller of the action, including those that never opted in.
+  RERUN_FAILED_ONLY=false run_with mixed-failures
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"::notice::"* ]]
+  [[ "$output" != *"::warning::"* ]]
+}
+
+@test "still annotates the fallback when the feature is enabled" {
+  GITHUB_RUN_ATTEMPT=1 run_with mixed-failures
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"::notice::"* ]]
+}
+
 @test "falls back to a full run on the first attempt" {
   GITHUB_RUN_ATTEMPT=1 run_with mixed-failures
   [ "$status" -eq 0 ]


### PR DESCRIPTION
The resolve step runs unconditionally so focused-rerun is never an empty string, but it annotated every run of every caller with a notice about a feature they never enabled. Exit quietly instead; the notice still fires when the feature is on and falls back to a full suite.