### PR TITLE
feat(auto-approve): support separate merge token

### DIFF
--- a/.github/actions/auto-approve-bot-prs/README.md
+++ b/.github/actions/auto-approve-bot-prs/README.md
@@ -80,6 +80,12 @@ rerun that was still coming. That stalled the `v0.34.7` cut
 With `auto-merge: true` the action tries a **plain merge first**, and uses
 GitHub's auto-merge queue (`--auto`) only as a fallback.
 
+The merge step uses `merge-token` when supplied, otherwise it keeps the existing
+behavior and uses `github-token`. This lets a caller approve with an identity
+that differs from the PR author, then merge with an identity that has a path
+through branch protection. The merge identity may match the PR author because
+GitHub forbids self-review, not self-merge.
+
 By the time the merge step runs, every other check is already green and the PR
 is approved, so there is normally nothing left for the queue to wait on.
 `--auto` additionally requires the repository's `allow_auto_merge` setting,
@@ -118,29 +124,32 @@ PR is benign, and a PR closed unmerged is a human decision.
 
 <!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
 
-|       INPUT        |  TYPE  | REQUIRED |                    DEFAULT                     |                                                                                                          DESCRIPTION                                                                                                           |
-|--------------------|--------|----------|------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-|     auto-merge     | string |  false   |                   `"false"`                    |                                                                      Merge the PR after approving it, <br>directly where possible. See README "Merging".                                                                       |
-|   ci-read-token    | string |  false   |                                                |           Token for the read-only CI poll <br>only; defaults to the caller GITHUB_TOKEN, <br>which needs `checks: read` and `statuses: read`. Never <br>the approving PAT. See README "Two <br>tokens, on purpose".            |
-|    github-token    | string |   true   |                                                | PAT used to read PR state, <br>approve, and — when auto-merge is <br>true — merge the PR directly, <br>so it needs a merge path <br>on the base branch, not just <br>the auto-merge toggle. Must NOT match <br>the PR author.  |
-|    merge-method    | string |  false   |                   `"squash"`                   |                                                                                               Merge method (squash|merge|rebase)                                                                                               |
-|  trusted-authors   | string |  false   | `"renovate[bot],loft-bot,github-actions[bot]"` |                                                                                           Comma-separated list of trusted bot logins                                                                                           |
-| wait-max-attempts  | string |  false   |                     `"90"`                     |                                                                                     Max polling attempts waiting for other <br>CI checks                                                                                       |
-| wait-min-attempts  | string |  false   |                     `"12"`                     |                                       Minimum polls before ci_green=true is allowed. <br>Prevents early approval while slow external <br>checks (e.g. Netlify) have not yet registered.                                        |
-| wait-sleep-seconds | string |  false   |                     `"10"`                     |                                                                                                Seconds between polling attempts                                                                                                |
+|       INPUT        |  TYPE  | REQUIRED |                    DEFAULT                     |                                                                                              DESCRIPTION                                                                                              |
+|--------------------|--------|----------|------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|     auto-merge     | string |  false   |                   `"false"`                    |                                                         Merge the PR after approving it, <br>directly where possible. See README "Merging".                                                           |
+|   ci-read-token    | string |  false   |                                                | Token for the read-only CI poll <br>only; defaults to the caller GITHUB_TOKEN, <br>which needs `checks: read` and `statuses: read`. Never <br>the approving PAT. See README "Tokens <br>by purpose".  |
+|    github-token    | string |   true   |                                                |                                   PAT used to read PR state <br>and approve. Must NOT match the <br>PR author. Also used to merge <br>when merge-token is omitted.                                    |
+|    merge-method    | string |  false   |                   `"squash"`                   |                                                                                  Merge method (squash|merge|rebase)                                                                                   |
+|    merge-token     | string |  false   |                                                |             Optional token used only to merge <br>when auto-merge is true. Defaults to <br>github-token. It may match the PR <br>author, but needs a merge path <br>on the base branch.               |
+|  trusted-authors   | string |  false   | `"renovate[bot],loft-bot,github-actions[bot]"` |                                                                              Comma-separated list of trusted bot logins                                                                               |
+| wait-max-attempts  | string |  false   |                     `"90"`                     |                                                                         Max polling attempts waiting for other <br>CI checks                                                                          |
+| wait-min-attempts  | string |  false   |                     `"12"`                     |                          Minimum polls before ci_green=true is allowed. <br>Prevents early approval while slow external <br>checks (e.g. Netlify) have not yet registered.                            |
+| wait-sleep-seconds | string |  false   |                     `"10"`                     |                                                                                   Seconds between polling attempts                                                                                    |
 
 <!-- AUTO-DOC-INPUT:END -->
 
-## Two tokens, on purpose
+## Tokens by purpose
 
 Approving needs a PAT, because GitHub forbids self-approval and the approver
-identity must differ from the PR author. **Reading CI state does not.** The two
-are split:
+identity must differ from the PR author. Reading CI state does not. Merging may
+need another identity when branch protection restricts pushes. The steps are
+split:
 
 | Step | Token |
 |------|-------|
-| `check-pr-ready`, *Approve PR*, *Enable auto-merge* | `github-token` (PAT) |
+| `check-pr-ready`, *Approve PR* | `github-token` (PAT) |
 | *Wait for other CI to pass* | `ci-read-token`, defaulting to `GITHUB_TOKEN` |
+| *Merge PR* | `merge-token`, defaulting to `github-token` |
 
 Do not point `ci-read-token` at the approving PAT.
 **Fine-grained PATs cannot call the Checks API at all** — there is no `Checks`

--- a/.github/actions/auto-approve-bot-prs/action.yml
+++ b/.github/actions/auto-approve-bot-prs/action.yml
@@ -21,10 +21,13 @@ inputs:
     required: false
     default: 'false'
   github-token:
-    description: 'PAT used to read PR state, approve, and — when auto-merge is true — merge the PR directly, so it needs a merge path on the base branch, not just the auto-merge toggle. Must NOT match the PR author.'
+    description: 'PAT used to read PR state and approve. Must NOT match the PR author. Also used to merge when merge-token is omitted.'
     required: true
+  merge-token:
+    description: 'Optional token used only to merge when auto-merge is true. Defaults to github-token. It may match the PR author, but needs a merge path on the base branch.'
+    required: false
   ci-read-token:
-    description: 'Token for the read-only CI poll only; defaults to the caller GITHUB_TOKEN, which needs `checks: read` and `statuses: read`. Never the approving PAT. See README "Two tokens, on purpose".'
+    description: 'Token for the read-only CI poll only; defaults to the caller GITHUB_TOKEN, which needs `checks: read` and `statuses: read`. Never the approving PAT. See README "Tokens by purpose".'
     required: false
   wait-max-attempts:
     description: 'Max polling attempts waiting for other CI checks'
@@ -96,7 +99,7 @@ runs:
       if: steps.ci.outputs.ci_green == 'true' && inputs.auto-merge == 'true'
       shell: bash
       env:
-        GH_TOKEN: ${{ inputs.github-token }}
+        GH_TOKEN: ${{ inputs.merge-token || inputs.github-token }}
         PR_NUMBER: ${{ github.event.pull_request.number }}
         MERGE_METHOD: ${{ inputs.merge-method }}
       run: ${{ github.action_path }}/src/enable-auto-merge.sh

--- a/.github/actions/auto-approve-bot-prs/test/token-contract.bats
+++ b/.github/actions/auto-approve-bot-prs/test/token-contract.bats
@@ -1,0 +1,25 @@
+#!/usr/bin/env bats
+
+ACTION="$BATS_TEST_DIRNAME/../action.yml"
+WORKFLOW="$BATS_TEST_DIRNAME/../../../workflows/auto-approve-bot-prs.yaml"
+
+@test "composite accepts an optional merge token" {
+  run grep -F "  merge-token:" "$ACTION"
+  [ "$status" -eq 0 ]
+  run grep -F 'GH_TOKEN: ${{ inputs.merge-token || inputs.github-token }}' "$ACTION"
+  [ "$status" -eq 0 ]
+}
+
+@test "reusable workflow threads the optional merge token to the composite" {
+  run grep -F "      merge-token:" "$WORKFLOW"
+  [ "$status" -eq 0 ]
+  run grep -F 'merge-token: ${{ secrets.merge-token }}' "$WORKFLOW"
+  [ "$status" -eq 0 ]
+}
+
+@test "approval still uses only the approval token" {
+  run grep -F 'github-token: ${{ inputs.github-token }}' "$ACTION"
+  [ "$status" -eq 0 ]
+  run grep -F 'github-token: ${{ secrets.gh-access-token }}' "$WORKFLOW"
+  [ "$status" -eq 0 ]
+}

--- a/.github/workflows/auto-approve-bot-prs.yaml
+++ b/.github/workflows/auto-approve-bot-prs.yaml
@@ -29,8 +29,11 @@ on:
         default: '10'
     secrets:
       gh-access-token:
-        description: 'GitHub PAT for approving PRs, and for merging them directly when auto-merge is true — so it needs a merge path on the base branch, not just the auto-merge toggle (must be different identity from PR author)'
+        description: 'GitHub PAT for approving PRs (must be different identity from PR author). Also used for merging when merge-token is omitted.'
         required: true
+      merge-token:
+        description: 'Optional token used only for merging when auto-merge is true. Defaults to gh-access-token and needs a merge path on the base branch.'
+        required: false
       ci-read-token:
         description: 'Optional escape hatch for the read-only CI poll when the caller cannot grant `checks: read` / `statuses: read`. Classic PAT with `repo` scope, or an App token. Never gh-access-token.'
         required: false
@@ -72,6 +75,7 @@ jobs:
           wait-min-attempts: ${{ inputs.wait-min-attempts }}
           wait-sleep-seconds: ${{ inputs.wait-sleep-seconds }}
           github-token: ${{ secrets.gh-access-token }} # zizmor: ignore[secrets-outside-env] -- PAT passed via workflow_call, not a repo secret
+          merge-token: ${{ secrets.merge-token }} # zizmor: ignore[secrets-outside-env] -- optional token passed via workflow_call
           # Empty when the caller does not set it, which falls back to
           # github.token inside the composite.
           ci-read-token: ${{ secrets.ci-read-token }} # zizmor: ignore[secrets-outside-env] -- optional token passed via workflow_call

--- a/README.md
+++ b/README.md
@@ -539,8 +539,9 @@ catches its own errors and exits 0, self-approval is pre-empted before calling
 the external approve action.
 
 With `auto-merge: true` the merge is performed **directly**, with GitHub's
-auto-merge queue only as a fallback — so `gh-access-token` needs a merge path on
-the base branch, not just the repository's auto-merge toggle. See the action's
+auto-merge queue only as a fallback. Pass the optional `merge-token` secret when
+the approving identity has no merge path on the base branch. When omitted, the
+workflow keeps using `gh-access-token` for both operations. See the action's
 [README](.github/actions/auto-approve-bot-prs/README.md#merging).
 
 **Location:** `.github/workflows/auto-approve-bot-prs.yaml`
@@ -567,6 +568,8 @@ jobs:
       auto-merge: false
     secrets:
       gh-access-token: ${{ secrets.GH_ACCESS_TOKEN }}
+      # Optional: a separate identity with a merge path on the base branch.
+      merge-token: ${{ secrets.MERGE_TOKEN }}
 ```
 
 `gh-access-token` must be a PAT whose identity differs from PR authors you want

--- a/docs/workflows/auto-approve-bot-prs.md
+++ b/docs/workflows/auto-approve-bot-prs.md
@@ -25,10 +25,11 @@ secret.
 
 <!-- AUTO-DOC-SECRETS:START - Do not remove or modify this section -->
 
-|     SECRET      | REQUIRED |                                                                                                            DESCRIPTION                                                                                                             |
-|-----------------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-|  ci-read-token  |  false   |              Optional escape hatch for the read-only <br>CI poll when the caller cannot <br>grant `checks: read` / `statuses: read`. Classic PAT <br>with `repo` scope, or an App <br>token. Never gh-access-token.                |
-| gh-access-token |   true   | GitHub PAT for approving PRs, and <br>for merging them directly when auto-merge <br>is true — so it needs <br>a merge path on the base <br>branch, not just the auto-merge toggle <br>(must be different identity from PR author)  |
+|     SECRET      | REQUIRED |                                                                                               DESCRIPTION                                                                                               |
+|-----------------|----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|  ci-read-token  |  false   | Optional escape hatch for the read-only <br>CI poll when the caller cannot <br>grant `checks: read` / `statuses: read`. Classic PAT <br>with `repo` scope, or an App <br>token. Never gh-access-token.  |
+| gh-access-token |   true   |                                  GitHub PAT for approving PRs (must be different identity from PR author). <br>Also used for merging when merge-token <br>is omitted.                                   |
+|   merge-token   |  false   |                            Optional token used only for merging <br>when auto-merge is true. Defaults to <br>gh-access-token and needs a merge path <br>on the base branch.                             |
 
 <!-- AUTO-DOC-SECRETS:END -->
 


### PR DESCRIPTION
## Summary

- add an optional merge token to the shared auto-approve action and workflow
- keep existing callers on the current single-token behavior by default
- document and test the approval, CI-read, and merge token boundaries

## Test plan

- `make test-auto-approve-bot-prs` (113 tests)
- `make check-docs`
- `actionlint .github/workflows/auto-approve-bot-prs.yaml .github/workflows/test-auto-approve-bot-prs.yaml`
- `zizmor .github/workflows/auto-approve-bot-prs.yaml .github/workflows/test-auto-approve-bot-prs.yaml`

References DEVOPS-1316
