### PR TITLE
feat(comment-triggered-check): add a comment-triggered check-run action

### DIFF
--- a/.github/actions/ai-step/README.md
+++ b/.github/actions/ai-step/README.md
@@ -6,10 +6,13 @@ expose the schema-conforming JSON as a step output. Downstream steps
 parse with `fromJSON(steps.<id>.outputs.result)` and branch on typed
 fields.
 
-The contract is the schema. Whatever the model returns, the action
-exposes it on `result` and sets `conclusion=success`. The action never
-emits `failed` — the caller knows what empty or unexpected output means
-for their pipeline, and decides whether to continue or `exit 1`.
+The contract is the schema. When the model returns schema-conforming
+JSON, the action exposes it on `result` and sets `conclusion=success`.
+The action never hard-fails the pipeline: provider errors, timeouts,
+and non-JSON output all degrade to `conclusion=failed` with an empty
+`result`, a `::warning::` in the log, and exit code 0. The caller knows
+what a failed or empty result means for their pipeline, and decides
+whether to continue or `exit 1`.
 
 ## When to use this vs `ai-pr-review`
 
@@ -107,25 +110,108 @@ ranges and business rules in your downstream step, not in the schema.
 
 ### Tool use / MCP
 
-Not supported in v1. If you need Claude Code tools, MCP servers, or
-filesystem access during the reasoning step, reach for
-`anthropics/claude-code-action` directly — `ai-step` is the minimal
-text-to-JSON primitive.
+Not supported in the single-call mode. If you need Claude Code tools,
+MCP servers, or filesystem access during the reasoning step, reach for
+`anthropics/claude-code-action` directly, or point the `agent` input at
+a deployed managed agent (below) — the single-call mode stays the
+minimal text-to-JSON primitive.
+
+## Session mode: trigger a deployed managed agent
+
+Setting `agent` to the name of a deployed managed agent
+(`loft-sh/ai-agents`: `pr-review-lead`, `sre-router`, ...) switches the
+action from a one-shot Messages call to a managed-agent session. The
+`prompt` and `input` become the session's opening user message, the
+agent runs with its own tools, MCP servers, and sandbox, and its final
+message lands on `result` — validated against `output-schema` on the
+runner, since sessions have no provider-side structured-output binding.
+Downstream steps and the `conclusion` contract do not change.
+
+```yaml
+- id: agent
+  uses: ./.github/actions/ai-step
+  with:
+    provider: anthropic
+    agent: sre-router
+    prompt: |
+      Investigate the alert below and return JSON matching the schema.
+    input: ${{ steps.alert.outputs.payload }}
+    output-schema: |
+      { "type": "object", "required": ["severity"], "properties":
+        { "severity": { "type": "string", "enum": ["page","ticket","ignore"] } } }
+    anthropic-session-key: ${{ secrets.ANTHROPIC_SESSION_KEY }}
+    vault-id: vlt_...          # only if the agent's MCP servers need it
+    session-timeout-seconds: '900'
+```
+
+Read this before wiring it into a pipeline:
+
+- **Anthropic-only.** `agent` with `provider: openai` skips with a
+  reason — there is no OpenAI counterpart to the deployed agents.
+- **Cost and latency change class.** A single call is ~15s and one
+  model invocation; a session runs minutes and is billed at session
+  scale (a pr-review panel run measures $20-47). Keep this mode behind
+  an explicit per-caller opt-in, never on a default PR path.
+- **The credential is different.** `anthropic-session-key` must be an
+  API key for the Console workspace the agent is deployed in. The
+  Messages-API `ANTHROPIC_API_KEY` cannot call the sessions API, and
+  workspace keys do not cross workspaces. Never expose the key to fork
+  PRs: callers inherit `ai-pr-review`'s same-repo guard
+  (`github.event.pull_request.head.repo.full_name == github.repository`)
+  and must not use `secrets: inherit`.
+- **Workload identity federation works instead of a key.** A job that
+  fetches its GitHub OIDC token (`permissions: id-token: write`,
+  audience `https://api.anthropic.com`) and sets the
+  `ANTHROPIC_FEDERATION_RULE_ID`, `ANTHROPIC_ORGANIZATION_ID`,
+  `ANTHROPIC_SERVICE_ACCOUNT_ID`, `ANTHROPIC_WORKSPACE_ID`, and
+  `ANTHROPIC_IDENTITY_TOKEN` (or `_FILE`) env vars can omit
+  `anthropic-session-key` entirely: the SDK exchanges the OIDC token
+  itself, and the resulting credential is session and workspace scoped.
+  The OIDC fetch belongs in the calling workflow, not in this action.
+  `ANTHROPIC_API_KEY` must be unset in that job, because it outranks
+  federation in the SDK's credential chain.
+- **Vaults.** Agents whose MCP servers authenticate through
+  session-scoped vault credentials need `vault-id` or their MCP servers
+  fail to initialize. A vault id names a resource, not a credential.
+- **The agent's final message lands in public CI logs.** `result` and
+  the raw output on validation failure are printed unmasked. A
+  vault-backed agent can read credential-authorized material, and a
+  prompt-injected turn can try to make it echo what it read, so never
+  point an agent whose output may contain secret material at this
+  action, and treat the agent's output as untrusted input downstream.
+- **Outbound network is unrestricted.** The per-run environment is
+  created with unrestricted egress, matching how the deployed products
+  run. The API's `limited` mode needs a per-agent host allowlist this
+  generic trigger cannot know; a caller-facing knob is deliberate
+  follow-up work if a caller needs narrower egress.
+- **Completion is polled, not streamed.** The action polls session
+  status until it leaves `running` and gates on `stop_reason=end_turn`
+  (a visible answer is not a finished session — ai-agents PR #81). A
+  session that outlives `session-timeout-seconds` ends the step with
+  `conclusion=failed`.
+- **Sessions are always deleted.** Every session (and its per-run
+  environment) the action creates is deleted before the step ends, on
+  success, failure, and timeout alike. A run you want to inspect in the
+  Console belongs in `ai-agents`' own tooling, not CI.
 
 ## Inputs
 
 <!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
 
-|       INPUT       |  TYPE  | REQUIRED |  DEFAULT   |                                                                                                                                            DESCRIPTION                                                                                                                                            |
-|-------------------|--------|----------|------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| anthropic-api-key | string |  false   |            |                                                                                                                       Anthropic API key. Required when provider=anthropic.                                                                                                                        |
-|      effort       | string |  false   | `"medium"` |                                                                                                           Effort level (low | medium | high) — maps to <br>a provider-specific model.                                                                                                             |
-|       input       | string |  false   |            |                                                  Optional data the model should act <br>on, appended to the prompt. Caller <br>sources it — a literal string, <br>a prior step output, or the <br>contents of a file read in <br>a prior step.                                                    |
-|  openai-api-key   | string |  false   |            |                                                                                                                          OpenAI API key. Required when provider=openai.                                                                                                                           |
-|   output-schema   | string |   true   |            | JSON Schema (string) the model output <br>must conform to. Required. Structured output <br>is the contract — without a <br>schema the action skips. For `anthropic` this <br>becomes `output_format.schema` on the Messages API; for <br>`openai` it becomes `response_format.json_schema.schema` |
-|                   |        |          |            |                                                                                                                                 on the Chat Completions <br>API.                                                                                                                                  |
-|      prompt       | string |   true   |            |                                                                                                                           Instructions for the model. Passed verbatim.                                                                                                                            |
-|     provider      | string |   true   |            |                                                                                                                               AI provider: `anthropic` or `openai`.                                                                                                                               |
+|          INPUT          |  TYPE  | REQUIRED |  DEFAULT   |                                                                                                                                                                                                                                                     DESCRIPTION                                                                                                                                                                                                                                                      |
+|-------------------------|--------|----------|------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|          agent          | string |  false   |            |      Optional name of a deployed managed <br>agent (loft-sh/ai-agents). When set, the action <br>creates a managed-agent session against that <br>agent instead of a one-shot Messages <br>call: prompt and input become the <br>session's opening user message, and the <br>agent's final output lands on the <br>result output. Anthropic-only — combined with <br>provider openai the step skips with <br>a reason. Expect minutes of latency <br>and session-scale cost instead of a <br>15s single call.        |
+|    anthropic-api-key    | string |  false   |            |                                                                                                                                                                                                                                 Anthropic API key. Required when provider=anthropic.                                                                                                                                                                                                                                 |
+|  anthropic-session-key  | string |  false   |            | Anthropic Console API key for the <br>workspace the agent is deployed in. <br>This is a different credential class <br>from anthropic-api-key: Messages-API and admin keys <br>cannot call the sessions API, and <br>workspace keys do not cross workspaces. <br>Required when agent is set, unless <br>the job provides workload identity federation <br>env vars (ANTHROPIC_FEDERATION_RULE_ID and friends), in which case <br>the SDK exchanges the job's OIDC <br>token itself and no static key <br>is needed.  |
+|         effort          | string |  false   | `"medium"` |                                                                                                                                                                                                                     Effort level (low | medium | high) — maps to <br>a provider-specific model.                                                                                                                                                                                                                      |
+|          input          | string |  false   |            |                                                                                                                                                            Optional data the model should act <br>on, appended to the prompt. Caller <br>sources it — a literal string, <br>a prior step output, or the <br>contents of a file read in <br>a prior step.                                                                                                                                                             |
+|     openai-api-key      | string |  false   |            |                                                                                                                                                                                                                                    OpenAI API key. Required when provider=openai.                                                                                                                                                                                                                                    |
+|      output-schema      | string |   true   |            |                                                                                                          JSON Schema (string) the model output <br>must conform to. Required. Structured output <br>is the contract — without a <br>schema the action skips. For `anthropic` this <br>becomes `output_format.schema` on the Messages API; for <br>`openai` it becomes `response_format.json_schema.schema`                                                                                                           |
+|                         |        |          |            |                                                                                                                                                                                                                                          on the Chat Completions <br>API.                                                                                                                                                                                                                                            |
+|         prompt          | string |   true   |            |                                                                                                                                                                                                                                     Instructions for the model. Passed verbatim.                                                                                                                                                                                                                                     |
+|        provider         | string |   true   |            |                                                                                                                                                                                                                                        AI provider: `anthropic` or `openai`.                                                                                                                                                                                                                                         |
+| session-timeout-seconds | string |  false   |  `"1200"`  |                                                                                                                                                                                            How long to wait for the <br>session to finish before giving up <br>with conclusion=failed. Only used when agent <br>is set.                                                                                                                                                                                              |
+|        vault-id         | string |  false   |            |                                                                                                           Optional vault id to attach to <br>the session. Agents whose MCP servers <br>authenticate through session-scoped vault credentials need <br>it or their MCP servers fail <br>to initialize. A vault id names <br>a resource, not a credential, so <br>it is safe to pass as <br>a plain input.                                                                                                             |
 
 <!-- AUTO-DOC-INPUT:END -->
 

--- a/.github/actions/ai-step/action.yml
+++ b/.github/actions/ai-step/action.yml
@@ -40,6 +40,43 @@ inputs:
   openai-api-key:
     description: 'OpenAI API key. Required when provider=openai.'
     required: false
+  agent:
+    description: |
+      Optional name of a deployed managed agent (loft-sh/ai-agents).
+      When set, the action creates a managed-agent session against that
+      agent instead of a one-shot Messages call: prompt and input become
+      the session's opening user message, and the agent's final output
+      lands on the result output. Anthropic-only — combined with
+      provider openai the step skips with a reason. Expect minutes of
+      latency and session-scale cost instead of a 15s single call.
+    required: false
+    default: ''
+  anthropic-session-key:
+    description: |
+      Anthropic Console API key for the workspace the agent is deployed
+      in. This is a different credential class from anthropic-api-key:
+      Messages-API and admin keys cannot call the sessions API, and
+      workspace keys do not cross workspaces. Required when agent is
+      set, unless the job provides workload identity federation env
+      vars (ANTHROPIC_FEDERATION_RULE_ID and friends), in which case
+      the SDK exchanges the job's OIDC token itself and no static key
+      is needed.
+    required: false
+  vault-id:
+    description: |
+      Optional vault id to attach to the session. Agents whose MCP
+      servers authenticate through session-scoped vault credentials
+      need it or their MCP servers fail to initialize. A vault id names
+      a resource, not a credential, so it is safe to pass as a plain
+      input.
+    required: false
+    default: ''
+  session-timeout-seconds:
+    description: |
+      How long to wait for the session to finish before giving up
+      with conclusion=failed. Only used when agent is set.
+    required: false
+    default: '1200'
 
 outputs:
   result:
@@ -64,20 +101,22 @@ runs:
         INPUT_PROVIDER: ${{ inputs.provider }}
         INPUT_EFFORT: ${{ inputs.effort }}
         INPUT_OUTPUT_SCHEMA: ${{ inputs.output-schema }}
+        INPUT_AGENT: ${{ inputs.agent }}
+        INPUT_ANTHROPIC_SESSION_KEY: ${{ inputs.anthropic-session-key }}
+        INPUT_SESSION_TIMEOUT: ${{ inputs.session-timeout-seconds }}
       run: ${{ github.action_path }}/src/resolve-config.sh
 
     - name: Install provider SDK
       if: steps.cfg.outputs.proceed == 'true'
       shell: bash
       env:
-        PROVIDER: ${{ inputs.provider }}
+        PACKAGES: ${{ steps.cfg.outputs.packages }}
       run: |
         set -euo pipefail
-        case "$PROVIDER" in
-          anthropic) python3 -m pip install --quiet --disable-pip-version-check anthropic ;;
-          openai)    python3 -m pip install --quiet --disable-pip-version-check openai ;;
-          *) echo "::error::unknown provider '$PROVIDER'"; exit 1 ;;
-        esac
+        # the resolver owns which packages each mode needs; this step
+        # only installs what it emitted
+        [ -n "$PACKAGES" ] || { echo "::error::resolver emitted no packages"; exit 1; }
+        echo "$PACKAGES" | xargs python3 -m pip install --quiet --disable-pip-version-check
 
     - name: Call provider
       id: run
@@ -85,12 +124,17 @@ runs:
       shell: bash
       env:
         INPUT_PROVIDER: ${{ inputs.provider }}
+        INPUT_MODE: ${{ steps.cfg.outputs.mode }}
         INPUT_MODEL: ${{ steps.cfg.outputs.model }}
         INPUT_PROMPT: ${{ inputs.prompt }}
         INPUT_INPUT: ${{ inputs.input }}
         INPUT_OUTPUT_SCHEMA: ${{ inputs.output-schema }}
         INPUT_ANTHROPIC_API_KEY: ${{ inputs.anthropic-api-key }}
         INPUT_OPENAI_API_KEY: ${{ inputs.openai-api-key }}
+        INPUT_AGENT: ${{ inputs.agent }}
+        INPUT_ANTHROPIC_SESSION_KEY: ${{ inputs.anthropic-session-key }}
+        INPUT_VAULT_ID: ${{ inputs.vault-id }}
+        INPUT_SESSION_TIMEOUT: ${{ inputs.session-timeout-seconds }}
       run: python3 ${{ github.action_path }}/src/run.py
 
     - name: Emit conclusion

--- a/.github/actions/ai-step/src/resolve-config.sh
+++ b/.github/actions/ai-step/src/resolve-config.sh
@@ -1,20 +1,30 @@
 #!/usr/bin/env bash
 # Validate caller inputs and resolve them into the concrete values the
-# downstream AI step needs: the provider-specific model id. All
-# conditional logic for the whole action lives here — YAML only
-# dispatches on outputs.
+# downstream AI step needs: the execution mode and, in single-call mode,
+# the provider-specific model id. All conditional logic for the whole
+# action lives here — YAML only dispatches on outputs.
 #
 # Required env: INPUT_PROVIDER, INPUT_EFFORT, INPUT_OUTPUT_SCHEMA
+# Optional env: INPUT_AGENT, INPUT_ANTHROPIC_SESSION_KEY, INPUT_SESSION_TIMEOUT
 # Writes to $GITHUB_OUTPUT:
 #   proceed=true|false  — whether the AI step should run
 #   reason=<string>     — one-line explanation (populated on skip)
-#   model=<string>      — provider-specific model identifier
+#   mode=single|session — session when INPUT_AGENT names a deployed agent
+#   model=<string>      — provider-specific model identifier (single mode
+#                         only; in session mode the deployed agent owns
+#                         its model, so this stays empty)
+#   packages=<string>   — space-separated pip packages the run step needs;
+#                         the install step consumes this verbatim so every
+#                         branch decision stays in this script
 # Always exits 0 — invalid input degrades to a skip, never hard-fails.
 set -euo pipefail
 
 : "${INPUT_PROVIDER:?INPUT_PROVIDER required}"
 : "${INPUT_EFFORT:?INPUT_EFFORT required}"
 : "${INPUT_OUTPUT_SCHEMA?INPUT_OUTPUT_SCHEMA required}"
+INPUT_AGENT="${INPUT_AGENT:-}"
+INPUT_ANTHROPIC_SESSION_KEY="${INPUT_ANTHROPIC_SESSION_KEY:-}"
+INPUT_SESSION_TIMEOUT="${INPUT_SESSION_TIMEOUT:-1200}"
 
 emit() {
   local k="$1" v="$2"
@@ -27,7 +37,9 @@ skip() {
   echo "::notice::ai-step: $reason"
   emit proceed false
   emit reason  "$reason"
+  emit mode    ""
   emit model   ""
+  emit packages ""
   exit 0
 }
 
@@ -36,7 +48,40 @@ if [ -z "${INPUT_OUTPUT_SCHEMA// }" ]; then
   skip "output-schema is required — structured output is the contract"
 fi
 
-# provider + effort → model
+# session mode: agent names a deployed managed agent. Anthropic-only, and
+# it needs the workspace-scoped session key — the Messages-API key cannot
+# call /v1/sessions. Effort is ignored: the deployed agent owns its model.
+if [ -n "${INPUT_AGENT// }" ]; then
+  if [ "$INPUT_PROVIDER" != "anthropic" ]; then
+    skip "agent mode is anthropic-only — provider '$INPUT_PROVIDER' has no managed-agent counterpart"
+  fi
+  # credential: an explicit workspace session key, or workload identity
+  # federation (DEVOPS-1019) — the SDK exchanges the caller-provided
+  # OIDC token itself when the ANTHROPIC_FEDERATION_* env vars are set,
+  # so no static key exists in that job at all.
+  if [ -z "${INPUT_ANTHROPIC_SESSION_KEY// }" ] && [ -z "${ANTHROPIC_FEDERATION_RULE_ID:-}" ]; then
+    skip "agent is set but no credential is available — pass anthropic-session-key, or set up workload identity federation (ANTHROPIC_FEDERATION_RULE_ID etc.) in the job env"
+  fi
+  case "$INPUT_SESSION_TIMEOUT" in
+    ''|*[!0-9]*|0) skip "invalid session-timeout-seconds '$INPUT_SESSION_TIMEOUT' — must be a positive integer" ;;
+  esac
+  emit proceed true
+  emit reason  ""
+  emit mode    session
+  emit model   ""
+  # jsonschema validates the agent's output against output-schema —
+  # sessions have no provider-side structured-output binding.
+  emit packages "anthropic jsonschema"
+  exit 0
+fi
+
+# a session key with no agent is almost certainly a half-wired session
+# mode; say so instead of letting the run step fail on the Messages key
+if [ -n "${INPUT_ANTHROPIC_SESSION_KEY// }" ]; then
+  echo "::warning::ai-step: anthropic-session-key is set but agent is empty — running single-call mode; set agent to target a deployed managed agent"
+fi
+
+# single-call mode: provider + effort → model
 case "$INPUT_PROVIDER:$INPUT_EFFORT" in
   anthropic:low)    model='claude-haiku-4-5' ;;
   anthropic:medium) model='claude-sonnet-4-6' ;;
@@ -51,4 +96,6 @@ esac
 
 emit proceed true
 emit reason  ""
+emit mode    single
 emit model   "$model"
+emit packages "$INPUT_PROVIDER"

--- a/.github/actions/ai-step/src/run.py
+++ b/.github/actions/ai-step/src/run.py
@@ -37,6 +37,11 @@ import time
 # loft-sh/ai-agents.
 BETA_HEADER = "managed-agents-2026-04-01"
 POLL_INTERVAL_S = 10
+# sessions.retrieve flips to idle slightly before the session.status_idle
+# event is visible in the event log (observed live on the DEVOPS-1352 wif
+# smoke, ai-agents run 32252874325), so the stop_reason lookup retries for
+# a bounded grace window instead of failing on the first empty read.
+STOP_REASON_GRACE_S = 60
 
 
 def enforce_strict(node):
@@ -241,11 +246,22 @@ def run_session(agent_name: str, user_content: str, api_key: str,
         if status == "terminated":
             fail_soft("session terminated before producing output")
 
-        idle = latest_event(client, session.id, "session.status_idle")
-        stop = getattr(getattr(idle, "stop_reason", None), "type", None)
+        stop = None
+        grace_deadline = time.time() + STOP_REASON_GRACE_S
+        while True:
+            idle = latest_event(client, session.id, "session.status_idle")
+            sr = getattr(idle, "stop_reason", None)
+            stop = sr if isinstance(sr, str) else getattr(sr, "type", None)
+            if stop is not None or time.time() >= grace_deadline:
+                break
+            time.sleep(POLL_INTERVAL_S)
         if stop != "end_turn":
+            recent = [getattr(e, "type", "?") for e in
+                      client.beta.sessions.events.list(session.id,
+                                                       order="desc", limit=10)]
             fail_soft(f"session stopped with stop_reason '{stop}' instead of "
-                      "end_turn — the agent did not complete its turn")
+                      f"end_turn — the agent did not complete its turn "
+                      f"(recent events: {recent})")
 
         msg = latest_event(client, session.id, "agent.message")
         if msg is None:

--- a/.github/actions/ai-step/src/run.py
+++ b/.github/actions/ai-step/src/run.py
@@ -1,20 +1,27 @@
 #!/usr/bin/env python3
 """Call the provider's chat API with response_format / output_format
-bound to the caller's JSON Schema. Writes the model's schema-conforming
+bound to the caller's JSON Schema, or (session mode) drive a deployed
+managed agent through one session turn. Writes the schema-conforming
 output to $GITHUB_OUTPUT as `result`.
 
 The action is advisory-only: any failure (bad schema, API error, empty
-content, non-JSON response) degrades to `conclusion=failed` with the
-upstream body preserved in the CI log. The caller decides how to react.
+content, non-JSON response, session timeout, non-end_turn stop) degrades
+to `conclusion=failed` with the upstream body preserved in the CI log.
+The caller decides how to react.
 
 Env in:
   INPUT_PROVIDER          anthropic | openai
-  INPUT_MODEL             provider-specific model id
+  INPUT_MODE              single | session (from resolve-config.sh)
+  INPUT_MODEL             provider-specific model id (single mode)
   INPUT_PROMPT            instructions
   INPUT_OUTPUT_SCHEMA     JSON Schema string
   INPUT_INPUT             optional data appended to the prompt
-  INPUT_ANTHROPIC_API_KEY required when provider=anthropic
+  INPUT_ANTHROPIC_API_KEY required when provider=anthropic (single mode)
   INPUT_OPENAI_API_KEY    required when provider=openai
+  INPUT_AGENT             deployed agent name (session mode)
+  INPUT_ANTHROPIC_SESSION_KEY workspace session key (session mode)
+  INPUT_VAULT_ID          optional vault to attach (session mode)
+  INPUT_SESSION_TIMEOUT   seconds to wait for the session (session mode)
 Env out ($GITHUB_OUTPUT):
   result                  the schema-conforming JSON string (or empty)
   conclusion              success | failed
@@ -24,6 +31,12 @@ from __future__ import annotations
 import json
 import os
 import sys
+import time
+
+# Managed agents GA beta header, same as pr-review/src/cma.py in
+# loft-sh/ai-agents.
+BETA_HEADER = "managed-agents-2026-04-01"
+POLL_INTERVAL_S = 10
 
 
 def enforce_strict(node):
@@ -135,9 +148,156 @@ def call_openai(model: str, user_content: str, schema: dict, api_key: str) -> st
     return text
 
 
+def latest_event(client, session_id: str, event_type: str):
+    """Newest event of one type on the session, or None."""
+    for ev in client.beta.sessions.events.list(
+        session_id, types=[event_type], order="desc", limit=1
+    ):
+        return ev
+    return None
+
+
+def run_session(agent_name: str, user_content: str, api_key: str,
+                vault_id: str, timeout_s: int) -> str:
+    """Drive one turn against a deployed managed agent: resolve the agent
+    by name, create a per-run environment, open a session (attaching the
+    vault when given), send the user message, poll session status until
+    it leaves running (ai-agents PR #81: a visible answer is not a
+    finished session, so never trust a stream idle event), gate on
+    stop_reason, and return the agent's final message text. The session
+    and environment are deleted on every path — a leaked CI session
+    keeps billing."""
+    from anthropic import Anthropic, APIError  # type: ignore
+
+    if api_key:
+        # GitHub only auto-masks values sourced from secrets.*; masking
+        # here scrubs the key from every log line no matter where the
+        # caller sourced it (workflow commands are intercepted by the
+        # runner, the value never lands in the log).
+        print(f"::add-mask::{api_key}")
+        client = Anthropic(api_key=api_key,
+                           default_headers={"anthropic-beta": BETA_HEADER})
+    else:
+        # No explicit key: let the SDK's credential chain resolve, which
+        # includes workload identity federation via the ANTHROPIC_*
+        # env vars (DEVOPS-1019). ANTHROPIC_API_KEY must be unset in the
+        # job or it outranks federation in that chain.
+        client = Anthropic(default_headers={"anthropic-beta": BETA_HEADER})
+
+    agent_id = None
+    try:
+        for a in client.beta.agents.list():
+            if getattr(a, "name", None) == agent_name:
+                agent_id = a.id
+                break
+    except APIError as e:
+        fail_soft(f"could not list agents: {e}", getattr(e, "body", ""))
+    except Exception as e:
+        fail_soft(f"agent lookup failed: {e}")
+    if agent_id is None:
+        fail_soft(f"agent '{agent_name}' not found — check the name and that "
+                  "the session credential belongs to the agent's workspace")
+
+    run_id = os.environ.get("GITHUB_RUN_ID", "local")
+    try:
+        # Networking is unrestricted like every deployed product's
+        # environment (ai-agents ensure_env): the API's narrower
+        # `limited` mode needs a per-agent host allowlist this generic
+        # trigger cannot know. Narrowing per caller is follow-up work.
+        env = client.beta.environments.create(
+            name=f"ai-step-{run_id}-{os.urandom(3).hex()}",
+            config={"type": "cloud", "networking": {"type": "unrestricted"}},
+        )
+    except APIError as e:
+        fail_soft(f"could not create environment: {e}", getattr(e, "body", ""))
+    except Exception as e:
+        fail_soft(f"environment creation failed: {e}")
+
+    session = None
+    try:
+        kwargs: dict = {"agent": agent_id, "environment_id": env.id,
+                        "title": f"ai-step {os.environ.get('GITHUB_REPOSITORY', '')}#{run_id}"}
+        if vault_id:
+            kwargs["vault_ids"] = [vault_id]
+        session = client.beta.sessions.create(**kwargs)
+        print(f"ai-step: session {session.id} against agent '{agent_name}'")
+        client.beta.sessions.events.send(
+            session.id,
+            events=[{"type": "user.message",
+                     "content": [{"type": "text", "text": user_content}]}],
+        )
+
+        deadline = time.time() + timeout_s
+        status = "running"
+        while time.time() < deadline:
+            status = client.beta.sessions.retrieve(session.id).status
+            if status in ("idle", "terminated"):
+                break
+            time.sleep(POLL_INTERVAL_S)
+
+        if status not in ("idle", "terminated"):
+            fail_soft(f"session still '{status}' after {timeout_s}s — raise "
+                      "session-timeout-seconds or pick a faster agent")
+        if status == "terminated":
+            fail_soft("session terminated before producing output")
+
+        idle = latest_event(client, session.id, "session.status_idle")
+        stop = getattr(getattr(idle, "stop_reason", None), "type", None)
+        if stop != "end_turn":
+            fail_soft(f"session stopped with stop_reason '{stop}' instead of "
+                      "end_turn — the agent did not complete its turn")
+
+        msg = latest_event(client, session.id, "agent.message")
+        if msg is None:
+            fail_soft("session went idle without an agent message")
+        return "\n".join(b.text for b in msg.content
+                         if getattr(b, "type", "") == "text")
+    except APIError as e:
+        fail_soft(f"anthropic API error during session: {e}",
+                  getattr(e, "body", ""))
+    except Exception as e:
+        # Mirror the APIError handler so an unexpected response shape
+        # (a retrieve without .status, an event without .stop_reason)
+        # still fails soft instead of exiting non-zero; SystemExit from
+        # fail_soft passes through untouched.
+        fail_soft(f"session mode failed unexpectedly: {e}")
+    finally:
+        # Delete unconditionally, even on the timeout path where the
+        # session may still be running: leaving it up spends tokens with
+        # nobody reading the result.
+        if session is not None:
+            try:
+                client.beta.sessions.delete(session.id)
+                print(f"ai-step: session {session.id} deleted")
+            except Exception as e:
+                print(f"::warning::ai-step: could not delete session "
+                      f"{session.id}: {e} — delete it in the Console")
+        try:
+            client.beta.environments.delete(env.id)
+        except Exception as e:
+            print(f"::warning::ai-step: could not delete environment "
+                  f"{env.id}: {e} — delete it in the Console")
+
+
+def validate_output(parsed, schema, text: str) -> None:
+    """Sessions have no provider-side structured-output binding, so the
+    schema contract is enforced here instead."""
+    try:
+        import jsonschema  # type: ignore
+    except ImportError:
+        fail_soft("jsonschema not installed — cannot validate session output")
+    try:
+        jsonschema.validate(parsed, schema)
+    except jsonschema.ValidationError as e:
+        fail_soft(f"agent output does not validate against output-schema: "
+                  f"{e.message}", text)
+    except jsonschema.SchemaError as e:
+        fail_soft(f"output-schema is not a valid JSON Schema: {e.message}")
+
+
 def main() -> None:
     provider = require("INPUT_PROVIDER")
-    model = require("INPUT_MODEL")
+    mode = os.environ.get("INPUT_MODE", "") or "single"
     prompt = require("INPUT_PROMPT")
     schema_raw = require("INPUT_OUTPUT_SCHEMA")
     input_text = os.environ.get("INPUT_INPUT", "")
@@ -147,9 +307,38 @@ def main() -> None:
     except json.JSONDecodeError as e:
         fail_soft(f"output-schema is not valid JSON: {e}")
 
-    enforce_strict(schema)
-
     user_content = f"{prompt}\n\n{input_text}" if input_text else prompt
+
+    if mode == "session":
+        agent_name = require("INPUT_AGENT")
+        api_key = os.environ.get("INPUT_ANTHROPIC_SESSION_KEY", "")
+        if not api_key and not os.environ.get("ANTHROPIC_FEDERATION_RULE_ID"):
+            fail_soft("agent is set but no credential is available — pass "
+                      "anthropic-session-key or set up workload identity "
+                      "federation in the job env")
+        try:
+            timeout_s = int(os.environ.get("INPUT_SESSION_TIMEOUT", "1200"))
+        except ValueError:
+            fail_soft("session-timeout-seconds must be an integer")
+        vault_id = os.environ.get("INPUT_VAULT_ID", "").strip()
+        text = run_session(agent_name, user_content, api_key, vault_id,
+                           timeout_s)
+        try:
+            parsed = json.loads(text)
+        except json.JSONDecodeError:
+            fail_soft("agent returned non-JSON content", text)
+        # Session output is validated against the caller's schema as
+        # written — enforce_strict is a provider-binding requirement,
+        # not part of the caller's contract.
+        validate_output(parsed, schema, text)
+        emit_block("result", text)
+        emit_kv("conclusion", "success")
+        print(f"ai-step: session against '{agent_name}' → success")
+        print(json.dumps(parsed, indent=2))
+        return
+
+    model = require("INPUT_MODEL")
+    enforce_strict(schema)
 
     if provider == "anthropic":
         api_key = os.environ.get("INPUT_ANTHROPIC_API_KEY", "")

--- a/.github/actions/ai-step/src/run.py
+++ b/.github/actions/ai-step/src/run.py
@@ -295,6 +295,21 @@ def run_session(agent_name: str, user_content: str, api_key: str,
                   f"{env.id}: {e} — delete it in the Console")
 
 
+def strip_fence(text: str) -> str:
+    """Sessions have no provider-side structured-output binding, and
+    agents habitually wrap their JSON in a markdown code fence (observed
+    live: sre-memory-curator on the DEVOPS-1352 wif smoke). Strip one
+    outer fence when present; anything else is returned as-is."""
+    t = text.strip()
+    if not t.startswith("```"):
+        return t
+    parts = t.split("\n", 1)
+    if len(parts) != 2 or not parts[1].rstrip().endswith("```"):
+        return t
+    inner = parts[1].rstrip()
+    return inner[: inner.rfind("```")].strip()
+
+
 def validate_output(parsed, schema, text: str) -> None:
     """Sessions have no provider-side structured-output binding, so the
     schema contract is enforced here instead."""
@@ -337,8 +352,8 @@ def main() -> None:
         except ValueError:
             fail_soft("session-timeout-seconds must be an integer")
         vault_id = os.environ.get("INPUT_VAULT_ID", "").strip()
-        text = run_session(agent_name, user_content, api_key, vault_id,
-                           timeout_s)
+        text = strip_fence(run_session(agent_name, user_content, api_key,
+                                       vault_id, timeout_s))
         try:
             parsed = json.loads(text)
         except json.JSONDecodeError:

--- a/.github/actions/ai-step/test/resolve-config.bats
+++ b/.github/actions/ai-step/test/resolve-config.bats
@@ -25,6 +25,21 @@ run_script() {
     GITHUB_OUTPUT="$GITHUB_OUTPUT" "$SCRIPT"
 }
 
+# Session-mode rows: agent set, optional session key and timeout.
+# ANTHROPIC_FEDERATION_RULE_ID is unset explicitly so the credential
+# rows stay deterministic regardless of the invoking environment.
+run_script_session() {
+  local provider="$1" agent="$2" key="$3" timeout="${4-1200}" effort="${5-medium}"
+  run env -u ANTHROPIC_FEDERATION_RULE_ID \
+    INPUT_PROVIDER="$provider" \
+    INPUT_EFFORT="$effort" \
+    INPUT_OUTPUT_SCHEMA="$SCHEMA" \
+    INPUT_AGENT="$agent" \
+    INPUT_ANTHROPIC_SESSION_KEY="$key" \
+    INPUT_SESSION_TIMEOUT="$timeout" \
+    GITHUB_OUTPUT="$GITHUB_OUTPUT" "$SCRIPT"
+}
+
 assert_kv() {
   local want="$1=$2" actual
   actual=$(grep "^$1=" "$GITHUB_OUTPUT" | tail -n1)
@@ -124,6 +139,126 @@ assert_kv() {
 
 @test "whitespace-only output-schema → proceed=false" {
   run_script anthropic medium "   "
+  [ "$status" -eq 0 ]
+  assert_kv proceed false
+  grep -q 'reason=.*output-schema is required' "$GITHUB_OUTPUT" || {
+    cat "$GITHUB_OUTPUT"; return 1;
+  }
+}
+
+# --- session mode (agent set) -------------------------------------------------
+
+@test "agent + anthropic + session key → proceed=true, mode=session, model empty" {
+  run_script_session anthropic pr-review-lead sk-test-key
+  [ "$status" -eq 0 ]
+  assert_kv proceed true
+  assert_kv mode session
+  assert_kv model ""
+  assert_kv packages "anthropic jsonschema"
+}
+
+@test "session key without agent → single mode with a warning naming the wiring" {
+  run env \
+    INPUT_PROVIDER=anthropic \
+    INPUT_EFFORT=medium \
+    INPUT_OUTPUT_SCHEMA="$SCHEMA" \
+    INPUT_ANTHROPIC_SESSION_KEY=sk-test-key \
+    GITHUB_OUTPUT="$GITHUB_OUTPUT" "$SCRIPT"
+  [ "$status" -eq 0 ]
+  assert_kv proceed true
+  assert_kv mode single
+  echo "$output" | grep -q '::warning::.*anthropic-session-key is set but agent is empty' || {
+    echo "$output"; return 1;
+  }
+}
+
+@test "agent + openai → proceed=false, reason says anthropic-only" {
+  run_script_session openai pr-review-lead sk-test-key
+  [ "$status" -eq 0 ]
+  assert_kv proceed false
+  grep -q 'reason=.*anthropic-only' "$GITHUB_OUTPUT" || {
+    cat "$GITHUB_OUTPUT"; return 1;
+  }
+}
+
+@test "agent + invalid provider → proceed=false, reason says anthropic-only" {
+  run_script_session bedrock pr-review-lead sk-test-key
+  [ "$status" -eq 0 ]
+  assert_kv proceed false
+  grep -q 'reason=.*anthropic-only' "$GITHUB_OUTPUT" || {
+    cat "$GITHUB_OUTPUT"; return 1;
+  }
+}
+
+@test "agent + anthropic without any credential → proceed=false, reason names both options" {
+  run_script_session anthropic pr-review-lead ""
+  [ "$status" -eq 0 ]
+  assert_kv proceed false
+  grep -q 'reason=.*anthropic-session-key' "$GITHUB_OUTPUT" || {
+    cat "$GITHUB_OUTPUT"; return 1;
+  }
+  grep -q 'reason=.*federation' "$GITHUB_OUTPUT" || {
+    cat "$GITHUB_OUTPUT"; return 1;
+  }
+}
+
+@test "agent + no key + federation env → proceed=true, mode=session" {
+  run env \
+    ANTHROPIC_FEDERATION_RULE_ID=fdrl_dummy_test_value \
+    INPUT_PROVIDER=anthropic \
+    INPUT_EFFORT=medium \
+    INPUT_OUTPUT_SCHEMA="$SCHEMA" \
+    INPUT_AGENT=pr-review-lead \
+    INPUT_ANTHROPIC_SESSION_KEY="" \
+    INPUT_SESSION_TIMEOUT=1200 \
+    GITHUB_OUTPUT="$GITHUB_OUTPUT" "$SCRIPT"
+  [ "$status" -eq 0 ]
+  assert_kv proceed true
+  assert_kv mode session
+  assert_kv packages "anthropic jsonschema"
+}
+
+@test "agent + non-numeric timeout → proceed=false, reason mentions timeout" {
+  run_script_session anthropic pr-review-lead sk-test-key never
+  [ "$status" -eq 0 ]
+  assert_kv proceed false
+  grep -q 'reason=.*session-timeout-seconds' "$GITHUB_OUTPUT" || {
+    cat "$GITHUB_OUTPUT"; return 1;
+  }
+}
+
+@test "agent + zero timeout → proceed=false" {
+  run_script_session anthropic pr-review-lead sk-test-key 0
+  [ "$status" -eq 0 ]
+  assert_kv proceed false
+}
+
+@test "agent ignores effort — invalid effort still proceeds in session mode" {
+  run_script_session anthropic pr-review-lead sk-test-key 1200 extreme
+  [ "$status" -eq 0 ]
+  assert_kv proceed true
+  assert_kv mode session
+}
+
+@test "agent unset → mode=single, packages track the provider" {
+  run_script anthropic medium
+  [ "$status" -eq 0 ]
+  assert_kv proceed true
+  assert_kv mode single
+  assert_kv packages anthropic
+  run_script openai medium
+  [ "$status" -eq 0 ]
+  assert_kv packages openai
+}
+
+@test "empty schema wins over agent — schema skip fires first" {
+  run env \
+    INPUT_PROVIDER=anthropic \
+    INPUT_EFFORT=medium \
+    INPUT_OUTPUT_SCHEMA="" \
+    INPUT_AGENT=pr-review-lead \
+    INPUT_ANTHROPIC_SESSION_KEY=sk-test-key \
+    GITHUB_OUTPUT="$GITHUB_OUTPUT" "$SCRIPT"
   [ "$status" -eq 0 ]
   assert_kv proceed false
   grep -q 'reason=.*output-schema is required' "$GITHUB_OUTPUT" || {

--- a/.github/actions/ai-step/test/test_run_session.py
+++ b/.github/actions/ai-step/test/test_run_session.py
@@ -36,11 +36,16 @@ class FakeClient:
 
     def __init__(self, *, agents=("sre-memory-curator",),
                  statuses=("idle",), stop_reason="end_turn",
-                 final_text='{"ok": true}', create_raises=None):
+                 final_text='{"ok": true}', create_raises=None,
+                 idle_event_delay=0, stop_is_str=False):
         self._statuses = list(statuses)
         self._stop = stop_reason
         self._final = final_text
         self._create_raises = create_raises
+        # status_idle event lags the status flip in the live API; this
+        # many lookups return empty before the event becomes visible
+        self._idle_delay = idle_event_delay
+        self._stop_is_str = stop_is_str
         self.deleted = {"sessions": [], "environments": []}
         self.sent = []
 
@@ -52,8 +57,13 @@ class FakeClient:
 
             def list(self, sid, types=None, order=None, limit=None):
                 if types == ["session.status_idle"]:
-                    stop = None if client._stop is None else _obj(type=client._stop)
-                    return iter([] if stop is None else [_obj(stop_reason=stop)])
+                    if client._idle_delay > 0:
+                        client._idle_delay -= 1
+                        return iter([])
+                    if client._stop is None:
+                        return iter([])
+                    stop = client._stop if client._stop_is_str else _obj(type=client._stop)
+                    return iter([_obj(stop_reason=stop)])
                 if types == ["agent.message"]:
                     if client._final is None:
                         return iter([])
@@ -107,6 +117,7 @@ def run_mod(monkeypatch, tmp_path):
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
     monkeypatch.setattr(mod, "POLL_INTERVAL_S", 0)
+    monkeypatch.setattr(mod, "STOP_REASON_GRACE_S", 0.3)
     mod._out_path = out
     mod._fake = fake
     return mod
@@ -168,6 +179,31 @@ def test_non_end_turn_stop_fails_soft(run_mod):
     assert e.value.code == 0
     _assert_failed(run_mod)
     assert client.deleted["sessions"] == ["sess_test"]
+
+
+def test_late_status_idle_event_is_awaited(run_mod):
+    # the live race (ai-agents run 32252874325): status flips to idle
+    # before the status_idle event is listable; the grace loop must
+    # absorb the lag instead of failing on the first empty read
+    client = FakeClient(idle_event_delay=2)
+    text = _run(run_mod, client)
+    assert text == '{"ok": true}'
+    assert client.deleted["sessions"] == ["sess_test"]
+
+
+def test_status_idle_event_never_appears_fails_soft(run_mod):
+    client = FakeClient(stop_reason=None)
+    with pytest.raises(SystemExit) as e:
+        _run(run_mod, client)
+    assert e.value.code == 0
+    _assert_failed(run_mod)
+    assert client.deleted["sessions"] == ["sess_test"]
+
+
+def test_string_stop_reason_is_accepted(run_mod):
+    client = FakeClient(stop_is_str=True)
+    text = _run(run_mod, client)
+    assert text == '{"ok": true}'
 
 
 def test_idle_without_message_fails_soft(run_mod):

--- a/.github/actions/ai-step/test/test_run_session.py
+++ b/.github/actions/ai-step/test/test_run_session.py
@@ -267,6 +267,17 @@ def test_happy_path_returns_text_and_deletes(run_mod):
     assert client.sent, "user.message was never sent"
 
 
+def test_strip_fence_unwraps_and_preserves(run_mod):
+    # observed live: agents fence their JSON since sessions have no
+    # provider-side structured-output binding
+    fenced = '```json\n{"ok": true}\n```'
+    assert run_mod.strip_fence(fenced) == '{"ok": true}'
+    assert run_mod.strip_fence('{"ok": true}') == '{"ok": true}'
+    assert run_mod.strip_fence("just prose") == "just prose"
+    unclosed = '```json\n{"ok": true}'
+    assert run_mod.strip_fence(unclosed) == unclosed
+
+
 def test_validate_output_rejects_schema_violation(run_mod):
     pytest.importorskip("jsonschema")
     with pytest.raises(SystemExit) as e:

--- a/.github/actions/ai-step/test/test_run_session.py
+++ b/.github/actions/ai-step/test/test_run_session.py
@@ -1,0 +1,251 @@
+"""Fail-soft matrix for run.py's session mode, driven against a stubbed
+anthropic SDK — no network, no tokens spent.
+
+Every fail path must end the process with exit code 0 (fail_soft raises
+SystemExit(0)), an empty `result` block and `conclusion=failed` in
+$GITHUB_OUTPUT, and — once the session or environment exists — a delete
+call for each. That is the action's advisory contract and DEVOPS-1352
+acceptance criteria 3, 4, and 6-9.
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+SRC = Path(__file__).resolve().parent.parent / "src" / "run.py"
+
+
+class FakeAPIError(Exception):
+    body = ""
+
+
+def _obj(**kw):
+    return types.SimpleNamespace(**kw)
+
+
+class FakeClient:
+    """Just enough of anthropic.Anthropic for run_session: agents.list,
+    environments.create/delete, sessions create/retrieve/delete and
+    events send/list. Tests steer it via the ctor knobs and read back
+    the `deleted` record."""
+
+    def __init__(self, *, agents=("sre-memory-curator",),
+                 statuses=("idle",), stop_reason="end_turn",
+                 final_text='{"ok": true}', create_raises=None):
+        self._statuses = list(statuses)
+        self._stop = stop_reason
+        self._final = final_text
+        self._create_raises = create_raises
+        self.deleted = {"sessions": [], "environments": []}
+        self.sent = []
+
+        client = self
+
+        class Events:
+            def send(self, sid, events):
+                client.sent.append(events)
+
+            def list(self, sid, types=None, order=None, limit=None):
+                if types == ["session.status_idle"]:
+                    stop = None if client._stop is None else _obj(type=client._stop)
+                    return iter([] if stop is None else [_obj(stop_reason=stop)])
+                if types == ["agent.message"]:
+                    if client._final is None:
+                        return iter([])
+                    return iter([_obj(content=[_obj(type="text", text=client._final)])])
+                return iter([])
+
+        class Sessions:
+            events = Events()
+
+            def create(self, **kw):
+                if client._create_raises:
+                    raise client._create_raises
+                return _obj(id="sess_test")
+
+            def retrieve(self, sid):
+                status = client._statuses.pop(0) if len(client._statuses) > 1 else client._statuses[0]
+                return _obj(status=status)
+
+            def delete(self, sid):
+                client.deleted["sessions"].append(sid)
+
+        class Environments:
+            def create(self, **kw):
+                return _obj(id="env_test")
+
+            def delete(self, eid):
+                client.deleted["environments"].append(eid)
+
+        class Agents:
+            def list(self):
+                return iter([_obj(name=n, id=f"agent_{n}") for n in agents])
+
+        self.beta = _obj(sessions=Sessions(), environments=Environments(), agents=Agents())
+
+
+@pytest.fixture()
+def run_mod(monkeypatch, tmp_path):
+    """Import run.py fresh with a stubbed anthropic module and a
+    per-test GITHUB_OUTPUT; poll delay zeroed so timeout tests spin
+    in real milliseconds."""
+    fake = types.ModuleType("anthropic")
+    fake.APIError = FakeAPIError
+    fake.Anthropic = None  # each test injects its FakeClient factory
+    monkeypatch.setitem(sys.modules, "anthropic", fake)
+
+    out = tmp_path / "github_output"
+    out.touch()
+    monkeypatch.setenv("GITHUB_OUTPUT", str(out))
+
+    spec = importlib.util.spec_from_file_location("ai_step_run", SRC)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    monkeypatch.setattr(mod, "POLL_INTERVAL_S", 0)
+    mod._out_path = out
+    mod._fake = fake
+    return mod
+
+
+def _wire(mod, client):
+    mod._fake.Anthropic = lambda **kw: client
+    return client
+
+
+def _output(mod):
+    return mod._out_path.read_text()
+
+
+def _assert_failed(mod):
+    text = _output(mod)
+    assert "conclusion=failed" in text
+    assert "result<<AISTEP_EOF\n\nAISTEP_EOF" in text
+
+
+def _run(mod, client, timeout_s=60):
+    _wire(mod, client)
+    return mod.run_session("sre-memory-curator", "hi", "sk-key", "", timeout_s)
+
+
+def test_agent_not_found_fails_soft(run_mod):
+    client = FakeClient(agents=("someone-else",))
+    with pytest.raises(SystemExit) as e:
+        _run(run_mod, client)
+    assert e.value.code == 0
+    _assert_failed(run_mod)
+    # nothing was created, so nothing to delete
+    assert client.deleted == {"sessions": [], "environments": []}
+
+
+def test_timeout_fails_soft_and_deletes(run_mod):
+    client = FakeClient(statuses=("running",))
+    with pytest.raises(SystemExit) as e:
+        _run(run_mod, client, timeout_s=0.2)
+    assert e.value.code == 0
+    _assert_failed(run_mod)
+    assert client.deleted["sessions"] == ["sess_test"]
+    assert client.deleted["environments"] == ["env_test"]
+
+
+def test_terminated_fails_soft_and_deletes(run_mod):
+    client = FakeClient(statuses=("running", "terminated"))
+    with pytest.raises(SystemExit) as e:
+        _run(run_mod, client)
+    assert e.value.code == 0
+    _assert_failed(run_mod)
+    assert client.deleted["sessions"] == ["sess_test"]
+
+
+def test_non_end_turn_stop_fails_soft(run_mod):
+    client = FakeClient(stop_reason="retries_exhausted")
+    with pytest.raises(SystemExit) as e:
+        _run(run_mod, client)
+    assert e.value.code == 0
+    _assert_failed(run_mod)
+    assert client.deleted["sessions"] == ["sess_test"]
+
+
+def test_idle_without_message_fails_soft(run_mod):
+    client = FakeClient(final_text=None)
+    with pytest.raises(SystemExit) as e:
+        _run(run_mod, client)
+    assert e.value.code == 0
+    _assert_failed(run_mod)
+
+
+def test_unexpected_exception_fails_soft_and_deletes_env(run_mod):
+    # blocker fix: a non-APIError inside the session sequence must not
+    # escape as a traceback / non-zero exit
+    client = FakeClient(create_raises=RuntimeError("kwarg rejected"))
+    with pytest.raises(SystemExit) as e:
+        _run(run_mod, client)
+    assert e.value.code == 0
+    _assert_failed(run_mod)
+    assert client.deleted["environments"] == ["env_test"]
+
+
+def test_session_key_is_masked_in_logs(run_mod, capsys):
+    # public-repo posture: the runner must scrub the key from every log
+    # line even when the caller did not source it from secrets.*
+    client = FakeClient()
+    _run(run_mod, client)
+    assert "::add-mask::sk-key" in capsys.readouterr().out
+
+
+def test_no_key_emits_no_mask_line(run_mod, capsys):
+    client = FakeClient()
+    _wire(run_mod, client)
+    run_mod.run_session("sre-memory-curator", "hi", "", "", 60)
+    assert "::add-mask::" not in capsys.readouterr().out
+
+
+def test_no_key_builds_client_for_sdk_credential_chain(run_mod):
+    # federation fallback: with no session key the client must be built
+    # WITHOUT api_key so the SDK's credential chain (workload identity
+    # federation env vars) can resolve the credential
+    captured = {}
+    client = FakeClient(statuses=("running", "idle"))
+
+    def factory(**kw):
+        captured.update(kw)
+        return client
+
+    run_mod._fake.Anthropic = factory
+    text = run_mod.run_session("sre-memory-curator", "hi", "", "", 60)
+    assert text == '{"ok": true}'
+    assert "api_key" not in captured
+    assert client.deleted["sessions"] == ["sess_test"]
+
+
+def test_happy_path_returns_text_and_deletes(run_mod):
+    client = FakeClient(statuses=("running", "idle"), final_text='{"ok": true}')
+    text = _run(run_mod, client)
+    assert text == '{"ok": true}'
+    assert client.deleted["sessions"] == ["sess_test"]
+    assert client.deleted["environments"] == ["env_test"]
+    assert client.sent, "user.message was never sent"
+
+
+def test_validate_output_rejects_schema_violation(run_mod):
+    pytest.importorskip("jsonschema")
+    with pytest.raises(SystemExit) as e:
+        run_mod.validate_output({"ok": "yes"},
+                                {"type": "object",
+                                 "properties": {"ok": {"type": "boolean"}}},
+                                '{"ok": "yes"}')
+    assert e.value.code == 0
+    _assert_failed(run_mod)
+
+
+def test_validate_output_accepts_conforming(run_mod):
+    pytest.importorskip("jsonschema")
+    run_mod.validate_output({"ok": True},
+                            {"type": "object",
+                             "properties": {"ok": {"type": "boolean"}}},
+                            '{"ok": true}')
+    assert "conclusion=failed" not in _output(run_mod)

--- a/.github/actions/comment-triggered-check/README.md
+++ b/.github/actions/comment-triggered-check/README.md
@@ -148,7 +148,7 @@ commenter's access is read from the event payload, not from an API call.
 |   check-name    | string |                                                                                                                                                                                                       Display name of the check-run, sanitized <br>and length-bounded.                                                                                                                                                                                                        |
 |  check-run-id   | string |                                                                                                                                                                                        Id of the opened check-run. Empty <br>when nothing was opened; gate the <br>finish job on it.                                                                                                                                                                                          |
 |   conclusion    | string |                                                                                                                                                                                                             finish mode. The conclusion that was <br>published.                                                                                                                                                                                                               |
-| concurrency-key | string |                                                                                                                                                                                          Filter reduced to a lowercase slug, <br>safe to interpolate into a concurrency <br>group.                                                                                                                                                                                            |
+| concurrency-key | string |                                                                                  Filter reduced to a lowercase slug <br>plus an eight-character digest of the <br>normalized filter, safe to interpolate into <br>a concurrency group. The digest is <br>not decoration: the slug alone drops <br>punctuation, so "a && b" and <br>"a || b" would share a <br>group and cancel each other.                                                                                    |
 |     filter      | string |                                                                                                                                                                                         Argument string with whitespace normalized. This <br>is what to pass to the <br>test runner.                                                                                                                                                                                          |
 |    head-sha     | string |                                                                                                                                                                                                Resolved head commit of the pull <br>request. The event does not carry <br>it.                                                                                                                                                                                                 |
 |     matched     | string |                                                                                                                                                                                                          "true" when the comment opened with <br>the command word.                                                                                                                                                                                                            |
@@ -245,9 +245,12 @@ command, and it cost three API calls plus a state machine whose own failure
 modes were worse than the problem.
 
 It matters because anything waiting on all of a commit's check-runs, including
-`auto-approve-bot-prs`, waits on a stuck one indefinitely. The recovery path is
-to re-run the workflow from the Actions tab, which re-runs `finish`, or to close
-the check by hand. The error message says so.
+`auto-approve-bot-prs`, waits on a stuck one indefinitely.
+
+The recovery path is **"Re-run failed jobs"**, not "Re-run all jobs". The
+narrow one re-runs `finish` alone and reuses the check-run id from `prepare`,
+whose outputs are preserved; the broad one runs `start` again and opens a
+second check-run for the same filter. The error message names the distinction.
 
 ## Reporting failures to the author
 

--- a/.github/actions/comment-triggered-check/README.md
+++ b/.github/actions/comment-triggered-check/README.md
@@ -1,0 +1,262 @@
+# Comment-triggered check
+
+Turns a pull request comment such as `/test snapshots` into a check-run on the
+pull request's head commit, and completes that check-run when the caller's work
+finishes.
+
+The action never runs tests. It decides whether a command should run, resolves
+the pull request identity that the event does not carry, and owns the check-run
+lifecycle. What runs in between is entirely the caller's business, which is why
+this lives here and the e2e half lives in the product repo.
+
+## Why the check-run is created through the API
+
+An `issue_comment` run has `GITHUB_SHA` set to the last commit on the default
+branch and `GITHUB_REF` set to the default branch. Every check-run GitHub
+publishes automatically for such a workflow therefore attaches to the default
+branch and is invisible on the pull request. Creating one against the resolved
+head SHA is the only way to get a row the reviewer can see, and it is a
+consequence of the trigger rather than a stylistic choice.
+
+The same fact is why `head-sha` and `base-ref` are outputs. Nothing downstream
+can infer them: a plain `actions/checkout` in a job of this workflow takes the
+default branch, and `github.base_ref` is empty.
+
+## Security boundary: same-repository only
+
+`issue_comment` is a privileged trigger. It runs from the default branch of the
+base repository with that repository's secrets and a write token, so a workflow
+that checks out and executes pull request code from a fork hands both to whoever
+opened the fork. GitHub's guidance is explicit that privileged workflows "must
+not explicitly check out untrusted code, including from pull request forks".
+
+So the fork test is a security boundary, not a capability gap, and `start`
+performs it before emitting anything a caller would act on. Keep the caller's
+checkout gated on `should-run`.
+
+## Who may run it
+
+From `author_association` in the event payload: `OWNER`, `MEMBER` and
+`COLLABORATOR` may, anything else may not, and an empty value is a no rather
+than a default yes.
+
+Be precise about what that means, because the output is named `should-run` and
+could be read as more than it is. An association is not a permission level.
+`MEMBER` means organization membership, not access to this repository, and
+`COLLABORATOR` says someone was added without saying at what level, so a
+read-only collaborator passes. This is deliberately coarser than the
+collaborator permission endpoint, which would cost an API call and a token
+scope. Because the command is same-repo only, the cost of the coarseness is
+runner time rather than access. Swap in the precise check if that stops being
+true.
+
+## The two modes
+
+`start` parses the comment, authorizes the commenter, resolves the pull request,
+and opens the check-run. Two API calls, and none at all for a comment that is
+not a command.
+
+`finish` resolves the terminal outcome and completes it. Give it the check-run
+id from `start` and the raw job results; it computes the conclusion so the
+matrix lives in a tested script rather than in workflow YAML.
+
+## The outcome matrix fails closed
+
+| Condition | Conclusion |
+| --- | --- |
+| `report-conclusion` is set and recognised | that value. **The only path to `neutral`** |
+| the suite or the build was cancelled | `cancelled` |
+| anything else | `failure` |
+
+Two mappings are deliberately absent, and they are the point.
+
+An empty report after the job ran does **not** become `cancelled`. That state
+also covers a failed checkout, setup, artifact download or cloud login, and
+`cancelled` is not a cheap default: the `auto-approve-bot-prs` action holds a
+cancelled check while it waits for a replacement and then refuses approval, so a
+mis-mapped `cancelled` stalls auto-approve instead of failing cleanly.
+
+A skipped suite after a successful build does **not** become `neutral`, because
+`neutral` is an acceptable verdict and an unexplained skip is not an acceptable
+outcome. Report `neutral` only from something that actually inspected the run,
+such as a test report saying zero specs matched.
+
+Values outside `success failure neutral cancelled timed_out` are rejected with a
+warning and fail closed, so an unexpected value can never read as green.
+
+## Repeated commands are GitHub's job, not this action's
+
+Typing the same command twice should not build twice, but the action does not
+deduplicate. Give the caller's suite job a `concurrency` group keyed on the
+repository, the pull request and the filter, with `cancel-in-progress: true`.
+GitHub then supersedes the older run, and the superseded job still triggers the
+caller's `always()` finish job, which closes its check-run as `cancelled`.
+
+This was originally built here instead, and it was a mistake worth recording.
+Deduplicating in the action meant listing check-runs, resolving the workflow run
+behind each one, and closing the orphans left by lost runners, which needed
+three extra API calls, a run id smuggled through `external_id`, a staleness
+rule, and a `queue: max` on the calling job to close the check-then-create race
+it introduced. Every failure mode in that machinery ended the same way: starting
+a duplicate build, the exact thing it existed to prevent. The platform already
+does this correctly.
+
+The one thing lost is that a repeat cancels the running suite rather than
+replying "already running". That is the same behaviour a new push already gets
+on the main pull request gate, so it is at least consistent.
+
+## Permissions
+
+The calling job needs `checks: write` to create and complete the check-run, and
+`pull-requests: read` to resolve the head SHA and base ref. That is all: the
+commenter's access is read from the event payload, not from an API call.
+
+## Inputs
+
+<!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
+
+|       INPUT        |  TYPE  | REQUIRED |           DEFAULT            |                                                                                                           DESCRIPTION                                                                                                            |
+|--------------------|--------|----------|------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| author-association | string |  false   |                              | start mode. How the commenter relates <br>to the repository. Pass the github.event.comment.author_association <br>context. OWNER, MEMBER and COLLABORATOR may <br>run the command; anything else, including <br>empty, may not.  |
+|    build-result    | string |  false   |                              |                                                                            finish mode. Result of the build <br>job. Pass the matching needs result.                                                                             |
+| check-name-prefix  | string |  false   |           `"e2e"`            |                                                                             start mode. Prefix for the check-run <br>name; the filter is appended.                                                                               |
+|    check-run-id    | string |  false   |                              |                                                          finish mode. The id returned by <br>start mode. Empty is not an <br>error; it means no check was <br>opened.                                                            |
+|      command       | string |  false   |          `"/test"`           |                                                                               Command word that must open the <br>comment, on its own first line.                                                                                |
+|   comment-author   | string |  false   |                              |                                                                    start mode. Login of the commenter. <br>Pass the github.event.comment.user.login context.                                                                     |
+|    comment-body    | string |  false   |                              |                                                                          start mode. The comment text. Pass <br>the github.event.comment.body context.                                                                           |
+|    details-url     | string |  false   |                              |                                                                                    finish mode. Link target for the <br>completed check-run.                                                                                     |
+|    github-token    | string |  false   |   `"${{ github.token }}"`    |                                                                     Token for gh. The calling job <br>must grant checks: write and pull-requests: <br>read.                                                                      |
+|        mode        | string |   true   |                              |                                                                                                   Either "start" or "finish".                                                                                                    |
+|     pr-number      | string |  false   |                              |                                                                        start mode. Pull request number. Pass <br>the github.event.issue.number context.                                                                          |
+|        repo        | string |  false   | `"${{ github.repository }}"` |                                                                                                  Repository in owner/name form.                                                                                                  |
+| report-conclusion  | string |  false   |                              |                                         finish mode. What the test run <br>declared about itself, parsed from its <br>report. The only input that can <br>produce a neutral conclusion.                                          |
+|       run-id       | string |  false   |                              |                                                                  start mode. Used to build the <br>check-run details link. Pass the github.run_id <br>context.                                                                   |
+|     server-url     | string |  false   |    `"https://github.com"`    |                                                           start mode. Base URL used to <br>build the check-run details link. Pass <br>the github.server_url context.                                                             |
+|    suite-result    | string |  false   |                              |                                                                            finish mode. Result of the suite <br>job. Pass the matching needs result.                                                                             |
+|      summary       | string |  false   |                              |                                                                finish mode. Markdown body for the <br>completed check-run. Defaults to the two <br>job results.                                                                  |
+
+<!-- AUTO-DOC-INPUT:END -->
+
+## Outputs
+
+<!-- AUTO-DOC-OUTPUT:START - Do not remove or modify this section -->
+
+|     OUTPUT      |  TYPE  |                                                                                                                                                                                                                                  DESCRIPTION                                                                                                                                                                                                                                  |
+|-----------------|--------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|      args       | string |                                                                                                                                                                                                           Raw argument string that followed the <br>command word.                                                                                                                                                                                                             |
+|    base-ref     | string |                                                                                                                                                                                            Resolved base branch of the pull <br>request. The event does not carry <br>it either.                                                                                                                                                                                              |
+|   check-name    | string |                                                                                                                                                                                                       Display name of the check-run, sanitized <br>and length-bounded.                                                                                                                                                                                                        |
+|  check-run-id   | string |                                                                                                                                                                                        Id of the opened check-run. Empty <br>when nothing was opened; gate the <br>finish job on it.                                                                                                                                                                                          |
+|   conclusion    | string |                                                                                                                                                                                                             finish mode. The conclusion that was <br>published.                                                                                                                                                                                                               |
+| concurrency-key | string |                                                                                                                                                                                          Filter reduced to a lowercase slug, <br>safe to interpolate into a concurrency <br>group.                                                                                                                                                                                            |
+|     filter      | string |                                                                                                                                                                                         Argument string with whitespace normalized. This <br>is what to pass to the <br>test runner.                                                                                                                                                                                          |
+|    head-sha     | string |                                                                                                                                                                                                Resolved head commit of the pull <br>request. The event does not carry <br>it.                                                                                                                                                                                                 |
+|     matched     | string |                                                                                                                                                                                                          "true" when the comment opened with <br>the command word.                                                                                                                                                                                                            |
+|     reason      | string |                                                                                                                                      Why the command will not run: <br>fork, insufficient-permission, empty-filter, not-a-pull-request, pull-request-closed, pull-request-unreadable, <br>or check-run-not-created. Empty when it will.                                                                                                                                       |
+|   should-run    | string | The caller's execution gate. "true" only <br>when a check-run was actually opened, <br>so it is false for a <br>comment that was not a command, <br>an empty filter, a fork, a <br>closed or unreadable pull request, a <br>rejected author_association, and a failed check-run <br>creation. Read reason for which. Note <br>the association test is not a <br>permission check: MEMBER means organization membership, <br>and COLLABORATOR does not say at <br>what level.  |
+
+<!-- AUTO-DOC-OUTPUT:END -->
+
+## Usage
+
+```yaml
+name: Test command
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  checks: write
+  pull-requests: read
+  contents: read
+
+jobs:
+  prepare:
+    # Cheap pre-filter so the job does not start for every comment in the repo.
+    if: github.event.issue.pull_request && startsWith(github.event.comment.body, '/test')
+    runs-on: ubuntu-latest
+    outputs:
+      should-run: ${{ steps.cmd.outputs.should-run }}
+      filter: ${{ steps.cmd.outputs.filter }}
+      head-sha: ${{ steps.cmd.outputs.head-sha }}
+      base-ref: ${{ steps.cmd.outputs.base-ref }}
+      key: ${{ steps.cmd.outputs.concurrency-key }}
+      check-run-id: ${{ steps.cmd.outputs.check-run-id }}
+    steps:
+      - uses: loft-sh/github-actions/.github/actions/comment-triggered-check@comment-triggered-check/v1
+        id: cmd
+        with:
+          mode: start
+          comment-body: ${{ github.event.comment.body }}
+          comment-author: ${{ github.event.comment.user.login }}
+          author-association: ${{ github.event.comment.author_association }}
+          pr-number: ${{ github.event.issue.number }}
+          run-id: ${{ github.run_id }}
+          server-url: ${{ github.server_url }}
+
+  suite:
+    needs: [prepare]
+    if: needs.prepare.outputs.should-run == 'true'
+    runs-on: ubuntu-latest
+    # This is the deduplication. A second identical command supersedes this run,
+    # and the finish job below still closes the superseded check-run.
+    concurrency:
+      group: comment-triggered-check-suite-${{ github.event.issue.number }}-${{ needs.prepare.outputs.key }}
+      cancel-in-progress: true
+    outputs:
+      check-conclusion: ${{ steps.run.outputs.check-conclusion }}
+    steps:
+      - id: run
+        run: echo "... build and test at needs.prepare.outputs.head-sha ..."
+
+  finish:
+    needs: [prepare, suite]
+    if: always() && needs.prepare.outputs.check-run-id != ''
+    runs-on: ubuntu-latest
+    steps:
+      - uses: loft-sh/github-actions/.github/actions/comment-triggered-check@comment-triggered-check/v1
+        with:
+          mode: finish
+          check-run-id: ${{ needs.prepare.outputs.check-run-id }}
+          report-conclusion: ${{ needs.suite.outputs.check-conclusion }}
+          suite-result: ${{ needs.suite.result }}
+          details-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+```
+
+A caller with a separate build job adds it to `needs` and passes
+`build-result: ${{ needs.build.result }}`, which lets a cancelled build be
+reported as `cancelled` rather than falling into the catch-all.
+
+The `finish` job needs every job whose result it reads, and it needs the id
+guard because `prepare` legitimately opens no check-run for a comment that was
+not a command, an unauthorized commenter, or a fork. It must also stay on
+`always()`: closing the check when the suite was cancelled is what keeps a
+superseded run from leaving one open.
+
+## What happens if `finish` cannot publish
+
+The PATCH is retried a few times, because this is the last chance to close the
+check-run and a transient API failure is the likely cause. If every attempt
+fails, or the runner is lost before the job runs at all, the check-run stays
+`in_progress` and nothing reconciles it. That is an accepted residual risk
+rather than an oversight: the alternative was a reconciliation pass on the next
+command, and it cost three API calls plus a state machine whose own failure
+modes were worse than the problem.
+
+It matters because anything waiting on all of a commit's check-runs, including
+`auto-approve-bot-prs`, waits on a stuck one indefinitely. The recovery path is
+to re-run the workflow from the Actions tab, which re-runs `finish`, or to close
+the check by hand. The error message says so.
+
+## Reporting failures to the author
+
+The action deliberately posts no comments. It emits `reason` and leaves
+messaging to the caller, which keeps it usable by repositories that surface
+results differently. Pair it with `sticky-pr-comment` when the caller wants a
+comment, and key the marker on the filter so concurrent commands do not
+overwrite each other's links.
+
+`reason` values: `fork`, `insufficient-permission`, `empty-filter`,
+`not-a-pull-request`, `pull-request-closed`, `pull-request-unreadable`,
+`check-run-not-created`. Empty when the command will run.

--- a/.github/actions/comment-triggered-check/README.md
+++ b/.github/actions/comment-triggered-check/README.md
@@ -36,8 +36,27 @@ flags that as `actions/untrusted-checkout-toctou`, correctly.
 Keeping this action's jobs free of any checkout and dispatching the actual work
 to a `workflow_dispatch` run on the head branch avoids it: that run is not a
 privileged trigger, and its trust model is the one a normal pull request run
-already has. Pass the check-run id along and let the dispatched workflow finish
-it.
+already has.
+
+Pass three things along, not one. The check-run id, so the dispatched workflow
+can finish what this one opened, and **both** refs, because they answer
+different questions:
+
+| output | what it is for |
+| --- | --- |
+| `head-ref` | the `--ref` of the dispatch. It selects which copy of the workflow runs, and it must be a branch or tag, never a SHA |
+| `head-sha` | the commit the check-run was opened on, and the commit the run must actually test |
+
+They can disagree. `head-sha` is resolved from the API when the comment arrives;
+`--ref` names a branch, and `github.sha` in the dispatched run is whatever that
+branch pointed at when the run started. A push in between means the run tests a
+different commit and publishes its verdict against the one in the check-run,
+which reads as a result for code that was never tested.
+
+So the dispatched workflow should take `head-sha` as an input and compare it
+against `github.sha` before doing any work, stopping if they differ. Pinning
+every checkout to `head-sha` is the thorough version; refusing to run is the
+cheap one, and either beats reporting the wrong commit.
 
 ## Security boundary: same-repository only
 

--- a/.github/actions/comment-triggered-check/README.md
+++ b/.github/actions/comment-triggered-check/README.md
@@ -18,9 +18,26 @@ branch and is invisible on the pull request. Creating one against the resolved
 head SHA is the only way to get a row the reviewer can see, and it is a
 consequence of the trigger rather than a stylistic choice.
 
-The same fact is why `head-sha` and `base-ref` are outputs. Nothing downstream
-can infer them: a plain `actions/checkout` in a job of this workflow takes the
-default branch, and `github.base_ref` is empty.
+The same fact is why `head-sha`, `head-ref` and `base-ref` are outputs. Nothing
+downstream can infer them: a plain `actions/checkout` in a job of this workflow
+takes the default branch, and `github.base_ref` is empty. `head-ref` is the
+branch rather than the commit, which a caller needs when it hands the real work
+to a separate, non-privileged run: `gh workflow run --ref` takes a branch or a
+tag and never a SHA.
+
+## Handing the work to a non-privileged run
+
+Worth doing, and the reason `head-ref` exists. A workflow triggered by
+`issue_comment` is privileged, so if it checks out the pull request and then
+calls a local action with `uses: ./...`, the *action definition* comes from the
+pull request and executes with repository secrets and a write token. CodeQL
+flags that as `actions/untrusted-checkout-toctou`, correctly.
+
+Keeping this action's jobs free of any checkout and dispatching the actual work
+to a `workflow_dispatch` run on the head branch avoids it: that run is not a
+privileged trigger, and its trust model is the one a normal pull request run
+already has. Pass the check-run id along and let the dispatched workflow finish
+it.
 
 ## Security boundary: same-repository only
 
@@ -150,6 +167,7 @@ commenter's access is read from the event payload, not from an API call.
 |   conclusion    | string |                                                                                                                                                                                                             finish mode. The conclusion that was <br>published.                                                                                                                                                                                                               |
 | concurrency-key | string |                                                                                  Filter reduced to a lowercase slug <br>plus an eight-character digest of the <br>normalized filter, safe to interpolate into <br>a concurrency group. The digest is <br>not decoration: the slug alone drops <br>punctuation, so "a && b" and <br>"a || b" would share a <br>group and cancel each other.                                                                                    |
 |     filter      | string |                                                                                                                                                                                         Argument string with whitespace normalized. This <br>is what to pass to the <br>test runner.                                                                                                                                                                                          |
+|    head-ref     | string |                                                                                                                                    Resolved head BRANCH of the pull <br>request. Needed by a caller that <br>dispatches the work to a non-privileged <br>run, because `gh workflow run --ref` takes a branch <br>or tag and never a SHA.                                                                                                                                      |
 |    head-sha     | string |                                                                                                                                                                                                Resolved head commit of the pull <br>request. The event does not carry <br>it.                                                                                                                                                                                                 |
 |     matched     | string |                                                                                                                                                                                                          "true" when the comment opened with <br>the command word.                                                                                                                                                                                                            |
 |     reason      | string |                                                                                                                                      Why the command will not run: <br>fork, insufficient-permission, empty-filter, not-a-pull-request, pull-request-closed, pull-request-unreadable, <br>or check-run-not-created. Empty when it will.                                                                                                                                       |

--- a/.github/actions/comment-triggered-check/action.yml
+++ b/.github/actions/comment-triggered-check/action.yml
@@ -1,0 +1,160 @@
+name: Comment-triggered check
+description: |
+  Turns a pull request comment such as `/test snapshots` into a check-run on the
+  pull request's head commit, and completes that check-run when the caller's
+  work finishes. Domain-agnostic: it never runs tests, it decides whether a
+  command should run, resolves the pull request identity the event does not
+  carry, and owns the check-run lifecycle.
+
+  Two modes. `start` parses the comment, authorizes the commenter, resolves the
+  head SHA and base ref, and opens the check-run. `finish` resolves the terminal
+  outcome with a fail-closed matrix and completes it. Repeated commands are
+  deduplicated by the caller's concurrency group, not here.
+inputs:
+  mode:
+    description: 'Either "start" or "finish".'
+    required: true
+  command:
+    description: 'Command word that must open the comment, on its own first line.'
+    required: false
+    default: '/test'
+  comment-body:
+    description: 'start mode. The comment text. Pass the github.event.comment.body context.'
+    required: false
+    default: ''
+  comment-author:
+    description: 'start mode. Login of the commenter. Pass the github.event.comment.user.login context.'
+    required: false
+    default: ''
+  author-association:
+    description: 'start mode. How the commenter relates to the repository. Pass the github.event.comment.author_association context. OWNER, MEMBER and COLLABORATOR may run the command; anything else, including empty, may not.'
+    required: false
+    default: ''
+  pr-number:
+    description: 'start mode. Pull request number. Pass the github.event.issue.number context.'
+    required: false
+    default: ''
+  repo:
+    description: 'Repository in owner/name form.'
+    required: false
+    default: ${{ github.repository }}
+  check-name-prefix:
+    description: 'start mode. Prefix for the check-run name; the filter is appended.'
+    required: false
+    default: 'e2e'
+  run-id:
+    description: 'start mode. Used to build the check-run details link. Pass the github.run_id context.'
+    required: false
+    default: ''
+  server-url:
+    description: 'start mode. Base URL used to build the check-run details link. Pass the github.server_url context.'
+    required: false
+    default: 'https://github.com'
+  check-run-id:
+    description: 'finish mode. The id returned by start mode. Empty is not an error; it means no check was opened.'
+    required: false
+    default: ''
+  report-conclusion:
+    description: 'finish mode. What the test run declared about itself, parsed from its report. The only input that can produce a neutral conclusion.'
+    required: false
+    default: ''
+  build-result:
+    description: 'finish mode. Result of the build job. Pass the matching needs result.'
+    required: false
+    default: ''
+  suite-result:
+    description: 'finish mode. Result of the suite job. Pass the matching needs result.'
+    required: false
+    default: ''
+  summary:
+    description: 'finish mode. Markdown body for the completed check-run. Defaults to the two job results.'
+    required: false
+    default: ''
+  details-url:
+    description: 'finish mode. Link target for the completed check-run.'
+    required: false
+    default: ''
+  github-token:
+    description: 'Token for gh. The calling job must grant checks: write and pull-requests: read.'
+    required: false
+    default: ${{ github.token }}
+outputs:
+  matched:
+    description: '"true" when the comment opened with the command word.'
+    value: ${{ steps.start.outputs.matched }}
+  args:
+    description: 'Raw argument string that followed the command word.'
+    value: ${{ steps.start.outputs.args }}
+  filter:
+    description: 'Argument string with whitespace normalized. This is what to pass to the test runner.'
+    value: ${{ steps.start.outputs.filter }}
+  should-run:
+    description: 'The caller''s execution gate. "true" only when a check-run was actually opened, so it is false for a comment that was not a command, an empty filter, a fork, a closed or unreadable pull request, a rejected author_association, and a failed check-run creation. Read reason for which. Note the association test is not a permission check: MEMBER means organization membership, and COLLABORATOR does not say at what level.'
+    value: ${{ steps.start.outputs.should-run }}
+  reason:
+    description: 'Why the command will not run: fork, insufficient-permission, empty-filter, not-a-pull-request, pull-request-closed, pull-request-unreadable, or check-run-not-created. Empty when it will.'
+    value: ${{ steps.start.outputs.reason }}
+  head-sha:
+    description: 'Resolved head commit of the pull request. The event does not carry it.'
+    value: ${{ steps.start.outputs.head-sha }}
+  base-ref:
+    description: 'Resolved base branch of the pull request. The event does not carry it either.'
+    value: ${{ steps.start.outputs.base-ref }}
+  concurrency-key:
+    description: 'Filter reduced to a lowercase slug, safe to interpolate into a concurrency group.'
+    value: ${{ steps.start.outputs.concurrency-key }}
+  check-name:
+    description: 'Display name of the check-run, sanitized and length-bounded.'
+    value: ${{ steps.start.outputs.check-name }}
+  check-run-id:
+    description: 'Id of the opened check-run. Empty when nothing was opened; gate the finish job on it.'
+    value: ${{ steps.start.outputs.check-run-id }}
+  conclusion:
+    description: 'finish mode. The conclusion that was published.'
+    value: ${{ steps.finish.outputs.conclusion }}
+runs:
+  using: composite
+  steps:
+    - name: Reject an unknown mode
+      if: inputs.mode != 'start' && inputs.mode != 'finish'
+      shell: bash
+      env:
+        INPUT_MODE: ${{ inputs.mode }}
+      run: |
+        echo "::error::mode must be 'start' or 'finish', got '${INPUT_MODE}'"
+        exit 1
+
+    - name: Start
+      id: start
+      if: inputs.mode == 'start'
+      shell: bash
+      env:
+        INPUT_COMMAND: ${{ inputs.command }}
+        INPUT_COMMENT_BODY: ${{ inputs.comment-body }}
+        INPUT_COMMENT_AUTHOR: ${{ inputs.comment-author }}
+        INPUT_AUTHOR_ASSOCIATION: ${{ inputs.author-association }}
+        INPUT_PR_NUMBER: ${{ inputs.pr-number }}
+        INPUT_REPO: ${{ inputs.repo }}
+        INPUT_CHECK_NAME_PREFIX: ${{ inputs.check-name-prefix }}
+        INPUT_RUN_ID: ${{ inputs.run-id }}
+        INPUT_SERVER_URL: ${{ inputs.server-url }}
+        GH_TOKEN: ${{ inputs.github-token }}
+      run: ${{ github.action_path }}/src/start.sh
+
+    - name: Finish
+      id: finish
+      if: inputs.mode == 'finish'
+      shell: bash
+      env:
+        INPUT_CHECK_RUN_ID: ${{ inputs.check-run-id }}
+        INPUT_REPO: ${{ inputs.repo }}
+        INPUT_REPORT_CONCLUSION: ${{ inputs.report-conclusion }}
+        INPUT_BUILD_RESULT: ${{ inputs.build-result }}
+        INPUT_SUITE_RESULT: ${{ inputs.suite-result }}
+        INPUT_SUMMARY: ${{ inputs.summary }}
+        INPUT_DETAILS_URL: ${{ inputs.details-url }}
+        GH_TOKEN: ${{ inputs.github-token }}
+      run: ${{ github.action_path }}/src/finish.sh
+branding:
+  icon: 'play-circle'
+  color: 'orange'

--- a/.github/actions/comment-triggered-check/action.yml
+++ b/.github/actions/comment-triggered-check/action.yml
@@ -97,6 +97,9 @@ outputs:
   head-sha:
     description: 'Resolved head commit of the pull request. The event does not carry it.'
     value: ${{ steps.start.outputs.head-sha }}
+  head-ref:
+    description: 'Resolved head BRANCH of the pull request. Needed by a caller that dispatches the work to a non-privileged run, because `gh workflow run --ref` takes a branch or tag and never a SHA.'
+    value: ${{ steps.start.outputs.head-ref }}
   base-ref:
     description: 'Resolved base branch of the pull request. The event does not carry it either.'
     value: ${{ steps.start.outputs.base-ref }}

--- a/.github/actions/comment-triggered-check/action.yml
+++ b/.github/actions/comment-triggered-check/action.yml
@@ -101,7 +101,7 @@ outputs:
     description: 'Resolved base branch of the pull request. The event does not carry it either.'
     value: ${{ steps.start.outputs.base-ref }}
   concurrency-key:
-    description: 'Filter reduced to a lowercase slug, safe to interpolate into a concurrency group.'
+    description: 'Filter reduced to a lowercase slug plus an eight-character digest of the normalized filter, safe to interpolate into a concurrency group. The digest is not decoration: the slug alone drops punctuation, so "a && b" and "a || b" would share a group and cancel each other.'
     value: ${{ steps.start.outputs.concurrency-key }}
   check-name:
     description: 'Display name of the check-run, sanitized and length-bounded.'

--- a/.github/actions/comment-triggered-check/src/finish.sh
+++ b/.github/actions/comment-triggered-check/src/finish.sh
@@ -54,6 +54,13 @@ if [[ -z "$summary" ]]; then
   summary="Build: ${build_result:-unknown}. Suite: ${suite_result:-unknown}."
 fi
 
+# Same reason as start mode: GitHub overrides details_url for this app, so the
+# completed check would otherwise offer no way back to the logs. Appended rather
+# than replacing, because the caller's summary is the useful part.
+if [[ -n "$details_url" ]]; then
+  summary="${summary}"$'\n\n'"[View the run](${details_url})"
+fi
+
 args=(--method PATCH "repos/${repo}/check-runs/${check_run_id}"
   -f "status=completed"
   -f "conclusion=${conclusion}"

--- a/.github/actions/comment-triggered-check/src/finish.sh
+++ b/.github/actions/comment-triggered-check/src/finish.sh
@@ -87,9 +87,13 @@ if [[ "$published" -eq 0 ]]; then
   # Accepted residual risk, stated rather than hidden: after this the check-run
   # is stuck in_progress and only a human can clear it. The alternative was a
   # reconciliation pass on the next command, which cost three API calls and a
-  # state machine whose own failure modes were worse. Re-running the workflow
-  # from the Actions tab re-runs this job and is the recovery path.
-  echo "::error::could not complete check-run ${check_run_id} after ${attempts} attempts; it is stuck in progress and will block anything waiting on this commit's checks. Re-run this workflow to retry, or close the check by hand."
+  # state machine whose own failure modes were worse.
+  #
+  # The recovery instruction has to be precise. "Re-run failed jobs" re-runs
+  # only this job, and the check-run id it needs comes from a successful job
+  # whose outputs are preserved, so the same check is closed. Re-running ALL
+  # jobs would run start again and open a second check-run for the same filter.
+  echo "::error::could not complete check-run ${check_run_id} after ${attempts} attempts; it is stuck in progress and will block anything waiting on this commit's checks. Use \"Re-run failed jobs\" to retry just this job, not \"Re-run all jobs\" which would open a second check-run, or close the check by hand."
   exit 1
 fi
 

--- a/.github/actions/comment-triggered-check/src/finish.sh
+++ b/.github/actions/comment-triggered-check/src/finish.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# finish mode: resolve the terminal outcome and complete the check-run opened by
+# start mode.
+#
+# Inputs (env):
+#   INPUT_CHECK_RUN_ID       id from start mode; empty means there is nothing to
+#                            finish, which is the normal path for a comment that
+#                            was not a command
+#   INPUT_REPO               owner/name
+#   INPUT_REPORT_CONCLUSION  what the test run declared about itself, if it got
+#                            far enough to declare anything
+#   INPUT_BUILD_RESULT       needs.<build>.result
+#   INPUT_SUITE_RESULT       needs.<suite>.result
+#   INPUT_SUMMARY            markdown for the check-run body
+#   INPUT_DETAILS_URL        where the check-run should link
+#   GH_TOKEN                 token for gh
+#
+# Output: conclusion — what was published, so the caller can reuse it in a
+# comment without recomputing the matrix.
+set -euo pipefail
+
+# shellcheck source=.github/actions/comment-triggered-check/src/lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+check_run_id="${INPUT_CHECK_RUN_ID:-}"
+repo="${INPUT_REPO:?INPUT_REPO required}"
+report="${INPUT_REPORT_CONCLUSION:-}"
+build_result="${INPUT_BUILD_RESULT:-}"
+suite_result="${INPUT_SUITE_RESULT:-}"
+summary="${INPUT_SUMMARY:-}"
+details_url="${INPUT_DETAILS_URL:-}"
+
+# No check was opened, so there is nothing to close. This is not an error: the
+# workflow fires on every comment, and most of them never reach start mode's
+# create step. The caller should also guard on the id, but a guard that exists
+# in only one place is a guard that gets dropped in a refactor.
+if [[ -z "$check_run_id" ]]; then
+  echo "no check-run to finish"
+  emit "conclusion" ""
+  exit 0
+fi
+
+conclusion="$(resolve_conclusion "$report" "$build_result" "$suite_result")"
+
+case "$conclusion" in
+  success) title="Passed" ;;
+  neutral) title="Nothing to run" ;;
+  cancelled) title="Cancelled" ;;
+  timed_out) title="Timed out" ;;
+  *) title="Failed" ;;
+esac
+
+if [[ -z "$summary" ]]; then
+  summary="Build: ${build_result:-unknown}. Suite: ${suite_result:-unknown}."
+fi
+
+args=(--method PATCH "repos/${repo}/check-runs/${check_run_id}"
+  -f "status=completed"
+  -f "conclusion=${conclusion}"
+  -f "output[title]=${title}"
+  -f "output[summary]=${summary}")
+
+if [[ -n "$details_url" ]]; then
+  args+=(-f "details_url=${details_url}")
+fi
+
+# Retry, because this is the last chance to close the check. Nothing else will:
+# there is no reconciliation pass, by design (see the README), so a check left
+# in_progress here stays that way until a human intervenes, and anything that
+# waits on every check-run of a commit waits on it forever. A transient API
+# failure is the common case and a retry costs nothing.
+attempts="${INPUT_PATCH_ATTEMPTS:-3}"
+delay="${INPUT_PATCH_DELAY_SECONDS:-2}"
+published=0
+for ((attempt = 1; attempt <= attempts; attempt++)); do
+  if gh api "${args[@]}" >/dev/null 2>&1; then
+    published=1
+    break
+  fi
+  if [[ "$attempt" -lt "$attempts" ]]; then
+    echo "::warning::could not complete check-run ${check_run_id} (attempt ${attempt}/${attempts}); retrying"
+    sleep "$delay"
+  fi
+done
+
+if [[ "$published" -eq 0 ]]; then
+  # Accepted residual risk, stated rather than hidden: after this the check-run
+  # is stuck in_progress and only a human can clear it. The alternative was a
+  # reconciliation pass on the next command, which cost three API calls and a
+  # state machine whose own failure modes were worse. Re-running the workflow
+  # from the Actions tab re-runs this job and is the recovery path.
+  echo "::error::could not complete check-run ${check_run_id} after ${attempts} attempts; it is stuck in progress and will block anything waiting on this commit's checks. Re-run this workflow to retry, or close the check by hand."
+  exit 1
+fi
+
+echo "::notice::published ${conclusion} to check-run ${check_run_id}"
+emit "conclusion" "$conclusion"

--- a/.github/actions/comment-triggered-check/src/lib.sh
+++ b/.github/actions/comment-triggered-check/src/lib.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# Pure helpers for the comment-triggered-check action.
+#
+# Everything here is network-free and side-effect free so the whole decision
+# surface is testable with bats. The scripts that talk to the API (start.sh,
+# finish.sh) source this file and keep only the I/O.
+
+# trim <string> — strip leading and trailing whitespace. Bash-only, no
+# subprocess, so it is safe to call in a loop.
+trim() {
+  local s="${1-}"
+  s="${s#"${s%%[![:space:]]*}"}"
+  s="${s%"${s##*[![:space:]]}"}"
+  printf '%s' "$s"
+}
+
+# parse_command <command> <comment-body>
+# Prints the argument string when the comment's FIRST line is the command.
+# Returns 1 otherwise.
+#
+# First line only, deliberately. Quoting a command while discussing it ("we
+# should run /test snapshots here") must not fire a run, and that is the common
+# case in a busy thread. It also keeps the trigger unambiguous when a comment
+# ends with a bot signature.
+parse_command() {
+  local command="${1-}" body="${2-}" first
+  first="${body%%$'\n'*}"
+  first="${first%$'\r'}"
+  first="$(trim "$first")"
+
+  if [[ "$first" != "$command" && "$first" != "$command "* && "$first" != "$command"$'\t'* ]]; then
+    return 1
+  fi
+
+  trim "${first#"$command"}"
+}
+
+# normalize_filter <string> — collapse internal whitespace runs to one space and
+# trim. A Ginkgo label filter is whitespace-insensitive, so this makes the
+# concurrency key and the check name stable across "a && b" and "a &&  b".
+normalize_filter() {
+  local s
+  s="$(printf '%s' "${1-}" | LC_ALL=C tr -s '[:space:]' ' ')"
+  trim "$s"
+}
+
+# sanitize_slug <string> [max-length]
+# Lowercase, non-alphanumerics collapsed to single dashes, trimmed, truncated.
+# Used for the concurrency key, which is interpolated into YAML and must not
+# carry quotes, braces or newlines from user input.
+sanitize_slug() {
+  local s="${1-}" max="${2:-60}"
+  s="$(printf '%s' "$s" \
+    | LC_ALL=C tr '[:upper:]' '[:lower:]' \
+    | LC_ALL=C sed -e 's/[^a-z0-9]\{1,\}/-/g' -e 's/^-*//' -e 's/-*$//')"
+  printf '%s' "${s:0:$max}"
+}
+
+# short_digest <string> — 8 stable hex-ish characters. cksum is in coreutils and
+# in the BSD userland, unlike sha256sum/shasum which differ between the runner
+# and a developer's Mac.
+short_digest() {
+  printf '%s' "${1-}" | cksum | awk '{ printf "%08x", $1 }'
+}
+
+# concurrency_key <filter> [max-slug-length]
+# A key that is safe to interpolate into a concurrency group AND unique per
+# filter. The slug alone is not: it drops every non-alphanumeric character, so
+# `snapshots && aws` and `snapshots || aws` both reduce to `snapshots-aws`.
+# Those are opposite requests, and sharing a group would make one cancel the
+# other. The digest is taken over the normalized filter, so it survives both the
+# punctuation loss and the truncation.
+concurrency_key() {
+  local filter normalized slug
+  normalized="$(normalize_filter "${1-}")"
+  slug="$(sanitize_slug "$normalized" "${2:-40}")"
+  printf '%s-%s' "${slug:-filter}" "$(short_digest "$normalized")"
+}
+
+# check_name <prefix> <filter> [max-length]
+# The display name of the check-run, derived from user input, so it is
+# sanitized and bounded. When the filter is too long to show in full the name
+# carries a digest of the whole filter, because this name is also the dedupe
+# key: two different long filters that truncated to the same text would
+# otherwise be treated as the same in-flight run.
+check_name() {
+  local prefix="${1-}" filter="${2-}" max="${3:-60}" cleaned
+  cleaned="$(printf '%s' "$(normalize_filter "$filter")" | LC_ALL=C tr -cd '\040-\176')"
+
+  if [[ "${#cleaned}" -le "$max" ]]; then
+    printf '%s: %s' "$prefix" "$cleaned"
+    return 0
+  fi
+
+  printf '%s: %s... (%s)' "$prefix" "${cleaned:0:$max}" "$(short_digest "$cleaned")"
+}
+
+# CONCLUSIONS_FROM_REPORT — the conclusions the suite is allowed to declare for
+# itself. Deliberately narrower than the Checks API set: action_required and
+# skipped are not outcomes a test run should ever report, and accepting them
+# would let an unexpected value through as something that reads acceptable.
+CONCLUSIONS_FROM_REPORT="success failure neutral cancelled timed_out"
+
+# resolve_conclusion <report-conclusion> <build-result> <suite-result>
+# The fail-closed outcome matrix. See the design doc, DEVOPS-1333.
+#
+#   explicit report conclusion    -> use it. THE ONLY PATH TO neutral.
+#   suite or build was cancelled  -> cancelled
+#   anything else                 -> failure
+#
+# The two mappings this deliberately does NOT have are the point:
+#
+#   "no output but the job ran" must not become cancelled, because that state
+#   also covers a failed checkout, setup, artifact download or cloud login, and
+#   cancelled is not cheap. wait-for-ci.sh holds a cancelled check waiting for a
+#   replacement and then refuses approval, so a mis-mapped cancelled stalls
+#   auto-approve instead of failing cleanly.
+#
+#   "suite skipped but build succeeded" must not become neutral, because
+#   neutral is an acceptable verdict and an unexplained skip is not an
+#   acceptable outcome. Once a check-run exists, anything we cannot explain is
+#   a failure.
+resolve_conclusion() {
+  local report="${1-}" build_result="${2-}" suite_result="${3-}"
+
+  if [[ -n "$report" ]]; then
+    if [[ " $CONCLUSIONS_FROM_REPORT " == *" $report "* ]]; then
+      printf '%s' "$report"
+      return 0
+    fi
+    echo "::warning::suite reported an unrecognised conclusion '${report}'; failing closed" >&2
+    printf 'failure'
+    return 0
+  fi
+
+  # A cancelled build or suite is an explained outcome, so it does not fall
+  # through to the catch-all. Cancelling the run leaves build=cancelled and
+  # suite=skipped, which would otherwise read as a red check for something the
+  # author did on purpose.
+  if [[ "$suite_result" == "cancelled" || "$build_result" == "cancelled" ]]; then
+    printf 'cancelled'
+    return 0
+  fi
+
+  printf 'failure'
+}
+
+# AUTHORIZED_ASSOCIATIONS — comment author_association values that imply access
+# to the repository. CONTRIBUTOR means "has landed a PR here", not "can run
+# things here", so it is not on the list.
+AUTHORIZED_ASSOCIATIONS="OWNER MEMBER COLLABORATOR"
+
+# is_authorized_association <association>
+# Whether the commenter may run the command, decided from the event payload
+# rather than a collaborator API call. Coarser than that endpoint, since a
+# read-only collaborator also reads as COLLABORATOR, and that trade is
+# deliberate: the command is same-repo only, so the cost of the coarseness is
+# runner time rather than access. Empty or unrecognised is always a no.
+is_authorized_association() {
+  local association="${1-}"
+  [[ -n "$association" ]] || return 1
+  [[ " $AUTHORIZED_ASSOCIATIONS " == *" $association "* ]]
+}
+
+# emit <name> <value> — write a step output and echo it for the log.
+emit() {
+  printf '%s=%s\n' "$1" "$2" >> "${GITHUB_OUTPUT:?GITHUB_OUTPUT required}"
+  printf '%s=%s\n' "$1" "$2"
+}

--- a/.github/actions/comment-triggered-check/src/lib.sh
+++ b/.github/actions/comment-triggered-check/src/lib.sh
@@ -124,7 +124,9 @@ resolve_conclusion() {
   local report="${1-}" build_result="${2-}" suite_result="${3-}"
 
   if [[ -n "$report" ]]; then
-    if [[ " $CONCLUSIONS_FROM_REPORT " == *" $report "* ]]; then
+    # Exact match, word by word. Substring membership passes any adjacent slice
+    # of the list, so "success failure" reaches the Checks API and 400s.
+    if printf '%s' "$CONCLUSIONS_FROM_REPORT" | tr ' ' '\n' | grep -qxF -- "$report"; then
       printf '%s' "$report"
       return 0
     fi

--- a/.github/actions/comment-triggered-check/src/start.sh
+++ b/.github/actions/comment-triggered-check/src/start.sh
@@ -42,6 +42,7 @@ filter=""
 should_run=false
 reason=""
 head_sha=""
+head_ref=""
 base_ref=""
 concurrency_key=""
 name=""
@@ -55,6 +56,7 @@ finish_and_exit() {
   emit "should-run" "$should_run"
   emit "reason" "$reason"
   emit "head-sha" "$head_sha"
+  emit "head-ref" "$head_ref"
   emit "base-ref" "$base_ref"
   emit "concurrency-key" "$concurrency_key"
   emit "check-name" "$name"
@@ -118,13 +120,17 @@ if ! pr_json="$(gh_json "repos/${repo}/pulls/${pr_number}")"; then
 fi
 
 head_sha="$(printf '%s' "$pr_json" | jq -r '.head.sha // ""')"
+# The branch name, not just the commit. A caller that hands the work to a
+# non-privileged run needs it: `gh workflow run --ref` takes a branch or tag,
+# never a SHA.
+head_ref="$(printf '%s' "$pr_json" | jq -r '.head.ref // ""')"
 base_ref="$(printf '%s' "$pr_json" | jq -r '.base.ref // ""')"
 head_repo="$(printf '%s' "$pr_json" | jq -r '.head.repo.full_name // ""')"
 pr_state="$(printf '%s' "$pr_json" | jq -r '.state // ""')"
 
-if [[ -z "$head_sha" || -z "$base_ref" ]]; then
+if [[ -z "$head_sha" || -z "$head_ref" || -z "$base_ref" ]]; then
   reason="pull-request-unreadable"
-  echo "::warning::${repo}#${pr_number} returned no head SHA or base ref; not starting a run"
+  echo "::warning::${repo}#${pr_number} returned no head SHA, head ref or base ref; not starting a run"
   finish_and_exit
 fi
 

--- a/.github/actions/comment-triggered-check/src/start.sh
+++ b/.github/actions/comment-triggered-check/src/start.sh
@@ -157,13 +157,26 @@ concurrency_key="$(concurrency_key "$filter")"
 # --- 4. Open the check-run ---------------------------------------------------
 # On the resolved head SHA, never on github.sha: for issue_comment that is the
 # default branch, so a check created there is invisible on the pull request.
+#
+# The run link goes in the summary, not only in details_url. GitHub overrides
+# details_url for check-runs owned by the github-actions app, so "View details"
+# lands on the check-run's own page and never reaches the logs. Verified in the
+# integration repo: details_url came back equal to html_url on every check-run,
+# on create and on update alike. The summary is stored verbatim, so it is the
+# only link that survives. details_url stays because a real GitHub App would
+# have it honoured, and because it costs nothing.
+summary="Requested by @${comment_author} with \`${command_word} ${filter}\`."
+if [[ -n "$run_id" ]]; then
+  summary="${summary}"$'\n\n'"[View the run](${server_url}/${repo}/actions/runs/${run_id})"
+fi
+
 if ! created="$(gh_json --method POST "repos/${repo}/check-runs" \
   -f "name=${name}" \
   -f "head_sha=${head_sha}" \
   -f "status=in_progress" \
   -f "details_url=${server_url}/${repo}/actions/runs/${run_id}" \
   -f "output[title]=Running" \
-  -f "output[summary]=Requested by @${comment_author} with \`${command_word} ${filter}\`.")"; then
+  -f "output[summary]=${summary}")"; then
   reason="check-run-not-created"
   should_run=false
   echo "::warning::could not create the check-run; not starting a run"

--- a/.github/actions/comment-triggered-check/src/start.sh
+++ b/.github/actions/comment-triggered-check/src/start.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# start mode: decide whether this comment is a command we should act on, and if
+# so open a check-run on the pull request's head commit.
+#
+# Three API calls, and no more. Deduplicating repeated commands is left to the
+# caller's `concurrency` group (see the README): GitHub already supersedes an
+# older run for the same key, and a superseded job still runs the caller's
+# `always()` finish job, which closes its check. Doing it here instead meant
+# listing checks, resolving the run behind each one, and closing orphans, which
+# is three more calls and a state machine whose failure modes all end in
+# starting a duplicate build.
+#
+# Inputs (env):
+#   INPUT_COMMAND             command word to match, e.g. "/test"
+#   INPUT_COMMENT_BODY        github.event.comment.body
+#   INPUT_COMMENT_AUTHOR      github.event.comment.user.login
+#   INPUT_AUTHOR_ASSOCIATION  github.event.comment.author_association
+#   INPUT_PR_NUMBER           github.event.issue.number
+#   INPUT_REPO                owner/name
+#   INPUT_CHECK_NAME_PREFIX   prefix for the check-run name
+#   INPUT_RUN_ID              github.run_id, used for the details link
+#   INPUT_SERVER_URL          github.server_url
+#   GH_TOKEN                  token for gh
+set -euo pipefail
+
+# shellcheck source=.github/actions/comment-triggered-check/src/lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+command_word="${INPUT_COMMAND:-/test}"
+comment_body="${INPUT_COMMENT_BODY:-}"
+comment_author="${INPUT_COMMENT_AUTHOR:-}"
+association="${INPUT_AUTHOR_ASSOCIATION:-}"
+pr_number="${INPUT_PR_NUMBER:-}"
+repo="${INPUT_REPO:?INPUT_REPO required}"
+prefix="${INPUT_CHECK_NAME_PREFIX:-e2e}"
+run_id="${INPUT_RUN_ID:-}"
+server_url="${INPUT_SERVER_URL:-https://github.com}"
+
+matched=false
+args=""
+filter=""
+should_run=false
+reason=""
+head_sha=""
+base_ref=""
+concurrency_key=""
+name=""
+check_run_id=""
+
+# Emitted on every path, so a caller never reads an undefined output.
+finish_and_exit() {
+  emit "matched" "$matched"
+  emit "args" "$args"
+  emit "filter" "$filter"
+  emit "should-run" "$should_run"
+  emit "reason" "$reason"
+  emit "head-sha" "$head_sha"
+  emit "base-ref" "$base_ref"
+  emit "concurrency-key" "$concurrency_key"
+  emit "check-name" "$name"
+  emit "check-run-id" "$check_run_id"
+  exit 0
+}
+
+# gh_json <path> — body on stdout, non-zero when the call failed.
+# Deliberately does NOT collapse a failure into an empty object: every caller
+# here has to tell "the API answered" apart from "we have no idea", because
+# guessing in the second case is how a command silently does the wrong thing.
+gh_json() {
+  local body
+  body="$(gh api "$@" 2>/dev/null)" || return 1
+  printf '%s' "$body"
+}
+
+# --- 1. Is this a command at all? -------------------------------------------
+# The workflow fires on every comment in the repository, so this is the path
+# almost every invocation takes. Stay quiet, and touch no API.
+if ! args="$(parse_command "$command_word" "$comment_body")"; then
+  echo "comment is not a ${command_word} command, nothing to do"
+  args=""
+  finish_and_exit
+fi
+matched=true
+
+if [[ -z "$pr_number" ]]; then
+  reason="not-a-pull-request"
+  echo "::notice::${command_word} is only available on pull requests"
+  finish_and_exit
+fi
+
+filter="$(normalize_filter "$args")"
+if [[ -z "$filter" ]]; then
+  reason="empty-filter"
+  echo "::notice::${command_word} needs a label filter, for example \`${command_word} snapshots\`"
+  finish_and_exit
+fi
+
+# --- 2. Authorize the commenter ---------------------------------------------
+# From the event payload, so no API call and no token scope to get wrong. It is
+# coarser than the collaborator endpoint: a read-only collaborator reads as
+# COLLABORATOR and would pass. On a same-repo-only command in an internal
+# repository the cost of that is runner time, not access.
+if ! is_authorized_association "$association"; then
+  reason="insufficient-permission"
+  echo "::notice::${comment_author} (${association:-unknown}) cannot run ${command_word}; it needs repository access"
+  finish_and_exit
+fi
+
+# --- 3. Resolve the pull request --------------------------------------------
+# The event carries no head SHA and no base ref: an issue_comment run is on the
+# default branch, so both have to come from the API. Getting the base ref wrong
+# is not cosmetic. A caller resolving an OSS chart branch from it would pair a
+# PR-head image with a main-line chart (ENGQA-1088).
+if ! pr_json="$(gh_json "repos/${repo}/pulls/${pr_number}")"; then
+  reason="pull-request-unreadable"
+  echo "::warning::could not read ${repo}#${pr_number}; not starting a run"
+  finish_and_exit
+fi
+
+head_sha="$(printf '%s' "$pr_json" | jq -r '.head.sha // ""')"
+base_ref="$(printf '%s' "$pr_json" | jq -r '.base.ref // ""')"
+head_repo="$(printf '%s' "$pr_json" | jq -r '.head.repo.full_name // ""')"
+pr_state="$(printf '%s' "$pr_json" | jq -r '.state // ""')"
+
+if [[ -z "$head_sha" || -z "$base_ref" ]]; then
+  reason="pull-request-unreadable"
+  echo "::warning::${repo}#${pr_number} returned no head SHA or base ref; not starting a run"
+  finish_and_exit
+fi
+
+if [[ "$pr_state" != "open" ]]; then
+  reason="pull-request-closed"
+  echo "::notice::${repo}#${pr_number} is ${pr_state}; not starting a run"
+  finish_and_exit
+fi
+
+# Fork check, before the caller checks anything out. This trigger is privileged:
+# it runs from the default branch of the base repository with its secrets and a
+# write token, so a workflow that fetches and runs fork code hands those to a
+# stranger. A security boundary, not a convenience limit.
+if [[ "$head_repo" != "$repo" ]]; then
+  reason="fork"
+  echo "::notice::${command_word} is not available on pull requests from forks"
+  finish_and_exit
+fi
+
+should_run=true
+name="$(check_name "$prefix" "$filter")"
+concurrency_key="$(concurrency_key "$filter")"
+
+# --- 4. Open the check-run ---------------------------------------------------
+# On the resolved head SHA, never on github.sha: for issue_comment that is the
+# default branch, so a check created there is invisible on the pull request.
+if ! created="$(gh_json --method POST "repos/${repo}/check-runs" \
+  -f "name=${name}" \
+  -f "head_sha=${head_sha}" \
+  -f "status=in_progress" \
+  -f "details_url=${server_url}/${repo}/actions/runs/${run_id}" \
+  -f "output[title]=Running" \
+  -f "output[summary]=Requested by @${comment_author} with \`${command_word} ${filter}\`.")"; then
+  reason="check-run-not-created"
+  should_run=false
+  echo "::warning::could not create the check-run; not starting a run"
+  finish_and_exit
+fi
+
+check_run_id="$(printf '%s' "$created" | jq -r '.id // ""')"
+echo "::notice::started ${name} on ${head_sha}"
+finish_and_exit

--- a/.github/actions/comment-triggered-check/src/start.sh
+++ b/.github/actions/comment-triggered-check/src/start.sh
@@ -184,5 +184,15 @@ if ! created="$(gh_json --method POST "repos/${repo}/check-runs" \
 fi
 
 check_run_id="$(printf '%s' "$created" | jq -r '.id // ""')"
+
+# A create that returned no id leaves a check-run nothing can ever close, so
+# treat it as a failed create rather than starting a run that cannot report.
+if [[ -z "$check_run_id" ]]; then
+  reason="check-run-not-created"
+  should_run=false
+  echo "::warning::the check-run create returned no id; not starting a run"
+  finish_and_exit
+fi
+
 echo "::notice::started ${name} on ${head_sha}"
 finish_and_exit

--- a/.github/actions/comment-triggered-check/test/finish.bats
+++ b/.github/actions/comment-triggered-check/test/finish.bats
@@ -161,3 +161,25 @@ patches() { calls_matching "PATCH"; }
   run bash "$SCRIPT"
   [ "$(kv conclusion)" = "" ]
 }
+
+# --- the link back to the logs -----------------------------------------------
+# details_url is overridden by GitHub for this app, so the summary is the only
+# place a link survives. See the note in start.sh.
+
+@test "the completed check-run links to the run from its summary" {
+  export INPUT_DETAILS_URL="https://github.com/loft-sh/demo/actions/runs/999"
+  run bash "$SCRIPT"
+  [ "$(calls_matching 'View the run.*actions/runs/999')" -ge 1 ]
+}
+
+@test "the caller's summary is kept and the link appended, not replaced" {
+  export INPUT_DETAILS_URL="https://github.com/loft-sh/demo/actions/runs/999"
+  export INPUT_SUMMARY="Suite reported 12 failures."
+  run bash "$SCRIPT"
+  [ "$(calls_matching 'Suite reported 12 failures.*View the run')" -ge 1 ]
+}
+
+@test "no details url means no link rather than a broken one" {
+  run bash "$SCRIPT"
+  [ "$(calls_matching 'View the run')" -eq 0 ]
+}

--- a/.github/actions/comment-triggered-check/test/finish.bats
+++ b/.github/actions/comment-triggered-check/test/finish.bats
@@ -1,0 +1,154 @@
+#!/usr/bin/env bats
+# Invocation-level tests for finish.sh against a stubbed gh.
+#
+# This is the completion boundary for the custom check-run. If it publishes the
+# wrong conclusion the pull request shows a wrong verdict, and if it publishes
+# nothing the check is stuck in progress, so both halves are pinned here rather
+# than only in the pure matrix tests.
+
+load gh_mock
+
+SCRIPT="$BATS_TEST_DIRNAME/../src/finish.sh"
+
+setup() {
+  setup_gh_mock
+  export GITHUB_OUTPUT; GITHUB_OUTPUT="$(mktemp)"
+  export INPUT_REPO="loft-sh/demo"
+  export INPUT_CHECK_RUN_ID="4242"
+  export INPUT_REPORT_CONCLUSION=""
+  export INPUT_BUILD_RESULT="success"
+  export INPUT_SUITE_RESULT="success"
+  export INPUT_SUMMARY=""
+  export INPUT_DETAILS_URL=""
+  # Keep retries fast; the retry count itself is asserted below.
+  export INPUT_PATCH_DELAY_SECONDS="0"
+  export GH_TOKEN="x"
+}
+
+teardown() {
+  rm -f "$GITHUB_OUTPUT"
+  teardown_gh_mock
+}
+
+kv() { grep "^$1=" "$GITHUB_OUTPUT" | tail -n1 | cut -d= -f2-; }
+patches() { calls_matching "PATCH"; }
+
+# --- the no-op path ----------------------------------------------------------
+
+@test "an empty check-run id is a no-op, not an error" {
+  export INPUT_CHECK_RUN_ID=""
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv conclusion)" = "" ]
+  [ "$(call_count)" -eq 0 ]
+}
+
+# --- conclusion propagation --------------------------------------------------
+
+@test "a report conclusion is published verbatim" {
+  export INPUT_REPORT_CONCLUSION="success"
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv conclusion)" = "success" ]
+  [ "$(patches)" -eq 1 ]
+  [ "$(calls_matching "conclusion=success")" -eq 1 ]
+}
+
+@test "neutral from the report reaches the API" {
+  export INPUT_REPORT_CONCLUSION="neutral"
+  run bash "$SCRIPT"
+  [ "$(kv conclusion)" = "neutral" ]
+  [ "$(calls_matching "conclusion=neutral")" -eq 1 ]
+}
+
+@test "a skipped suite with no report publishes failure, not neutral" {
+  export INPUT_SUITE_RESULT="skipped"
+  run bash "$SCRIPT"
+  [ "$(kv conclusion)" = "failure" ]
+  [ "$(calls_matching "conclusion=failure")" -eq 1 ]
+}
+
+@test "a cancelled run publishes cancelled" {
+  export INPUT_BUILD_RESULT="cancelled"
+  export INPUT_SUITE_RESULT="skipped"
+  run bash "$SCRIPT"
+  [ "$(kv conclusion)" = "cancelled" ]
+  [ "$(calls_matching "conclusion=cancelled")" -eq 1 ]
+}
+
+@test "an unrecognised report conclusion publishes failure" {
+  export INPUT_REPORT_CONCLUSION="action_required"
+  run bash "$SCRIPT"
+  [ "$(kv conclusion)" = "failure" ]
+  [ "$(calls_matching "conclusion=action_required")" -eq 0 ]
+}
+
+@test "the title matches the conclusion" {
+  export INPUT_REPORT_CONCLUSION="timed_out"
+  run bash "$SCRIPT"
+  [ "$(calls_matching "Timed out")" -eq 1 ]
+}
+
+# --- wiring ------------------------------------------------------------------
+
+@test "the details url is passed through when given" {
+  export INPUT_DETAILS_URL="https://example.test/run/1"
+  run bash "$SCRIPT"
+  [ "$(calls_matching "details_url=https://example.test/run/1")" -eq 1 ]
+}
+
+@test "no details url means the flag is omitted rather than sent empty" {
+  run bash "$SCRIPT"
+  [ "$(calls_matching "details_url=")" -eq 0 ]
+}
+
+@test "a caller summary overrides the default" {
+  export INPUT_SUMMARY="17 specs failed"
+  run bash "$SCRIPT"
+  [ "$(calls_matching "17 specs failed")" -eq 1 ]
+}
+
+@test "the default summary reports both job results" {
+  export INPUT_SUITE_RESULT="failure"
+  run bash "$SCRIPT"
+  [ "$(calls_matching "Suite: failure")" -eq 1 ]
+}
+
+@test "it patches the check-run named by the input" {
+  run bash "$SCRIPT"
+  [ "$(calls_matching "check-runs/4242")" -eq 1 ]
+}
+
+# --- the failure that leaves a stuck check ----------------------------------
+
+@test "a failing patch is retried and then reported as an error" {
+  export GH_MOCK_PATCH_FAIL=1
+  export INPUT_PATCH_ATTEMPTS="3"
+  run bash "$SCRIPT"
+  [ "$status" -ne 0 ]
+  [ "$(patches)" -eq 3 ]
+  [[ "$output" == *"::error::"* ]]
+  [[ "$output" == *"stuck in progress"* ]]
+}
+
+@test "the error names a recovery path rather than a removed mechanism" {
+  export GH_MOCK_PATCH_FAIL=1
+  export INPUT_PATCH_ATTEMPTS="1"
+  run bash "$SCRIPT"
+  [[ "$output" == *"Re-run this workflow"* ]]
+  [[ "$output" != *"reconcile"* ]]
+}
+
+@test "a single configured attempt makes exactly one call" {
+  export GH_MOCK_PATCH_FAIL=1
+  export INPUT_PATCH_ATTEMPTS="1"
+  run bash "$SCRIPT"
+  [ "$(patches)" -eq 1 ]
+}
+
+@test "no conclusion output is emitted when publishing failed" {
+  export GH_MOCK_PATCH_FAIL=1
+  export INPUT_PATCH_ATTEMPTS="1"
+  run bash "$SCRIPT"
+  [ "$(kv conclusion)" = "" ]
+}

--- a/.github/actions/comment-triggered-check/test/finish.bats
+++ b/.github/actions/comment-triggered-check/test/finish.bats
@@ -135,8 +135,17 @@ patches() { calls_matching "PATCH"; }
   export GH_MOCK_PATCH_FAIL=1
   export INPUT_PATCH_ATTEMPTS="1"
   run bash "$SCRIPT"
-  [[ "$output" == *"Re-run this workflow"* ]]
   [[ "$output" != *"reconcile"* ]]
+}
+
+# Re-running everything would run start again and open a second check-run for
+# the same filter, so the instruction has to name the narrower option.
+@test "the recovery instruction points at re-running only the failed job" {
+  export GH_MOCK_PATCH_FAIL=1
+  export INPUT_PATCH_ATTEMPTS="1"
+  run bash "$SCRIPT"
+  [[ "$output" == *"Re-run failed jobs"* ]]
+  [[ "$output" == *"second check-run"* ]]
 }
 
 @test "a single configured attempt makes exactly one call" {

--- a/.github/actions/comment-triggered-check/test/gh_mock.bash
+++ b/.github/actions/comment-triggered-check/test/gh_mock.bash
@@ -32,7 +32,7 @@ all="$*"
 # Defaults are assigned, never inlined into "${VAR:-...}": a JSON literal inside
 # a parameter-expansion default loses its double quotes and keeps any single
 # quotes, which produces a body jq cannot parse.
-default_pr='{"head":{"sha":"abc123","repo":{"full_name":"loft-sh/demo"}},"base":{"ref":"main"},"state":"open"}'
+default_pr='{"head":{"sha":"abc123","ref":"feature/x","repo":{"full_name":"loft-sh/demo"}},"base":{"ref":"main"},"state":"open"}'
 default_create='{"id":4242}'
 
 case "$all" in

--- a/.github/actions/comment-triggered-check/test/gh_mock.bash
+++ b/.github/actions/comment-triggered-check/test/gh_mock.bash
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Shared helper: install a stub `gh` on PATH for the comment-triggered-check scripts.
+# Same shape as auto-approve-bot-prs/test/gh_mock.bash: dispatch on the api
+# path, control responses with env vars, record every call.
+#
+# Only success and failure are modelled, matching the scripts, which use plain
+# `gh api` and distinguish "the API answered" from "we have no idea" rather than
+# branching on HTTP status.
+#
+# Controls, all optional:
+#   GH_MOCK_PR_JSON      body for .../pulls/N
+#   GH_MOCK_PR_FAIL      non-empty → the pulls call fails
+#   GH_MOCK_CREATE_JSON  body for POST .../check-runs
+#   GH_MOCK_CREATE_FAIL  non-empty → the create call fails
+#   GH_MOCK_PATCH_FAIL   non-empty → a PATCH fails
+#   GH_MOCK_CALLS        path; each invocation appends one line of args
+
+setup_gh_mock() {
+  MOCK_DIR="$(mktemp -d)"
+  export MOCK_DIR
+  PATH="$MOCK_DIR:$PATH"
+  export PATH
+
+  cat > "$MOCK_DIR/gh" <<'EOF'
+#!/usr/bin/env bash
+set -o pipefail
+
+[ -n "${GH_MOCK_CALLS:-}" ] && printf '%s\n' "$*" >> "$GH_MOCK_CALLS"
+
+all="$*"
+
+# Defaults are assigned, never inlined into "${VAR:-...}": a JSON literal inside
+# a parameter-expansion default loses its double quotes and keeps any single
+# quotes, which produces a body jq cannot parse.
+default_pr='{"head":{"sha":"abc123","repo":{"full_name":"loft-sh/demo"}},"base":{"ref":"main"},"state":"open"}'
+default_create='{"id":4242}'
+
+case "$all" in
+  *"--method POST"*"check-runs"*)
+    [ -n "${GH_MOCK_CREATE_FAIL:-}" ] && { echo "mock: create failed" >&2; exit 1; }
+    printf '%s\n' "${GH_MOCK_CREATE_JSON:-$default_create}"
+    ;;
+  *"--method PATCH"*)
+    [ -n "${GH_MOCK_PATCH_FAIL:-}" ] && { echo "mock: patch failed" >&2; exit 1; }
+    printf '{}\n'
+    ;;
+  *"/pulls/"*)
+    [ -n "${GH_MOCK_PR_FAIL:-}" ] && { echo "mock: pulls failed" >&2; exit 1; }
+    printf '%s\n' "${GH_MOCK_PR_JSON:-$default_pr}"
+    ;;
+  *)
+    printf '{}\n'
+    ;;
+esac
+EOF
+  chmod +x "$MOCK_DIR/gh"
+
+  export GH_MOCK_CALLS="$MOCK_DIR/calls.log"
+  : > "$GH_MOCK_CALLS"
+}
+
+teardown_gh_mock() {
+  rm -rf "$MOCK_DIR"
+}
+
+# calls_matching <pattern> — how many recorded gh invocations match.
+calls_matching() {
+  grep -c -- "$1" "$GH_MOCK_CALLS" || true
+}
+
+# call_count — total recorded gh invocations.
+call_count() {
+  wc -l < "$GH_MOCK_CALLS" | tr -d ' '
+}

--- a/.github/actions/comment-triggered-check/test/gh_mock.bash
+++ b/.github/actions/comment-triggered-check/test/gh_mock.bash
@@ -25,7 +25,10 @@ setup_gh_mock() {
 #!/usr/bin/env bash
 set -o pipefail
 
-[ -n "${GH_MOCK_CALLS:-}" ] && printf '%s\n' "$*" >> "$GH_MOCK_CALLS"
+# One line per invocation, so newlines inside an argument are escaped rather
+# than recorded. A check-run summary is markdown and contains them; without this
+# a single call is counted as three.
+[ -n "${GH_MOCK_CALLS:-}" ] && printf '%s\n' "${*//$'\n'/\\n}" >> "$GH_MOCK_CALLS"
 
 all="$*"
 

--- a/.github/actions/comment-triggered-check/test/lib.bats
+++ b/.github/actions/comment-triggered-check/test/lib.bats
@@ -1,0 +1,284 @@
+#!/usr/bin/env bats
+# Tests for the pure decision surface of the comment-triggered-check action.
+#
+# Everything in lib.sh is network-free, so the parsing, sanitizing and outcome
+# rules are covered here rather than only in a live smoke run. The scripts that
+# call the API keep no decisions of their own beyond wiring these.
+
+LIB="$BATS_TEST_DIRNAME/../src/lib.sh"
+
+setup() {
+  # shellcheck source=.github/actions/comment-triggered-check/src/lib.sh
+  source "$LIB"
+}
+
+# --- parse_command -----------------------------------------------------------
+
+@test "parse_command: bare command matches with empty args" {
+  run parse_command "/test" "/test"
+  [ "$status" -eq 0 ]
+  [ "$output" = "" ]
+}
+
+@test "parse_command: command with a filter returns the filter" {
+  run parse_command "/test" "/test snapshots"
+  [ "$status" -eq 0 ]
+  [ "$output" = "snapshots" ]
+}
+
+@test "parse_command: only the first line is considered" {
+  run parse_command "/test" "$(printf '/test snapshots\nplease ignore this')"
+  [ "$status" -eq 0 ]
+  [ "$output" = "snapshots" ]
+}
+
+@test "parse_command: a quoted command later in the comment does not fire" {
+  run parse_command "/test" "$(printf 'we should run\n/test snapshots\nafter this lands')"
+  [ "$status" -ne 0 ]
+}
+
+@test "parse_command: a command mid-line does not fire" {
+  run parse_command "/test" "maybe /test snapshots would help"
+  [ "$status" -ne 0 ]
+}
+
+@test "parse_command: a longer command word is not a prefix match" {
+  run parse_command "/test" "/testing something"
+  [ "$status" -ne 0 ]
+}
+
+@test "parse_command: leading whitespace and CRLF are tolerated" {
+  run parse_command "/test" "$(printf '   /test  snapshots  \r\nrest')"
+  [ "$status" -eq 0 ]
+  [ "$output" = "snapshots" ]
+}
+
+@test "parse_command: an unrelated comment does not fire" {
+  run parse_command "/test" "LGTM, nice work"
+  [ "$status" -ne 0 ]
+}
+
+# --- normalize_filter --------------------------------------------------------
+
+@test "normalize_filter: collapses whitespace runs and trims" {
+  run normalize_filter "  db-datasource   &&    aws  "
+  [ "$output" = "db-datasource && aws" ]
+}
+
+@test "normalize_filter: a real category label survives intact" {
+  run normalize_filter 'containsAny {aws, azure}'
+  [ "$output" = "containsAny {aws, azure}" ]
+}
+
+# --- sanitize_slug -----------------------------------------------------------
+
+@test "sanitize_slug: braces, spaces and punctuation become single dashes" {
+  run sanitize_slug 'containsAny {aws, azure}'
+  [ "$output" = "containsany-aws-azure" ]
+}
+
+@test "sanitize_slug: no leading or trailing dashes" {
+  run sanitize_slug '  && snapshots &&  '
+  [ "$output" = "snapshots" ]
+}
+
+@test "sanitize_slug: truncates to the requested length" {
+  run sanitize_slug "aaaaaaaaaaaaaaaaaaaa" 8
+  [ "$output" = "aaaaaaaa" ]
+}
+
+@test "sanitize_slug: a shell metacharacter payload is reduced to a slug" {
+  run sanitize_slug '$(rm -rf /) && `id`'
+  [[ "$output" != *'$'* ]]
+  [[ "$output" != *'`'* ]]
+  [[ "$output" != *'('* ]]
+}
+
+# --- concurrency_key ---------------------------------------------------------
+
+@test "concurrency_key: opposite operators do not share a key" {
+  a="$(concurrency_key 'snapshots && aws')"
+  b="$(concurrency_key 'snapshots || aws')"
+  [ "$a" != "$b" ]
+}
+
+@test "concurrency_key: the slug alone would have collided" {
+  # Pins the reason the digest exists, so removing it fails loudly.
+  [ "$(sanitize_slug 'snapshots && aws')" = "$(sanitize_slug 'snapshots || aws')" ]
+}
+
+@test "concurrency_key: negation is distinguished from plain" {
+  a="$(concurrency_key 'snapshots')"
+  b="$(concurrency_key '!snapshots')"
+  [ "$a" != "$b" ]
+}
+
+@test "concurrency_key: whitespace-only differences share a key" {
+  a="$(concurrency_key 'snapshots   &&  aws')"
+  b="$(concurrency_key 'snapshots && aws')"
+  [ "$a" = "$b" ]
+}
+
+@test "concurrency_key: two long filters differing past truncation do not collide" {
+  base="$(printf 'a%.0s' {1..60})"
+  a="$(concurrency_key "${base}alpha")"
+  b="$(concurrency_key "${base}omega")"
+  [ "$a" != "$b" ]
+}
+
+@test "concurrency_key: is safe to interpolate" {
+  run concurrency_key 'containsAny {aws, azure} && !non-default'
+  [[ "$output" =~ ^[a-z0-9-]+$ ]]
+}
+
+@test "concurrency_key: a punctuation-only filter still yields a usable key" {
+  run concurrency_key '&& ||'
+  [[ "$output" =~ ^[a-z0-9-]+$ ]]
+  [ -n "$output" ]
+}
+
+@test "concurrency_key: is stable across calls" {
+  a="$(concurrency_key 'snapshots && aws')"
+  b="$(concurrency_key 'snapshots && aws')"
+  [ "$a" = "$b" ]
+}
+
+# --- check_name --------------------------------------------------------------
+
+@test "check_name: short filter is shown in full" {
+  run check_name "e2e" "snapshots"
+  [ "$output" = "e2e: snapshots" ]
+}
+
+@test "check_name: control characters are stripped" {
+  run check_name "e2e" "$(printf 'snap\x01shots')"
+  [ "$output" = "e2e: snapshots" ]
+}
+
+@test "check_name: a long filter is truncated and digested" {
+  long="$(printf 'a%.0s' {1..120})"
+  run check_name "e2e" "$long"
+  [[ "$output" == "e2e: aaa"* ]]
+  [[ "$output" == *"... ("* ]]
+  [ "${#output}" -lt 90 ]
+}
+
+@test "check_name: two different long filters do not collide" {
+  a="$(printf 'a%.0s' {1..80})x"
+  b="$(printf 'a%.0s' {1..80})y"
+  run check_name "e2e" "$a"
+  first="$output"
+  run check_name "e2e" "$b"
+  [ "$first" != "$output" ]
+}
+
+# --- resolve_conclusion ------------------------------------------------------
+
+@test "resolve_conclusion: an explicit report conclusion wins" {
+  run resolve_conclusion "success" "success" "success"
+  [ "$output" = "success" ]
+}
+
+@test "resolve_conclusion: neutral is reachable only from the report" {
+  run resolve_conclusion "neutral" "success" "success"
+  [ "$output" = "neutral" ]
+}
+
+@test "resolve_conclusion: a skipped suite after a good build is a failure, not neutral" {
+  run resolve_conclusion "" "success" "skipped"
+  [ "$output" = "failure" ]
+}
+
+@test "resolve_conclusion: an empty report after the job ran is a failure, not cancelled" {
+  run resolve_conclusion "" "success" "failure"
+  [ "$output" = "failure" ]
+}
+
+@test "resolve_conclusion: a build failure is a failure" {
+  run resolve_conclusion "" "failure" "skipped"
+  [ "$output" = "failure" ]
+}
+
+@test "resolve_conclusion: cancelling the whole run reads as cancelled, not failure" {
+  run resolve_conclusion "" "cancelled" "skipped"
+  [ "$output" = "cancelled" ]
+}
+
+@test "resolve_conclusion: a genuinely cancelled suite is cancelled" {
+  run resolve_conclusion "" "success" "cancelled"
+  [ "$output" = "cancelled" ]
+}
+
+# The warning names the rejected value, so it has to be kept out of the
+# assertion: `run` merges stderr into $output. Capture stdout on its own.
+@test "resolve_conclusion: an unrecognised report conclusion fails closed" {
+  result="$(resolve_conclusion "action_required" "success" "success" 2>/dev/null)"
+  [ "$result" = "failure" ]
+}
+
+@test "resolve_conclusion: rejecting a bad value warns rather than passing it through" {
+  warning="$(resolve_conclusion "action_required" "success" "success" 2>&1 >/dev/null)"
+  [[ "$warning" == *"::warning::"* ]]
+  [[ "$warning" == *"action_required"* ]]
+}
+
+@test "resolve_conclusion: skipped is not accepted from the report" {
+  result="$(resolve_conclusion "skipped" "success" "success" 2>/dev/null)"
+  [ "$result" = "failure" ]
+}
+
+@test "resolve_conclusion: every unmapped combination is a failure" {
+  for build in success failure skipped; do
+    for suite in success failure skipped; do
+      run resolve_conclusion "" "$build" "$suite"
+      [ "$output" = "failure" ]
+    done
+  done
+}
+
+# --- is_authorized_association -----------------------------------------------
+
+@test "is_authorized_association: an owner may run it" {
+  run is_authorized_association "OWNER"
+  [ "$status" -eq 0 ]
+}
+
+@test "is_authorized_association: an org member may run it" {
+  run is_authorized_association "MEMBER"
+  [ "$status" -eq 0 ]
+}
+
+@test "is_authorized_association: a collaborator may run it" {
+  run is_authorized_association "COLLABORATOR"
+  [ "$status" -eq 0 ]
+}
+
+@test "is_authorized_association: a past contributor may not" {
+  run is_authorized_association "CONTRIBUTOR"
+  [ "$status" -ne 0 ]
+}
+
+@test "is_authorized_association: an outsider may not" {
+  run is_authorized_association "NONE"
+  [ "$status" -ne 0 ]
+}
+
+@test "is_authorized_association: a first-time contributor may not" {
+  run is_authorized_association "FIRST_TIME_CONTRIBUTOR"
+  [ "$status" -ne 0 ]
+}
+
+@test "is_authorized_association: empty is a no, not a default yes" {
+  run is_authorized_association ""
+  [ "$status" -ne 0 ]
+}
+
+@test "is_authorized_association: an unrecognised value is a no" {
+  run is_authorized_association "MANNEQUIN"
+  [ "$status" -ne 0 ]
+}
+
+@test "is_authorized_association: matching is exact, not substring" {
+  run is_authorized_association "OWNE"
+  [ "$status" -ne 0 ]
+}

--- a/.github/actions/comment-triggered-check/test/lib.bats
+++ b/.github/actions/comment-triggered-check/test/lib.bats
@@ -216,6 +216,18 @@ setup() {
   [ "$result" = "failure" ]
 }
 
+# The list is checked word by word. Substring membership passed any adjacent
+# slice of it, and the value went to the Checks API verbatim.
+@test "resolve_conclusion: a multi-token value is not a member of the list" {
+  result="$(resolve_conclusion "success failure" "success" "success" 2>/dev/null)"
+  [ "$result" = "failure" ]
+}
+
+@test "resolve_conclusion: a trailing slice of the list is rejected too" {
+  result="$(resolve_conclusion "neutral cancelled" "success" "success" 2>/dev/null)"
+  [ "$result" = "failure" ]
+}
+
 @test "resolve_conclusion: rejecting a bad value warns rather than passing it through" {
   warning="$(resolve_conclusion "action_required" "success" "success" 2>&1 >/dev/null)"
   [[ "$warning" == *"::warning::"* ]]

--- a/.github/actions/comment-triggered-check/test/start.bats
+++ b/.github/actions/comment-triggered-check/test/start.bats
@@ -160,6 +160,15 @@ created() { calls_matching "POST"; }
   [ "$(kv should-run)" = "false" ]
 }
 
+# A 200 with no id leaves a check-run on the commit that nothing can ever close.
+@test "a create returning no id is reported, not returned as success" {
+  export GH_MOCK_CREATE_JSON='{}'
+  run bash "$SCRIPT"
+  [ "$(kv reason)" = "check-run-not-created" ]
+  [ "$(kv check-run-id)" = "" ]
+  [ "$(kv should-run)" = "false" ]
+}
+
 # --- quiet paths -------------------------------------------------------------
 
 @test "an ordinary comment touches no API at all" {

--- a/.github/actions/comment-triggered-check/test/start.bats
+++ b/.github/actions/comment-triggered-check/test/start.bats
@@ -45,10 +45,25 @@ created() { calls_matching "POST"; }
 }
 
 @test "resolves a release-line base ref, not just the head sha" {
-  export GH_MOCK_PR_JSON='{"head":{"sha":"deadbee","repo":{"full_name":"loft-sh/demo"}},"base":{"ref":"v0.29"},"state":"open"}'
+  export GH_MOCK_PR_JSON='{"head":{"sha":"deadbee","ref":"fix/thing","repo":{"full_name":"loft-sh/demo"}},"base":{"ref":"v0.29"},"state":"open"}'
   run bash "$SCRIPT"
   [ "$(kv base-ref)" = "v0.29" ]
   [ "$(kv head-sha)" = "deadbee" ]
+}
+
+# A caller that hands the work to a non-privileged run dispatches by branch, and
+# `gh workflow run --ref` will not take a SHA.
+@test "resolves the head branch as well as the head sha" {
+  export GH_MOCK_PR_JSON='{"head":{"sha":"deadbee","ref":"fix/thing","repo":{"full_name":"loft-sh/demo"}},"base":{"ref":"v0.29"},"state":"open"}'
+  run bash "$SCRIPT"
+  [ "$(kv head-ref)" = "fix/thing" ]
+}
+
+@test "a payload with no head ref is treated as unreadable" {
+  export GH_MOCK_PR_JSON='{"head":{"sha":"abc123","repo":{"full_name":"loft-sh/demo"}},"base":{"ref":"main"},"state":"open"}'
+  run bash "$SCRIPT"
+  [ "$(kv reason)" = "pull-request-unreadable" ]
+  [ "$(created)" -eq 0 ]
 }
 
 @test "the whole happy path costs exactly two API calls" {
@@ -92,7 +107,7 @@ created() { calls_matching "POST"; }
 }
 
 @test "a fork pull request is refused and nothing is created" {
-  export GH_MOCK_PR_JSON='{"head":{"sha":"abc123","repo":{"full_name":"someone/demo"}},"base":{"ref":"main"},"state":"open"}'
+  export GH_MOCK_PR_JSON='{"head":{"sha":"abc123","ref":"feature/x","repo":{"full_name":"someone/demo"}},"base":{"ref":"main"},"state":"open"}'
   run bash "$SCRIPT"
   [ "$(kv reason)" = "fork" ]
   [ "$(kv should-run)" = "false" ]
@@ -100,7 +115,7 @@ created() { calls_matching "POST"; }
 }
 
 @test "a closed pull request is refused" {
-  export GH_MOCK_PR_JSON='{"head":{"sha":"abc123","repo":{"full_name":"loft-sh/demo"}},"base":{"ref":"main"},"state":"closed"}'
+  export GH_MOCK_PR_JSON='{"head":{"sha":"abc123","ref":"feature/x","repo":{"full_name":"loft-sh/demo"}},"base":{"ref":"main"},"state":"closed"}'
   run bash "$SCRIPT"
   [ "$(kv reason)" = "pull-request-closed" ]
   [ "$(created)" -eq 0 ]
@@ -116,7 +131,7 @@ created() { calls_matching "POST"; }
 }
 
 @test "a pull request payload missing the base ref is treated as unreadable" {
-  export GH_MOCK_PR_JSON='{"head":{"sha":"abc123","repo":{"full_name":"loft-sh/demo"}},"state":"open"}'
+  export GH_MOCK_PR_JSON='{"head":{"sha":"abc123","ref":"feature/x","repo":{"full_name":"loft-sh/demo"}},"state":"open"}'
   run bash "$SCRIPT"
   [ "$(kv reason)" = "pull-request-unreadable" ]
   [ "$(created)" -eq 0 ]

--- a/.github/actions/comment-triggered-check/test/start.bats
+++ b/.github/actions/comment-triggered-check/test/start.bats
@@ -1,0 +1,154 @@
+#!/usr/bin/env bats
+# API-level tests for start.sh against a stubbed gh.
+#
+# The rule these pin down: a path that cannot confirm what it needs must refuse
+# to open a check-run, rather than fall through and start work on a guess.
+
+load gh_mock
+
+SCRIPT="$BATS_TEST_DIRNAME/../src/start.sh"
+
+setup() {
+  setup_gh_mock
+  export GITHUB_OUTPUT; GITHUB_OUTPUT="$(mktemp)"
+  export INPUT_COMMAND="/test"
+  export INPUT_COMMENT_BODY="/test snapshots"
+  export INPUT_COMMENT_AUTHOR="dev"
+  export INPUT_AUTHOR_ASSOCIATION="MEMBER"
+  export INPUT_PR_NUMBER="7"
+  export INPUT_REPO="loft-sh/demo"
+  export INPUT_CHECK_NAME_PREFIX="e2e"
+  export INPUT_RUN_ID="999"
+  export INPUT_SERVER_URL="https://github.com"
+  export GH_TOKEN="x"
+}
+
+teardown() {
+  rm -f "$GITHUB_OUTPUT"
+  teardown_gh_mock
+}
+
+kv() { grep "^$1=" "$GITHUB_OUTPUT" | tail -n1 | cut -d= -f2-; }
+created() { calls_matching "POST"; }
+
+# --- happy path --------------------------------------------------------------
+
+@test "opens a check-run and returns the identity the event does not carry" {
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv matched)" = "true" ]
+  [ "$(kv should-run)" = "true" ]
+  [ "$(kv head-sha)" = "abc123" ]
+  [ "$(kv base-ref)" = "main" ]
+  [ "$(kv check-run-id)" = "4242" ]
+  [ "$(kv reason)" = "" ]
+}
+
+@test "resolves a release-line base ref, not just the head sha" {
+  export GH_MOCK_PR_JSON='{"head":{"sha":"deadbee","repo":{"full_name":"loft-sh/demo"}},"base":{"ref":"v0.29"},"state":"open"}'
+  run bash "$SCRIPT"
+  [ "$(kv base-ref)" = "v0.29" ]
+  [ "$(kv head-sha)" = "deadbee" ]
+}
+
+@test "the whole happy path costs exactly two API calls" {
+  run bash "$SCRIPT"
+  [ "$(call_count)" -eq 2 ]
+}
+
+@test "emits a concurrency key the caller can interpolate safely" {
+  export INPUT_COMMENT_BODY='/test containsAny {aws, azure}'
+  run bash "$SCRIPT"
+  key="$(kv concurrency-key)"
+  [[ "$key" =~ ^containsany-aws-azure-[0-9a-f]{8}$ ]]
+}
+
+@test "the emitted key distinguishes filters the slug alone would merge" {
+  export INPUT_COMMENT_BODY='/test snapshots && aws'
+  run bash "$SCRIPT"
+  first="$(kv concurrency-key)"
+
+  : > "$GITHUB_OUTPUT"
+  export INPUT_COMMENT_BODY='/test snapshots || aws'
+  run bash "$SCRIPT"
+  [ "$first" != "$(kv concurrency-key)" ]
+}
+
+# --- authorization -----------------------------------------------------------
+
+@test "a past contributor cannot run it, and no API call is made" {
+  export INPUT_AUTHOR_ASSOCIATION="CONTRIBUTOR"
+  run bash "$SCRIPT"
+  [ "$(kv reason)" = "insufficient-permission" ]
+  [ "$(kv should-run)" = "false" ]
+  [ "$(call_count)" -eq 0 ]
+}
+
+@test "a missing association is refused rather than defaulted to allowed" {
+  export INPUT_AUTHOR_ASSOCIATION=""
+  run bash "$SCRIPT"
+  [ "$(kv reason)" = "insufficient-permission" ]
+  [ "$(call_count)" -eq 0 ]
+}
+
+@test "a fork pull request is refused and nothing is created" {
+  export GH_MOCK_PR_JSON='{"head":{"sha":"abc123","repo":{"full_name":"someone/demo"}},"base":{"ref":"main"},"state":"open"}'
+  run bash "$SCRIPT"
+  [ "$(kv reason)" = "fork" ]
+  [ "$(kv should-run)" = "false" ]
+  [ "$(created)" -eq 0 ]
+}
+
+@test "a closed pull request is refused" {
+  export GH_MOCK_PR_JSON='{"head":{"sha":"abc123","repo":{"full_name":"loft-sh/demo"}},"base":{"ref":"main"},"state":"closed"}'
+  run bash "$SCRIPT"
+  [ "$(kv reason)" = "pull-request-closed" ]
+  [ "$(created)" -eq 0 ]
+}
+
+# --- API failures must not fall through -------------------------------------
+
+@test "an unreadable pull request stops rather than guessing" {
+  export GH_MOCK_PR_FAIL=1
+  run bash "$SCRIPT"
+  [ "$(kv reason)" = "pull-request-unreadable" ]
+  [ "$(created)" -eq 0 ]
+}
+
+@test "a pull request payload missing the base ref is treated as unreadable" {
+  export GH_MOCK_PR_JSON='{"head":{"sha":"abc123","repo":{"full_name":"loft-sh/demo"}},"state":"open"}'
+  run bash "$SCRIPT"
+  [ "$(kv reason)" = "pull-request-unreadable" ]
+  [ "$(created)" -eq 0 ]
+}
+
+@test "a failed create is reported, not returned as success" {
+  export GH_MOCK_CREATE_FAIL=1
+  run bash "$SCRIPT"
+  [ "$(kv reason)" = "check-run-not-created" ]
+  [ "$(kv check-run-id)" = "" ]
+  [ "$(kv should-run)" = "false" ]
+}
+
+# --- quiet paths -------------------------------------------------------------
+
+@test "an ordinary comment touches no API at all" {
+  export INPUT_COMMENT_BODY="LGTM"
+  run bash "$SCRIPT"
+  [ "$(kv matched)" = "false" ]
+  [ "$(call_count)" -eq 0 ]
+}
+
+@test "an empty filter is reported before any API call" {
+  export INPUT_COMMENT_BODY="/test"
+  run bash "$SCRIPT"
+  [ "$(kv reason)" = "empty-filter" ]
+  [ "$(call_count)" -eq 0 ]
+}
+
+@test "a comment outside a pull request is reported before any API call" {
+  export INPUT_PR_NUMBER=""
+  run bash "$SCRIPT"
+  [ "$(kv reason)" = "not-a-pull-request" ]
+  [ "$(call_count)" -eq 0 ]
+}

--- a/.github/actions/comment-triggered-check/test/start.bats
+++ b/.github/actions/comment-triggered-check/test/start.bats
@@ -51,6 +51,21 @@ created() { calls_matching "POST"; }
   [ "$(kv head-sha)" = "deadbee" ]
 }
 
+# GitHub overrides details_url for check-runs owned by the github-actions app,
+# so the summary carries the only link back to the logs that survives. Losing it
+# leaves a check whose "View details" goes nowhere useful while the suite runs.
+@test "the opened check-run links to the run from its summary" {
+  run bash "$SCRIPT"
+  [ "$(calls_matching 'View the run.*actions/runs/999')" -ge 1 ]
+}
+
+@test "no run id means no link rather than a broken one" {
+  export INPUT_RUN_ID=""
+  run bash "$SCRIPT"
+  [ "$(calls_matching 'View the run')" -eq 0 ]
+  [ "$(kv check-run-id)" = "4242" ]
+}
+
 # A caller that hands the work to a non-privileged run dispatches by branch, and
 # `gh workflow run --ref` will not take a SHA.
 @test "resolves the head branch as well as the head sha" {

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,3 +30,12 @@ jobs:
         with:
           persist-credentials: false
       - run: pip install zizmor==1.24.1 && zizmor .github/
+
+  bats-jobs:
+    name: Check bats jobs run their suites
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - run: make check-bats-jobs

--- a/.github/workflows/test-ai-pr-review.yaml
+++ b/.github/workflows/test-ai-pr-review.yaml
@@ -5,6 +5,7 @@ on:
     paths:
       - '.github/workflows/ai-pr-review.yaml'
       - '.github/actions/ai-pr-review/**'
+      - '.github/workflows/test-ai-pr-review.yaml'
 
 permissions:
   contents: read
@@ -19,7 +20,12 @@ jobs:
           persist-credentials: false
       - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
         with:
-          tests: .github/actions/ai-pr-review/test
+          support-install: false
+          assert-install: false
+          detik-install: false
+          file-install: false
+      - name: Run ai-pr-review tests
+        run: bats .github/actions/ai-pr-review/test/*.bats
 
   # Composite smoke tests used to rely on the allowed-bots filter to
   # short-circuit before spending API tokens on human-authored PRs. With

--- a/.github/workflows/test-ai-step.yaml
+++ b/.github/workflows/test-ai-step.yaml
@@ -17,6 +17,16 @@ on:
         type: choice
         options: [low, medium, high]
         default: low
+      agent:
+        description: >-
+          Deployed managed-agent name for the session smoke test.
+          Leave empty to run the single-call smoke instead.
+        type: string
+        default: ''
+      vault-id:
+        description: 'Optional vault id to attach to the session smoke'
+        type: string
+        default: ''
 
 permissions:
   contents: read
@@ -38,13 +48,25 @@ jobs:
       - name: Run ai-step tests
         run: bats .github/actions/ai-step/test/*.bats
 
+  pytest:
+    name: Run session-lifecycle tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Install test dependencies
+        run: python3 -m pip install --quiet --disable-pip-version-check pytest jsonschema
+      - name: Run pytest
+        run: python3 -m pytest .github/actions/ai-step/test/ -q
+
   # Live smoke test. Spends real tokens, so gated behind workflow_dispatch
   # only — never runs on PR events. Proves the whole pipeline: schema is
   # forwarded to the provider, model returns JSON conforming to it, the
   # action re-exposes it on `result`, and `fromJSON(...)` parses cleanly
   # downstream.
   smoke:
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch' && inputs.agent == ''
     name: Live smoke (${{ inputs.provider }}, ${{ inputs.effort }})
     runs-on: ubuntu-latest
     steps:
@@ -92,3 +114,73 @@ jobs:
           echo "$RESULT" | jq -e '.confidence | type == "number"' >/dev/null \
             || { echo "::error::confidence field missing or not a number"; exit 1; }
           echo "ai-step returned schema-conforming JSON"
+
+  # Live session smoke. Spends session-scale tokens (minutes, not
+  # seconds), so gated behind workflow_dispatch with an explicit agent
+  # name — never runs on PR events. Proves the session mode end to end:
+  # agent resolved by name, session created and driven through one turn,
+  # final message validated against the schema and re-exposed on
+  # `result`, session and environment deleted afterwards.
+  session-smoke:
+    if: github.event_name == 'workflow_dispatch' && inputs.agent != ''
+    name: Live session smoke (${{ inputs.agent }})
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - id: agent
+        uses: ./.github/actions/ai-step
+        with:
+          provider: anthropic
+          agent: ${{ inputs.agent }}
+          vault-id: ${{ inputs.vault-id }}
+          prompt: |
+            This is a CI smoke test of the session trigger path. Do not
+            start any real work and change nothing. Reply with a single
+            JSON object matching the schema: set ok to true, and in note
+            name one fact you can read from your memory store (or say
+            the store is empty). Keep note under 200 characters.
+          output-schema: |
+            {
+              "type": "object",
+              "required": ["ok", "note"],
+              "properties": {
+                "ok":   { "type": "boolean" },
+                "note": { "type": "string" }
+              }
+            }
+          anthropic-session-key: ${{ secrets.ANTHROPIC_SESSION_KEY }}
+
+      - name: Assert structured output
+        env:
+          RESULT: ${{ steps.agent.outputs.result }}
+          CONCLUSION: ${{ steps.agent.outputs.conclusion }}
+          REASON: ${{ steps.agent.outputs.reason }}
+        run: |
+          echo "conclusion=$CONCLUSION"
+          echo "result=$RESULT"
+          [ "$CONCLUSION" = "success" ] || { echo "::error::expected conclusion=success, got '$CONCLUSION' (reason: $REASON)"; exit 1; }
+          [ -n "$RESULT" ] || { echo "::error::empty result"; exit 1; }
+          echo "$RESULT" | jq -e '.ok == true' >/dev/null \
+            || { echo "::error::ok field missing or not true"; exit 1; }
+          echo "$RESULT" | jq -e '.note | type == "string"' >/dev/null \
+            || { echo "::error::note field missing or not a string"; exit 1; }
+          echo "ai-step session mode returned schema-conforming JSON"
+
+      # Acceptance criterion 4: every session the action creates is
+      # deleted before the step ends, confirmed against a live listing.
+      - name: Assert session was deleted
+        env:
+          ANTHROPIC_SESSION_KEY: ${{ secrets.ANTHROPIC_SESSION_KEY }}
+          TITLE: ai-step ${{ github.repository }}#${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          leftover=$(curl -sS https://api.anthropic.com/v1/sessions?limit=100 \
+            -H "x-api-key: $ANTHROPIC_SESSION_KEY" \
+            -H "anthropic-beta: managed-agents-2026-04-01" \
+            | jq '[.data[]? | select(.title == env.TITLE)] | length')
+          [ "$leftover" = "0" ] \
+            || { echo "::error::$leftover session(s) titled '$TITLE' still listed — cleanup regressed"; exit 1; }
+          echo "no leftover session titled '$TITLE'"

--- a/.github/workflows/test-ai-step.yaml
+++ b/.github/workflows/test-ai-step.yaml
@@ -31,7 +31,12 @@ jobs:
           persist-credentials: false
       - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
         with:
-          tests: .github/actions/ai-step/test
+          support-install: false
+          assert-install: false
+          detik-install: false
+          file-install: false
+      - name: Run ai-step tests
+        run: bats .github/actions/ai-step/test/*.bats
 
   # Live smoke test. Spends real tokens, so gated behind workflow_dispatch
   # only — never runs on PR events. Proves the whole pipeline: schema is

--- a/.github/workflows/test-auto-approve-bot-prs.yaml
+++ b/.github/workflows/test-auto-approve-bot-prs.yaml
@@ -5,6 +5,7 @@ on:
     paths:
       - '.github/workflows/auto-approve-bot-prs.yaml'
       - '.github/actions/auto-approve-bot-prs/**'
+      - '.github/workflows/test-auto-approve-bot-prs.yaml'
 
 permissions:
   contents: read
@@ -19,7 +20,12 @@ jobs:
           persist-credentials: false
       - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
         with:
-          tests: .github/actions/auto-approve-bot-prs/test
+          support-install: false
+          assert-install: false
+          detik-install: false
+          file-install: false
+      - name: Run auto-approve-bot-prs tests
+        run: bats .github/actions/auto-approve-bot-prs/test/*.bats
 
   # Smoke test the composite action on the PR branch (the reusable workflow
   # pins ref: main, which wouldn't yet contain the composite during this

--- a/.github/workflows/test-aws-test-infra.yaml
+++ b/.github/workflows/test-aws-test-infra.yaml
@@ -5,9 +5,11 @@ on:
     branches: [main]
     paths:
       - '.github/actions/aws-test-infra/**'
+      - '.github/workflows/test-aws-test-infra.yaml'
   pull_request:
     paths:
       - '.github/actions/aws-test-infra/**'
+      - '.github/workflows/test-aws-test-infra.yaml'
 
 jobs:
   test:
@@ -39,4 +41,9 @@ jobs:
           persist-credentials: false
       - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
         with:
-          tests: .github/actions/aws-test-infra/test
+          support-install: false
+          assert-install: false
+          detik-install: false
+          file-install: false
+      - name: Run aws-test-infra tests
+        run: bats .github/actions/aws-test-infra/test/*.bats

--- a/.github/workflows/test-backport-legacy-allowlist.yaml
+++ b/.github/workflows/test-backport-legacy-allowlist.yaml
@@ -18,4 +18,9 @@ jobs:
           persist-credentials: false
       - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
         with:
-          tests: .github/actions/backport-legacy-allowlist/test
+          support-install: false
+          assert-install: false
+          detik-install: false
+          file-install: false
+      - name: Run backport-legacy-allowlist tests
+        run: bats .github/actions/backport-legacy-allowlist/test/*.bats

--- a/.github/workflows/test-backport-legacy-split.yaml
+++ b/.github/workflows/test-backport-legacy-split.yaml
@@ -18,4 +18,9 @@ jobs:
           persist-credentials: false
       - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
         with:
-          tests: .github/actions/backport-legacy-split/test
+          support-install: false
+          assert-install: false
+          detik-install: false
+          file-install: false
+      - name: Run backport-legacy-split tests
+        run: bats .github/actions/backport-legacy-split/test/*.bats

--- a/.github/workflows/test-ci-test-notify.yaml
+++ b/.github/workflows/test-ci-test-notify.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - '.github/actions/ci-test-notify/**'
+      - '.github/workflows/test-ci-test-notify.yaml'
 
 permissions: {}
 
@@ -17,4 +18,9 @@ jobs:
           persist-credentials: false
       - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
         with:
-          tests: .github/actions/ci-test-notify/test
+          support-install: false
+          assert-install: false
+          detik-install: false
+          file-install: false
+      - name: Run ci-test-notify tests
+        run: bats .github/actions/ci-test-notify/test/*.bats

--- a/.github/workflows/test-cleanup-head-charts.yaml
+++ b/.github/workflows/test-cleanup-head-charts.yaml
@@ -5,6 +5,7 @@ on:
     paths:
       - '.github/scripts/cleanup-head-charts/**'
       - '.github/workflows/cleanup-head-charts.yaml'
+      - '.github/workflows/test-cleanup-head-charts.yaml'
 
 permissions: {}
 
@@ -18,4 +19,9 @@ jobs:
           persist-credentials: false
       - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
         with:
-          tests: .github/scripts/cleanup-head-charts/test
+          support-install: false
+          assert-install: false
+          detik-install: false
+          file-install: false
+      - name: Run cleanup-head-charts tests
+        run: bats .github/scripts/cleanup-head-charts/test/*.bats

--- a/.github/workflows/test-comment-triggered-check.yaml
+++ b/.github/workflows/test-comment-triggered-check.yaml
@@ -19,7 +19,12 @@ jobs:
           persist-credentials: false
       - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
         with:
-          tests: .github/actions/comment-triggered-check/test
+          support-install: false
+          assert-install: false
+          detik-install: false
+          file-install: false
+      - name: Run comment-triggered-check tests
+        run: bats .github/actions/comment-triggered-check/test/*.bats
 
   composite-smoke:
     name: Composite smoke (paths that need no API)

--- a/.github/workflows/test-comment-triggered-check.yaml
+++ b/.github/workflows/test-comment-triggered-check.yaml
@@ -1,0 +1,159 @@
+name: Test comment-triggered-check
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/test-comment-triggered-check.yaml'
+      - '.github/actions/comment-triggered-check/**'
+
+permissions:
+  contents: read
+
+jobs:
+  bats:
+    name: Run bats tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
+        with:
+          tests: .github/actions/comment-triggered-check/test
+
+  composite-smoke:
+    name: Composite smoke (paths that need no API)
+    runs-on: ubuntu-latest
+    # Every case below returns before the action touches the API, so this job
+    # needs no elevated permissions and no pull request fixture. The API paths
+    # are exercised by the caller in vcluster-pro; what is pinned here is that
+    # the action stays quiet and well-formed on the paths it takes for the vast
+    # majority of comments in a repository.
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: An ordinary comment is not a command
+        id: not-a-command
+        uses: ./.github/actions/comment-triggered-check
+        with:
+          mode: start
+          comment-body: 'LGTM, nice work'
+          comment-author: someone
+          pr-number: '1'
+
+      - name: Verify it did not match and emitted the full output set
+        env:
+          MATCHED: ${{ steps.not-a-command.outputs.matched }}
+          AUTHORIZED: ${{ steps.not-a-command.outputs.should-run }}
+          CHECK_RUN_ID: ${{ steps.not-a-command.outputs.check-run-id }}
+        run: |
+          echo "matched=$MATCHED should-run=$AUTHORIZED"
+          [[ "$MATCHED" == "false" ]]
+          [[ "$AUTHORIZED" == "false" ]]
+          [[ -z "$CHECK_RUN_ID" ]]
+
+      - name: A command quoted mid-thread does not fire
+        id: quoted
+        uses: ./.github/actions/comment-triggered-check
+        with:
+          mode: start
+          comment-body: |
+            we should run
+            /test snapshots
+            once this lands
+          comment-author: someone
+          pr-number: '1'
+
+      - name: Verify the quoted command did not match
+        env:
+          MATCHED: ${{ steps.quoted.outputs.matched }}
+        run: |
+          echo "matched=$MATCHED"
+          [[ "$MATCHED" == "false" ]]
+
+      - name: A command with no filter is reported, not run
+        id: empty-filter
+        uses: ./.github/actions/comment-triggered-check
+        with:
+          mode: start
+          comment-body: '/test'
+          comment-author: someone
+          pr-number: '1'
+
+      - name: Verify the empty-filter reason
+        env:
+          MATCHED: ${{ steps.empty-filter.outputs.matched }}
+          REASON: ${{ steps.empty-filter.outputs.reason }}
+          AUTHORIZED: ${{ steps.empty-filter.outputs.should-run }}
+        run: |
+          echo "matched=$MATCHED reason=$REASON should-run=$AUTHORIZED"
+          [[ "$MATCHED" == "true" ]]
+          [[ "$REASON" == "empty-filter" ]]
+          [[ "$AUTHORIZED" == "false" ]]
+
+      - name: An outsider cannot run the command
+        id: outsider
+        uses: ./.github/actions/comment-triggered-check
+        with:
+          mode: start
+          comment-body: '/test snapshots'
+          comment-author: someone
+          author-association: CONTRIBUTOR
+          pr-number: '1'
+
+      - name: Verify the outsider was refused
+        env:
+          REASON: ${{ steps.outsider.outputs.reason }}
+          AUTHORIZED: ${{ steps.outsider.outputs.should-run }}
+        run: |
+          echo "reason=$REASON should-run=$AUTHORIZED"
+          [[ "$REASON" == "insufficient-permission" ]]
+          [[ "$AUTHORIZED" == "false" ]]
+
+      - name: A comment outside a pull request is reported, not run
+        id: not-a-pr
+        uses: ./.github/actions/comment-triggered-check
+        with:
+          mode: start
+          comment-body: '/test snapshots'
+          comment-author: someone
+          pr-number: ''
+
+      - name: Verify the not-a-pull-request reason
+        env:
+          REASON: ${{ steps.not-a-pr.outputs.reason }}
+        run: |
+          echo "reason=$REASON"
+          [[ "$REASON" == "not-a-pull-request" ]]
+
+      - name: finish with no check-run is a no-op, not an error
+        id: finish-noop
+        uses: ./.github/actions/comment-triggered-check
+        with:
+          mode: finish
+          check-run-id: ''
+          build-result: success
+          suite-result: success
+
+      - name: Verify the no-op published nothing
+        env:
+          CONCLUSION: ${{ steps.finish-noop.outputs.conclusion }}
+        run: |
+          echo "conclusion=$CONCLUSION"
+          [[ -z "$CONCLUSION" ]]
+
+      - name: An unknown mode fails loudly
+        id: bad-mode
+        continue-on-error: true
+        uses: ./.github/actions/comment-triggered-check
+        with:
+          mode: sideways
+
+      - name: Verify the unknown mode failed
+        env:
+          OUTCOME: ${{ steps.bad-mode.outcome }}
+        run: |
+          echo "outcome=$OUTCOME"
+          [[ "$OUTCOME" == "failure" ]]

--- a/.github/workflows/test-comment-triggered-check.yaml
+++ b/.github/workflows/test-comment-triggered-check.yaml
@@ -46,12 +46,12 @@ jobs:
       - name: Verify it did not match and emitted the full output set
         env:
           MATCHED: ${{ steps.not-a-command.outputs.matched }}
-          AUTHORIZED: ${{ steps.not-a-command.outputs.should-run }}
+          SHOULD_RUN: ${{ steps.not-a-command.outputs.should-run }}
           CHECK_RUN_ID: ${{ steps.not-a-command.outputs.check-run-id }}
         run: |
-          echo "matched=$MATCHED should-run=$AUTHORIZED"
+          echo "matched=$MATCHED should-run=$SHOULD_RUN"
           [[ "$MATCHED" == "false" ]]
-          [[ "$AUTHORIZED" == "false" ]]
+          [[ "$SHOULD_RUN" == "false" ]]
           [[ -z "$CHECK_RUN_ID" ]]
 
       - name: A command quoted mid-thread does not fire
@@ -86,12 +86,12 @@ jobs:
         env:
           MATCHED: ${{ steps.empty-filter.outputs.matched }}
           REASON: ${{ steps.empty-filter.outputs.reason }}
-          AUTHORIZED: ${{ steps.empty-filter.outputs.should-run }}
+          SHOULD_RUN: ${{ steps.empty-filter.outputs.should-run }}
         run: |
-          echo "matched=$MATCHED reason=$REASON should-run=$AUTHORIZED"
+          echo "matched=$MATCHED reason=$REASON should-run=$SHOULD_RUN"
           [[ "$MATCHED" == "true" ]]
           [[ "$REASON" == "empty-filter" ]]
-          [[ "$AUTHORIZED" == "false" ]]
+          [[ "$SHOULD_RUN" == "false" ]]
 
       - name: An outsider cannot run the command
         id: outsider
@@ -106,11 +106,11 @@ jobs:
       - name: Verify the outsider was refused
         env:
           REASON: ${{ steps.outsider.outputs.reason }}
-          AUTHORIZED: ${{ steps.outsider.outputs.should-run }}
+          SHOULD_RUN: ${{ steps.outsider.outputs.should-run }}
         run: |
-          echo "reason=$REASON should-run=$AUTHORIZED"
+          echo "reason=$REASON should-run=$SHOULD_RUN"
           [[ "$REASON" == "insufficient-permission" ]]
-          [[ "$AUTHORIZED" == "false" ]]
+          [[ "$SHOULD_RUN" == "false" ]]
 
       - name: A comment outside a pull request is reported, not run
         id: not-a-pr

--- a/.github/workflows/test-go-licenses.yaml
+++ b/.github/workflows/test-go-licenses.yaml
@@ -18,4 +18,9 @@ jobs:
           persist-credentials: false
       - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
         with:
-          tests: .github/actions/go-licenses/test
+          support-install: false
+          assert-install: false
+          detik-install: false
+          file-install: false
+      - name: Run go-licenses tests
+        run: bats .github/actions/go-licenses/test/*.bats

--- a/.github/workflows/test-govulncheck.yaml
+++ b/.github/workflows/test-govulncheck.yaml
@@ -18,4 +18,9 @@ jobs:
           persist-credentials: false
       - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
         with:
-          tests: .github/actions/govulncheck/test
+          support-install: false
+          assert-install: false
+          detik-install: false
+          file-install: false
+      - name: Run govulncheck tests
+        run: bats .github/actions/govulncheck/test/*.bats

--- a/.github/workflows/test-oss-commit-sync.yaml
+++ b/.github/workflows/test-oss-commit-sync.yaml
@@ -18,4 +18,9 @@ jobs:
           persist-credentials: false
       - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
         with:
-          tests: .github/actions/oss-commit-sync/test
+          support-install: false
+          assert-install: false
+          detik-install: false
+          file-install: false
+      - name: Run oss-commit-sync tests
+        run: bats .github/actions/oss-commit-sync/test/*.bats

--- a/.github/workflows/test-parse-label-filter.yaml
+++ b/.github/workflows/test-parse-label-filter.yaml
@@ -19,7 +19,12 @@ jobs:
           persist-credentials: false
       - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
         with:
-          tests: .github/actions/parse-label-filter/test
+          support-install: false
+          assert-install: false
+          detik-install: false
+          file-install: false
+      - name: Run parse-label-filter tests
+        run: bats .github/actions/parse-label-filter/test/*.bats
 
   composite-smoke:
     name: Composite smoke (parse + skip decision)

--- a/.github/workflows/test-prerelease-setup.yaml
+++ b/.github/workflows/test-prerelease-setup.yaml
@@ -19,4 +19,9 @@ jobs:
           persist-credentials: false
       - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
         with:
-          tests: .github/actions/prerelease-setup/test
+          support-install: false
+          assert-install: false
+          detik-install: false
+          file-install: false
+      - name: Run prerelease-setup tests
+        run: bats .github/actions/prerelease-setup/test/*.bats

--- a/.github/workflows/test-promote-release.yaml
+++ b/.github/workflows/test-promote-release.yaml
@@ -19,7 +19,12 @@ jobs:
           persist-credentials: false
       - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
         with:
-          tests: .github/actions/promote-release/test
+          support-install: false
+          assert-install: false
+          detik-install: false
+          file-install: false
+      - name: Run promote-release tests
+        run: bats .github/actions/promote-release/test/*.bats
 
   smoke:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-publish-helm-chart.yaml
+++ b/.github/workflows/test-publish-helm-chart.yaml
@@ -22,4 +22,9 @@ jobs:
           version: v4.53.3
       - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
         with:
-          tests: .github/actions/publish-helm-chart/test
+          support-install: false
+          assert-install: false
+          detik-install: false
+          file-install: false
+      - name: Run publish-helm-chart tests
+        run: bats .github/actions/publish-helm-chart/test/*.bats

--- a/.github/workflows/test-release-branch-freeze.yaml
+++ b/.github/workflows/test-release-branch-freeze.yaml
@@ -19,4 +19,9 @@ jobs:
           persist-credentials: false
       - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
         with:
-          tests: .github/actions/release-branch-freeze/test
+          support-install: false
+          assert-install: false
+          detik-install: false
+          file-install: false
+      - name: Run release-branch-freeze tests
+        run: bats .github/actions/release-branch-freeze/test/*.bats

--- a/.github/workflows/test-repository-dispatch.yaml
+++ b/.github/workflows/test-repository-dispatch.yaml
@@ -19,4 +19,9 @@ jobs:
           persist-credentials: false
       - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
         with:
-          tests: .github/actions/repository-dispatch/test
+          support-install: false
+          assert-install: false
+          detik-install: false
+          file-install: false
+      - name: Run repository-dispatch tests
+        run: bats .github/actions/repository-dispatch/test/*.bats

--- a/.github/workflows/test-run-ginkgo.yaml
+++ b/.github/workflows/test-run-ginkgo.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - '.github/actions/run-ginkgo/**'
+      - '.github/workflows/test-run-ginkgo.yaml'
 
 permissions: {}
 
@@ -17,7 +18,12 @@ jobs:
           persist-credentials: false
       - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
         with:
-          tests: .github/actions/run-ginkgo/test
+          support-install: false
+          assert-install: false
+          detik-install: false
+          file-install: false
+      - name: Run run-ginkgo tests
+        run: bats .github/actions/run-ginkgo/test/*.bats
 
   focus-selection:
     name: Run focus selection tests

--- a/.github/workflows/test-sticky-pr-comment.yaml
+++ b/.github/workflows/test-sticky-pr-comment.yaml
@@ -19,7 +19,12 @@ jobs:
           persist-credentials: false
       - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
         with:
-          tests: .github/actions/sticky-pr-comment/test
+          support-install: false
+          assert-install: false
+          detik-install: false
+          file-install: false
+      - name: Run sticky-pr-comment tests
+        run: bats .github/actions/sticky-pr-comment/test/*.bats
 
   composite-smoke:
     name: Composite smoke (create + update)

--- a/.github/workflows/test-subtree-mirror.yaml
+++ b/.github/workflows/test-subtree-mirror.yaml
@@ -18,4 +18,9 @@ jobs:
           persist-credentials: false
       - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
         with:
-          tests: .github/actions/subtree-mirror/test
+          support-install: false
+          assert-install: false
+          detik-install: false
+          file-install: false
+      - name: Run subtree-mirror tests
+        run: bats .github/actions/subtree-mirror/test/*.bats

--- a/.github/workflows/test-vcluster-release.yaml
+++ b/.github/workflows/test-vcluster-release.yaml
@@ -19,4 +19,9 @@ jobs:
           persist-credentials: false
       - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
         with:
-          tests: .github/actions/vcluster-release/test
+          support-install: false
+          assert-install: false
+          detik-install: false
+          file-install: false
+      - name: Run vcluster-release tests
+        run: bats .github/actions/vcluster-release/test/*.bats

--- a/.github/workflows/test-wait-for-release.yaml
+++ b/.github/workflows/test-wait-for-release.yaml
@@ -19,4 +19,9 @@ jobs:
           persist-credentials: false
       - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
         with:
-          tests: .github/actions/wait-for-release/test
+          support-install: false
+          assert-install: false
+          detik-install: false
+          file-install: false
+      - name: Run wait-for-release tests
+        run: bats .github/actions/wait-for-release/test/*.bats

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-semver-validation test-linear-pr-commenter test-link-backport-prs test-release-notification test-linear-release-sync test-aws-test-infra test-cleanup-head-charts test-ci-test-notify test-auto-approve-bot-prs test-ai-pr-review test-ai-step test-publish-helm-chart test-govulncheck test-go-licenses test-run-ginkgo test-sticky-pr-comment test-repository-dispatch test-parse-label-filter test-release-branch-freeze test-prerelease-setup test-vcluster-release test-subtree-mirror test-oss-commit-sync test-backport-legacy-allowlist test-backport-legacy-split test-promote-release test-wait-for-release test-cve-scan test-commitlint build-linear-release-sync lint install-auto-doc generate-docs check-docs help
+.PHONY: test test-semver-validation test-linear-pr-commenter test-link-backport-prs test-release-notification test-linear-release-sync test-aws-test-infra test-cleanup-head-charts test-ci-test-notify test-auto-approve-bot-prs test-ai-pr-review test-ai-step test-publish-helm-chart test-govulncheck test-go-licenses test-run-ginkgo test-sticky-pr-comment test-repository-dispatch test-parse-label-filter test-release-branch-freeze test-prerelease-setup test-vcluster-release test-subtree-mirror test-oss-commit-sync test-backport-legacy-allowlist test-backport-legacy-split test-promote-release test-wait-for-release test-cve-scan test-commitlint test-comment-triggered-check build-linear-release-sync lint install-auto-doc generate-docs check-docs help
 
 ACTIONS_DIR := .github/actions
 WORKFLOWS_DIR := .github/workflows
@@ -93,7 +93,7 @@ check-docs: generate-docs ## verify docs are up to date (fails if drift detected
 help: ## show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-30s %s\n", $$1, $$2}'
 
-test: test-semver-validation test-linear-pr-commenter test-link-backport-prs test-release-notification test-linear-release-sync test-aws-test-infra test-cleanup-head-charts test-auto-approve-bot-prs test-ai-pr-review test-ai-step test-ci-test-notify test-go-licenses test-publish-helm-chart test-govulncheck test-run-ginkgo test-sticky-pr-comment test-repository-dispatch test-parse-label-filter test-release-branch-freeze test-prerelease-setup test-vcluster-release test-subtree-mirror test-oss-commit-sync test-backport-legacy-allowlist test-backport-legacy-split test-promote-release test-wait-for-release test-cve-scan test-commitlitn ## run all action tests
+test: test-semver-validation test-linear-pr-commenter test-link-backport-prs test-release-notification test-linear-release-sync test-aws-test-infra test-cleanup-head-charts test-auto-approve-bot-prs test-ai-pr-review test-ai-step test-ci-test-notify test-go-licenses test-publish-helm-chart test-govulncheck test-run-ginkgo test-sticky-pr-comment test-repository-dispatch test-parse-label-filter test-release-branch-freeze test-prerelease-setup test-vcluster-release test-subtree-mirror test-oss-commit-sync test-backport-legacy-allowlist test-backport-legacy-split test-promote-release test-wait-for-release test-cve-scan test-commitlint test-comment-triggered-check ## run all action tests
 
 test-semver-validation: ## run semver-validation unit tests
 	cd $(ACTIONS_DIR)/semver-validation && npm ci --silent && NODE_OPTIONS=--experimental-vm-modules npx jest --ci --coverage --watchAll=false
@@ -153,6 +153,9 @@ test-repository-dispatch: ## run repository-dispatch bats tests
 
 test-parse-label-filter: ## run parse-label-filter bats tests
 	bats $(ACTIONS_DIR)/parse-label-filter/test
+
+test-comment-triggered-check: ## run comment-triggered-check bats tests
+	bats $(ACTIONS_DIR)/comment-triggered-check/test
 
 test-release-branch-freeze: ## run release-branch-freeze bats tests
 	bats $(ACTIONS_DIR)/release-branch-freeze/test

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-semver-validation test-linear-pr-commenter test-link-backport-prs test-release-notification test-linear-release-sync test-aws-test-infra test-cleanup-head-charts test-ci-test-notify test-auto-approve-bot-prs test-ai-pr-review test-ai-step test-publish-helm-chart test-govulncheck test-go-licenses test-run-ginkgo test-sticky-pr-comment test-repository-dispatch test-parse-label-filter test-release-branch-freeze test-prerelease-setup test-vcluster-release test-subtree-mirror test-oss-commit-sync test-backport-legacy-allowlist test-backport-legacy-split test-promote-release test-wait-for-release test-cve-scan test-commitlint build-linear-release-sync lint install-auto-doc generate-docs check-docs help
+.PHONY: test test-semver-validation test-linear-pr-commenter test-link-backport-prs test-release-notification test-linear-release-sync test-aws-test-infra test-cleanup-head-charts test-ci-test-notify test-auto-approve-bot-prs test-ai-pr-review test-ai-step test-publish-helm-chart test-govulncheck test-go-licenses test-run-ginkgo test-sticky-pr-comment test-repository-dispatch test-parse-label-filter test-release-branch-freeze test-prerelease-setup test-vcluster-release test-subtree-mirror test-oss-commit-sync test-backport-legacy-allowlist test-backport-legacy-split test-promote-release test-wait-for-release test-cve-scan test-commitlint build-linear-release-sync lint check-bats-jobs install-auto-doc generate-docs check-docs help
 
 ACTIONS_DIR := .github/actions
 WORKFLOWS_DIR := .github/workflows
@@ -93,7 +93,7 @@ check-docs: generate-docs ## verify docs are up to date (fails if drift detected
 help: ## show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-30s %s\n", $$1, $$2}'
 
-test: test-semver-validation test-linear-pr-commenter test-link-backport-prs test-release-notification test-linear-release-sync test-aws-test-infra test-cleanup-head-charts test-auto-approve-bot-prs test-ai-pr-review test-ai-step test-ci-test-notify test-go-licenses test-publish-helm-chart test-govulncheck test-run-ginkgo test-sticky-pr-comment test-repository-dispatch test-parse-label-filter test-release-branch-freeze test-prerelease-setup test-vcluster-release test-subtree-mirror test-oss-commit-sync test-backport-legacy-allowlist test-backport-legacy-split test-promote-release test-wait-for-release test-cve-scan test-commitlitn ## run all action tests
+test: test-semver-validation test-linear-pr-commenter test-link-backport-prs test-release-notification test-linear-release-sync test-aws-test-infra test-cleanup-head-charts test-auto-approve-bot-prs test-ai-pr-review test-ai-step test-ci-test-notify test-go-licenses test-publish-helm-chart test-govulncheck test-run-ginkgo test-sticky-pr-comment test-repository-dispatch test-parse-label-filter test-release-branch-freeze test-prerelease-setup test-vcluster-release test-subtree-mirror test-oss-commit-sync test-backport-legacy-allowlist test-backport-legacy-split test-promote-release test-wait-for-release test-cve-scan test-commitlint ## run all action tests
 
 test-semver-validation: ## run semver-validation unit tests
 	cd $(ACTIONS_DIR)/semver-validation && npm ci --silent && NODE_OPTIONS=--experimental-vm-modules npx jest --ci --coverage --watchAll=false
@@ -187,9 +187,31 @@ test-commitlint: ## run commitlint bats tests
 build-linear-release-sync: ## build linear-release-sync binary (linux/amd64)
 	cd $(ACTIONS_DIR)/linear-release-sync/src && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-s -w" -o ../linear-release-sync-linux-amd64 .
 
-lint: ## run actionlint and zizmor on workflows
+lint: check-bats-jobs ## run actionlint and zizmor on workflows
 	actionlint .github/workflows/*.yaml
 	zizmor .github/
+
+# bats-action only installs bats; it has no `tests` input. Unknown inputs are a
+# warning, so a job that hands it a path and stops there goes green having run
+# nothing, which is how 23 suites stayed dead without anyone noticing.
+check-bats-jobs: ## fail if a workflow installs bats but never runs a suite
+	@fail=0; \
+	for wf in $(WORKFLOWS_DIR)/*.yaml; do \
+	  grep -q 'bats-core/bats-action' "$$wf" || continue; \
+	  if awk '/bats-core\/bats-action/{w=1;next} \
+	          w && /^[[:space:]]*tests:/{found=1;exit} \
+	          w && /^[[:space:]]*- /{w=0} \
+	          END{exit !found}' "$$wf"; then \
+	    echo "ERROR: $$wf passes a 'tests' input to bats-action, which has no such input; the suite never runs."; \
+	    fail=1; \
+	  fi; \
+	  if ! grep -qE '^[[:space:]]*(run: )?bats[[:space:]]' "$$wf"; then \
+	    echo "ERROR: $$wf installs bats but never runs it; add a 'run: bats <path>/*.bats' step."; \
+	    fail=1; \
+	  fi; \
+	done; \
+	if [ "$$fail" -eq 1 ]; then exit 1; fi; \
+	echo "Every workflow that installs bats runs a suite."
 
 # Reusable workflow tests (test-*.yaml for workflow_call workflows) run in CI only.
 # They require GitHub event context and cannot be executed locally.

--- a/Makefile
+++ b/Makefile
@@ -123,8 +123,9 @@ test-auto-approve-bot-prs: ## run auto-approve-bot-prs bats tests
 test-ai-pr-review: ## run ai-pr-review bats tests
 	bats $(ACTIONS_DIR)/ai-pr-review/test/*.bats
 
-test-ai-step: ## run ai-step bats tests
+test-ai-step: ## run ai-step bats + python tests (python needs: pip install pytest jsonschema)
 	bats $(ACTIONS_DIR)/ai-step/test/*.bats
+	python3 -m pytest $(ACTIONS_DIR)/ai-step/test/ -q
 
 test-ci-test-notify: ## run ci-test-notify bats tests
 	bats $(ACTIONS_DIR)/ci-test-notify/test

--- a/README.md
+++ b/README.md
@@ -241,6 +241,81 @@ Pair with a concurrency group that splits edited from code events
 edit cannot cancel a still-running code run and then skip. See the action
 README for full details.
 
+### Comment-triggered check
+
+Turns a PR comment such as `/test snapshots` into a check-run on the pull
+request's head commit, and completes it when the caller's work finishes. It
+runs no tests: it decides whether a command should run, resolves the pull
+request identity that an `issue_comment` event does not carry, and owns the
+check-run lifecycle.
+
+Two modes. `start` parses the comment, authorizes the commenter from
+`author_association`, resolves the head SHA and base ref, and opens the
+check-run. `finish` resolves the outcome with a fail-closed matrix and
+completes it. Three API calls in total.
+
+**Location:** `.github/actions/comment-triggered-check`
+
+**Usage:**
+
+```yaml
+jobs:
+  prepare:
+    if: github.event.issue.pull_request && startsWith(github.event.comment.body, '/test')
+    runs-on: ubuntu-22.04
+    outputs:
+      should-run: ${{ steps.cmd.outputs.should-run }}
+      filter: ${{ steps.cmd.outputs.filter }}
+      head-sha: ${{ steps.cmd.outputs.head-sha }}
+      base-ref: ${{ steps.cmd.outputs.base-ref }}
+      key: ${{ steps.cmd.outputs.concurrency-key }}
+      check-run-id: ${{ steps.cmd.outputs.check-run-id }}
+    steps:
+      - id: cmd
+        uses: loft-sh/github-actions/.github/actions/comment-triggered-check@comment-triggered-check/v1
+        with:
+          mode: start
+          comment-body: ${{ github.event.comment.body }}
+          comment-author: ${{ github.event.comment.user.login }}
+          author-association: ${{ github.event.comment.author_association }}
+          pr-number: ${{ github.event.issue.number }}
+          run-id: ${{ github.run_id }}
+          server-url: ${{ github.server_url }}
+
+  # Deduplication is GitHub's: a second identical command supersedes this run,
+  # and the always() finish job still closes the superseded check.
+  suite:
+    needs: [prepare]
+    if: needs.prepare.outputs.should-run == 'true'
+    runs-on: large-8_32
+    concurrency:
+      group: comment-triggered-check-suite-${{ github.event.issue.number }}-${{ needs.prepare.outputs.key }}
+      cancel-in-progress: true
+    steps:
+      - run: echo "... build and test at needs.prepare.outputs.head-sha ..."
+
+  finish:
+    needs: [prepare, suite]
+    if: always() && needs.prepare.outputs.check-run-id != ''
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: loft-sh/github-actions/.github/actions/comment-triggered-check@comment-triggered-check/v1
+        with:
+          mode: finish
+          check-run-id: ${{ needs.prepare.outputs.check-run-id }}
+          report-conclusion: ${{ needs.suite.outputs.check-conclusion }}
+          suite-result: ${{ needs.suite.result }}
+```
+
+**Key outputs:** `matched`, `should-run`, `reason`, `head-sha`, `base-ref`,
+`concurrency-key`, `check-name`, `check-run-id`, `conclusion`.
+
+Two things that are easy to get wrong and are handled here. An `issue_comment`
+run's `GITHUB_SHA` is the default branch, so a check-run must be created against
+the resolved head SHA or it never appears on the PR, and neither the head SHA
+nor the base ref can be inferred from the event. Fork PRs are rejected as a
+security boundary, because this trigger is privileged. See the action README.
+
 ### Repository Dispatch
 
 Sends a `repository_dispatch` event to a target repository so any source repo
@@ -992,6 +1067,7 @@ the action's files change:
 - `test-link-backport-prs.yaml` - triggers on `.github/actions/link-backport-prs/**`
 - `test-linear-release-sync.yaml` - triggers on `.github/actions/linear-release-sync/**`
 - `test-sticky-pr-comment.yaml` - triggers on `.github/actions/sticky-pr-comment/**`
+- `test-comment-triggered-check.yaml` - triggers on `.github/actions/comment-triggered-check/**`
 - `release-linear-release-sync.yaml` - builds and publishes the binary on tag push or `workflow_dispatch`
 
 Each reusable workflow (`workflow_call`) also has a smoke/integration test

--- a/README.md
+++ b/README.md
@@ -599,9 +599,13 @@ and input, bind the output to a JSON Schema, expose the schema-conforming
 JSON as a step output. Downstream steps parse with `fromJSON(...)` and
 branch on typed fields.
 
-Structured output is the contract. Whatever the model returns is exposed
-on `result` and `conclusion=success`. The action never emits `failed` — the
-caller knows what empty output means for their pipeline.
+Structured output is the contract. Schema-conforming output is exposed on
+`result` with `conclusion=success`; any failure degrades to
+`conclusion=failed` with an empty `result` and exit code 0 — the caller
+knows what a failed result means for their pipeline. Setting the `agent`
+input switches the action to a session against a deployed managed agent
+from `loft-sh/ai-agents` (Anthropic-only, minutes not seconds, needs a
+workspace session key).
 
 **Location:** `.github/actions/ai-step`
 

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -56,8 +56,26 @@ requirements. The table below captures current status and guidance:
 - Testing frameworks: **vitest** for TypeScript, **uv + pytest** for Python,
   standard `go test` for Go, **[bats](https://github.com/bats-core/bats-core)**
   for Bash scripts. CI uses
-  [`bats-core/bats-action`](https://github.com/bats-core/bats-action); locally
-  install bats with your package manager:
+  [`bats-core/bats-action`](https://github.com/bats-core/bats-action) to install
+  bats, then runs the suite in an explicit step:
+  ```yaml
+  - uses: bats-core/bats-action@<sha> # 4.0.0
+    with:
+      support-install: false
+      assert-install: false
+      detik-install: false
+      file-install: false
+  - name: Run <action-name> tests
+    run: bats .github/actions/<action-name>/test/*.bats
+  ```
+  `bats-action` only installs bats. It does not run anything, and it has no
+  `tests` input. Handing it a path is an unknown input, which is a warning
+  rather than an error, so a job that stops there passes without executing a
+  single test. `make check-bats-jobs` (run by `make lint` and by CI) fails the
+  build on that shape.
+- Every test workflow's `paths` filter MUST include the workflow file itself, so
+  a change to the test harness is exercised by the PR that makes it.
+- Locally, install bats with your package manager:
   ```bash
   # macOS
   brew install bats-core

--- a/docs/workflows/ai-step.md
+++ b/docs/workflows/ai-step.md
@@ -5,6 +5,19 @@
 > [action README](../../.github/actions/ai-step/README.md) for inputs,
 > outputs, and usage examples.
 
+> **Addendum (DEVOPS-1352, 2026-08).** Two ways this record has drifted
+> from what shipped. First, the implemented v1 calls the provider APIs
+> directly with native structured-output binding; the `tools`,
+> `mcp-config`, and `fail-on-invalid` inputs sketched below never
+> shipped, and the action is dual-provider (`provider: anthropic |
+> openai`), always fail-soft. Second, DEVOPS-1352 added a session mode:
+> an optional `agent` input targets a deployed managed agent from
+> `loft-sh/ai-agents`, turning the ~15s single call into a minutes-long,
+> session-scale run whose final message is validated against
+> `output-schema` on the runner (sessions have no provider-side
+> binding). Anthropic-only, opt-in per caller, needs a workspace-scoped
+> session key. The README is the authoritative contract for both modes.
+
 ## Problem
 
 We have `ai-pr-review`: a composite action + reusable workflow that


### PR DESCRIPTION
## Summary

Add `comment-triggered-check`, a reusable action for turning pull request comments such as `/test snapshots` into check-runs on the pull request's head commit.

The action owns the generic parts of the flow:

- parse and authorize the command
- resolve the pull request's head SHA, head branch, and base branch
- reject forks before any pull request code can run
- create the check-run on the pull request commit
- derive and publish a fail-closed conclusion

The caller remains responsible for running the requested work and for reporting its raw job results back to the action.

## Why this action is needed

An `issue_comment` workflow runs against the default branch, so its automatic checks attach to the default-branch commit rather than the pull request. `start` resolves the pull request through the API and creates the check-run on its immutable head SHA instead.

The action also separates the privileged comment handler from the workflow that executes pull request code. It emits both identifiers required for that handoff:

- `head-ref` selects the branch workflow with `workflow_dispatch`
- `head-sha` pins the code that the dispatched workflow must check out and test

Callers must preserve both values. A branch can move between command parsing and dispatch; the result must still describe the same commit as the check-run.

## Action contract

### `start`

`start` parses the first line of the comment, checks `author_association`, reads the pull request, rejects forks and closed pull requests, and opens the check-run. It returns `should-run`, the normalized filter, pull request refs, a filter-specific concurrency key, and the check-run ID.

Authorization deliberately uses `author_association` rather than the collaborator-permission endpoint. `OWNER`, `MEMBER`, and `COLLABORATOR` pass, but this is not a write-permission check: organization members and read-only collaborators may pass. Because execution is restricted to same-repository pull requests, this grants runner time rather than access to fork code.

### `finish`

`finish` accepts the check-run ID, report conclusion, and raw build and suite results. Its tested matrix fails closed:

- a recognized report conclusion is authoritative and is the only path to `neutral`
- a cancelled build or suite becomes `cancelled`
- every unexplained or unrecognized state becomes `failure`

The Checks API update is retried three times. If all attempts fail, the action reports the stuck check and directs the operator to **Re-run failed jobs**, which retries `finish` without creating another check-run.

## Concurrency

The action does not deduplicate commands. The caller applies filter-keyed concurrency to the cancellable work job, not the entire workflow, and keeps an `always()` finish job outside that cancellation boundary. This lets a repeated command supersede the previous work while still closing its check-run as `cancelled`.

The concurrency key contains a normalized slug and digest. The digest prevents distinct filters such as `snapshots && aws` and `snapshots || aws` from canceling each other after punctuation is removed from the slug.

## Additional change


## Verification

- 77 Bats tests covering parsing, authorization, API failure paths, conclusion resolution, retries, and check-run lifecycle
- `shellcheck` clean
- `actionlint` clean
- `zizmor` clean, aside from the three expected internal-tag suppressions
- `make check-docs` clean
- smoke workflow green

## Rollout

After this PR merges, publish `comment-triggered-check/v1` and update [loft-sh/vcluster-pro#2288](https://github.com/loft-sh/vcluster-pro/pull/2288) from its temporary SHA references to that tag. The integration caller must prove the live command, dispatch, and check-run lifecycle before the tag advances.

References DEVOPS-1333

