### PR TITLE
fix(ci): run the bats suites the test workflows only installed

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,3 +30,12 @@ jobs:
         with:
           persist-credentials: false
       - run: pip install zizmor==1.24.1 && zizmor .github/
+
+  bats-jobs:
+    name: Check bats jobs run their suites
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - run: make check-bats-jobs

--- a/.github/workflows/test-ai-pr-review.yaml
+++ b/.github/workflows/test-ai-pr-review.yaml
@@ -5,6 +5,7 @@ on:
     paths:
       - '.github/workflows/ai-pr-review.yaml'
       - '.github/actions/ai-pr-review/**'
+      - '.github/workflows/test-ai-pr-review.yaml'
 
 permissions:
   contents: read
@@ -19,7 +20,12 @@ jobs:
           persist-credentials: false
       - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
         with:
-          tests: .github/actions/ai-pr-review/test
+          support-install: false
+          assert-install: false
+          detik-install: false
+          file-install: false
+      - name: Run ai-pr-review tests
+        run: bats .github/actions/ai-pr-review/test/*.bats
 
   # Composite smoke tests used to rely on the allowed-bots filter to
   # short-circuit before spending API tokens on human-authored PRs. With

--- a/.github/workflows/test-ai-step.yaml
+++ b/.github/workflows/test-ai-step.yaml
@@ -31,7 +31,12 @@ jobs:
           persist-credentials: false
       - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
         with:
-          tests: .github/actions/ai-step/test
+          support-install: false
+          assert-install: false
+          detik-install: false
+          file-install: false
+      - name: Run ai-step tests
+        run: bats .github/actions/ai-step/test/*.bats
 
   # Live smoke test. Spends real tokens, so gated behind workflow_dispatch
   # only — never runs on PR events. Proves the whole pipeline: schema is

--- a/.github/workflows/test-auto-approve-bot-prs.yaml
+++ b/.github/workflows/test-auto-approve-bot-prs.yaml
@@ -5,6 +5,7 @@ on:
     paths:
       - '.github/workflows/auto-approve-bot-prs.yaml'
       - '.github/actions/auto-approve-bot-prs/**'
+      - '.github/workflows/test-auto-approve-bot-prs.yaml'
 
 permissions:
   contents: read
@@ -19,7 +20,12 @@ jobs:
           persist-credentials: false
       - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
         with:
-          tests: .github/actions/auto-approve-bot-prs/test
+          support-install: false
+          assert-install: false
+          detik-install: false
+          file-install: false
+      - name: Run auto-approve-bot-prs tests
+        run: bats .github/actions/auto-approve-bot-prs/test/*.bats
 
   # Smoke test the composite action on the PR branch (the reusable workflow
   # pins ref: main, which wouldn't yet contain the composite during this

--- a/.github/workflows/test-aws-test-infra.yaml
+++ b/.github/workflows/test-aws-test-infra.yaml
@@ -5,9 +5,11 @@ on:
     branches: [main]
     paths:
       - '.github/actions/aws-test-infra/**'
+      - '.github/workflows/test-aws-test-infra.yaml'
   pull_request:
     paths:
       - '.github/actions/aws-test-infra/**'
+      - '.github/workflows/test-aws-test-infra.yaml'
 
 jobs:
   test:
@@ -39,4 +41,9 @@ jobs:
           persist-credentials: false
       - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
         with:
-          tests: .github/actions/aws-test-infra/test
+          support-install: false
+          assert-install: false
+          detik-install: false
+          file-install: false
+      - name: Run aws-test-infra tests
+        run: bats .github/actions/aws-test-infra/test/*.bats

--- a/.github/workflows/test-backport-legacy-allowlist.yaml
+++ b/.github/workflows/test-backport-legacy-allowlist.yaml
@@ -18,4 +18,9 @@ jobs:
           persist-credentials: false
       - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
         with:
-          tests: .github/actions/backport-legacy-allowlist/test
+          support-install: false
+          assert-install: false
+          detik-install: false
+          file-install: false
+      - name: Run backport-legacy-allowlist tests
+        run: bats .github/actions/backport-legacy-allowlist/test/*.bats

--- a/.github/workflows/test-backport-legacy-split.yaml
+++ b/.github/workflows/test-backport-legacy-split.yaml
@@ -18,4 +18,9 @@ jobs:
           persist-credentials: false
       - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
         with:
-          tests: .github/actions/backport-legacy-split/test
+          support-install: false
+          assert-install: false
+          detik-install: false
+          file-install: false
+      - name: Run backport-legacy-split tests
+        run: bats .github/actions/backport-legacy-split/test/*.bats

--- a/.github/workflows/test-ci-test-notify.yaml
+++ b/.github/workflows/test-ci-test-notify.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - '.github/actions/ci-test-notify/**'
+      - '.github/workflows/test-ci-test-notify.yaml'
 
 permissions: {}
 
@@ -17,4 +18,9 @@ jobs:
           persist-credentials: false
       - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
         with:
-          tests: .github/actions/ci-test-notify/test
+          support-install: false
+          assert-install: false
+          detik-install: false
+          file-install: false
+      - name: Run ci-test-notify tests
+        run: bats .github/actions/ci-test-notify/test/*.bats

--- a/.github/workflows/test-cleanup-head-charts.yaml
+++ b/.github/workflows/test-cleanup-head-charts.yaml
@@ -5,6 +5,7 @@ on:
     paths:
       - '.github/scripts/cleanup-head-charts/**'
       - '.github/workflows/cleanup-head-charts.yaml'
+      - '.github/workflows/test-cleanup-head-charts.yaml'
 
 permissions: {}
 
@@ -18,4 +19,9 @@ jobs:
           persist-credentials: false
       - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
         with:
-          tests: .github/scripts/cleanup-head-charts/test
+          support-install: false
+          assert-install: false
+          detik-install: false
+          file-install: false
+      - name: Run cleanup-head-charts tests
+        run: bats .github/scripts/cleanup-head-charts/test/*.bats

--- a/.github/workflows/test-go-licenses.yaml
+++ b/.github/workflows/test-go-licenses.yaml
@@ -18,4 +18,9 @@ jobs:
           persist-credentials: false
       - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
         with:
-          tests: .github/actions/go-licenses/test
+          support-install: false
+          assert-install: false
+          detik-install: false
+          file-install: false
+      - name: Run go-licenses tests
+        run: bats .github/actions/go-licenses/test/*.bats

--- a/.github/workflows/test-govulncheck.yaml
+++ b/.github/workflows/test-govulncheck.yaml
@@ -18,4 +18,9 @@ jobs:
           persist-credentials: false
       - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
         with:
-          tests: .github/actions/govulncheck/test
+          support-install: false
+          assert-install: false
+          detik-install: false
+          file-install: false
+      - name: Run govulncheck tests
+        run: bats .github/actions/govulncheck/test/*.bats

--- a/.github/workflows/test-oss-commit-sync.yaml
+++ b/.github/workflows/test-oss-commit-sync.yaml
@@ -18,4 +18,9 @@ jobs:
           persist-credentials: false
       - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
         with:
-          tests: .github/actions/oss-commit-sync/test
+          support-install: false
+          assert-install: false
+          detik-install: false
+          file-install: false
+      - name: Run oss-commit-sync tests
+        run: bats .github/actions/oss-commit-sync/test/*.bats

--- a/.github/workflows/test-parse-label-filter.yaml
+++ b/.github/workflows/test-parse-label-filter.yaml
@@ -19,7 +19,12 @@ jobs:
           persist-credentials: false
       - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
         with:
-          tests: .github/actions/parse-label-filter/test
+          support-install: false
+          assert-install: false
+          detik-install: false
+          file-install: false
+      - name: Run parse-label-filter tests
+        run: bats .github/actions/parse-label-filter/test/*.bats
 
   composite-smoke:
     name: Composite smoke (parse + skip decision)

--- a/.github/workflows/test-prerelease-setup.yaml
+++ b/.github/workflows/test-prerelease-setup.yaml
@@ -19,4 +19,9 @@ jobs:
           persist-credentials: false
       - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
         with:
-          tests: .github/actions/prerelease-setup/test
+          support-install: false
+          assert-install: false
+          detik-install: false
+          file-install: false
+      - name: Run prerelease-setup tests
+        run: bats .github/actions/prerelease-setup/test/*.bats

--- a/.github/workflows/test-promote-release.yaml
+++ b/.github/workflows/test-promote-release.yaml
@@ -19,7 +19,12 @@ jobs:
           persist-credentials: false
       - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
         with:
-          tests: .github/actions/promote-release/test
+          support-install: false
+          assert-install: false
+          detik-install: false
+          file-install: false
+      - name: Run promote-release tests
+        run: bats .github/actions/promote-release/test/*.bats
 
   smoke:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-publish-helm-chart.yaml
+++ b/.github/workflows/test-publish-helm-chart.yaml
@@ -22,4 +22,9 @@ jobs:
           version: v4.53.3
       - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
         with:
-          tests: .github/actions/publish-helm-chart/test
+          support-install: false
+          assert-install: false
+          detik-install: false
+          file-install: false
+      - name: Run publish-helm-chart tests
+        run: bats .github/actions/publish-helm-chart/test/*.bats

--- a/.github/workflows/test-release-branch-freeze.yaml
+++ b/.github/workflows/test-release-branch-freeze.yaml
@@ -19,4 +19,9 @@ jobs:
           persist-credentials: false
       - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
         with:
-          tests: .github/actions/release-branch-freeze/test
+          support-install: false
+          assert-install: false
+          detik-install: false
+          file-install: false
+      - name: Run release-branch-freeze tests
+        run: bats .github/actions/release-branch-freeze/test/*.bats

--- a/.github/workflows/test-repository-dispatch.yaml
+++ b/.github/workflows/test-repository-dispatch.yaml
@@ -19,4 +19,9 @@ jobs:
           persist-credentials: false
       - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
         with:
-          tests: .github/actions/repository-dispatch/test
+          support-install: false
+          assert-install: false
+          detik-install: false
+          file-install: false
+      - name: Run repository-dispatch tests
+        run: bats .github/actions/repository-dispatch/test/*.bats

--- a/.github/workflows/test-run-ginkgo.yaml
+++ b/.github/workflows/test-run-ginkgo.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - '.github/actions/run-ginkgo/**'
+      - '.github/workflows/test-run-ginkgo.yaml'
 
 permissions: {}
 
@@ -17,7 +18,12 @@ jobs:
           persist-credentials: false
       - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
         with:
-          tests: .github/actions/run-ginkgo/test
+          support-install: false
+          assert-install: false
+          detik-install: false
+          file-install: false
+      - name: Run run-ginkgo tests
+        run: bats .github/actions/run-ginkgo/test/*.bats
 
   focus-selection:
     name: Run focus selection tests

--- a/.github/workflows/test-sticky-pr-comment.yaml
+++ b/.github/workflows/test-sticky-pr-comment.yaml
@@ -19,7 +19,12 @@ jobs:
           persist-credentials: false
       - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
         with:
-          tests: .github/actions/sticky-pr-comment/test
+          support-install: false
+          assert-install: false
+          detik-install: false
+          file-install: false
+      - name: Run sticky-pr-comment tests
+        run: bats .github/actions/sticky-pr-comment/test/*.bats
 
   composite-smoke:
     name: Composite smoke (create + update)

--- a/.github/workflows/test-subtree-mirror.yaml
+++ b/.github/workflows/test-subtree-mirror.yaml
@@ -18,4 +18,9 @@ jobs:
           persist-credentials: false
       - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
         with:
-          tests: .github/actions/subtree-mirror/test
+          support-install: false
+          assert-install: false
+          detik-install: false
+          file-install: false
+      - name: Run subtree-mirror tests
+        run: bats .github/actions/subtree-mirror/test/*.bats

--- a/.github/workflows/test-vcluster-release.yaml
+++ b/.github/workflows/test-vcluster-release.yaml
@@ -19,4 +19,9 @@ jobs:
           persist-credentials: false
       - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
         with:
-          tests: .github/actions/vcluster-release/test
+          support-install: false
+          assert-install: false
+          detik-install: false
+          file-install: false
+      - name: Run vcluster-release tests
+        run: bats .github/actions/vcluster-release/test/*.bats

--- a/.github/workflows/test-wait-for-release.yaml
+++ b/.github/workflows/test-wait-for-release.yaml
@@ -19,4 +19,9 @@ jobs:
           persist-credentials: false
       - uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
         with:
-          tests: .github/actions/wait-for-release/test
+          support-install: false
+          assert-install: false
+          detik-install: false
+          file-install: false
+      - name: Run wait-for-release tests
+        run: bats .github/actions/wait-for-release/test/*.bats

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-semver-validation test-linear-pr-commenter test-link-backport-prs test-release-notification test-linear-release-sync test-aws-test-infra test-cleanup-head-charts test-ci-test-notify test-auto-approve-bot-prs test-ai-pr-review test-ai-step test-publish-helm-chart test-govulncheck test-go-licenses test-run-ginkgo test-sticky-pr-comment test-repository-dispatch test-parse-label-filter test-release-branch-freeze test-prerelease-setup test-vcluster-release test-subtree-mirror test-oss-commit-sync test-backport-legacy-allowlist test-backport-legacy-split test-promote-release test-wait-for-release test-cve-scan test-commitlint build-linear-release-sync lint install-auto-doc generate-docs check-docs help
+.PHONY: test test-semver-validation test-linear-pr-commenter test-link-backport-prs test-release-notification test-linear-release-sync test-aws-test-infra test-cleanup-head-charts test-ci-test-notify test-auto-approve-bot-prs test-ai-pr-review test-ai-step test-publish-helm-chart test-govulncheck test-go-licenses test-run-ginkgo test-sticky-pr-comment test-repository-dispatch test-parse-label-filter test-release-branch-freeze test-prerelease-setup test-vcluster-release test-subtree-mirror test-oss-commit-sync test-backport-legacy-allowlist test-backport-legacy-split test-promote-release test-wait-for-release test-cve-scan test-commitlint build-linear-release-sync lint check-bats-jobs install-auto-doc generate-docs check-docs help
 
 ACTIONS_DIR := .github/actions
 WORKFLOWS_DIR := .github/workflows
@@ -93,7 +93,7 @@ check-docs: generate-docs ## verify docs are up to date (fails if drift detected
 help: ## show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-30s %s\n", $$1, $$2}'
 
-test: test-semver-validation test-linear-pr-commenter test-link-backport-prs test-release-notification test-linear-release-sync test-aws-test-infra test-cleanup-head-charts test-auto-approve-bot-prs test-ai-pr-review test-ai-step test-ci-test-notify test-go-licenses test-publish-helm-chart test-govulncheck test-run-ginkgo test-sticky-pr-comment test-repository-dispatch test-parse-label-filter test-release-branch-freeze test-prerelease-setup test-vcluster-release test-subtree-mirror test-oss-commit-sync test-backport-legacy-allowlist test-backport-legacy-split test-promote-release test-wait-for-release test-cve-scan test-commitlitn ## run all action tests
+test: test-semver-validation test-linear-pr-commenter test-link-backport-prs test-release-notification test-linear-release-sync test-aws-test-infra test-cleanup-head-charts test-auto-approve-bot-prs test-ai-pr-review test-ai-step test-ci-test-notify test-go-licenses test-publish-helm-chart test-govulncheck test-run-ginkgo test-sticky-pr-comment test-repository-dispatch test-parse-label-filter test-release-branch-freeze test-prerelease-setup test-vcluster-release test-subtree-mirror test-oss-commit-sync test-backport-legacy-allowlist test-backport-legacy-split test-promote-release test-wait-for-release test-cve-scan test-commitlint ## run all action tests
 
 test-semver-validation: ## run semver-validation unit tests
 	cd $(ACTIONS_DIR)/semver-validation && npm ci --silent && NODE_OPTIONS=--experimental-vm-modules npx jest --ci --coverage --watchAll=false
@@ -187,9 +187,31 @@ test-commitlint: ## run commitlint bats tests
 build-linear-release-sync: ## build linear-release-sync binary (linux/amd64)
 	cd $(ACTIONS_DIR)/linear-release-sync/src && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-s -w" -o ../linear-release-sync-linux-amd64 .
 
-lint: ## run actionlint and zizmor on workflows
+lint: check-bats-jobs ## run actionlint and zizmor on workflows
 	actionlint .github/workflows/*.yaml
 	zizmor .github/
+
+# bats-action only installs bats; it has no `tests` input. Unknown inputs are a
+# warning, so a job that hands it a path and stops there goes green having run
+# nothing, which is how 23 suites stayed dead without anyone noticing.
+check-bats-jobs: ## fail if a workflow installs bats but never runs a suite
+	@fail=0; \
+	for wf in $(WORKFLOWS_DIR)/*.yaml; do \
+	  grep -q 'bats-core/bats-action' "$$wf" || continue; \
+	  if awk '/bats-core\/bats-action/{w=1;next} \
+	          w && /^[[:space:]]*tests:/{found=1;exit} \
+	          w && /^[[:space:]]*- /{w=0} \
+	          END{exit !found}' "$$wf"; then \
+	    echo "ERROR: $$wf passes a 'tests' input to bats-action, which has no such input; the suite never runs."; \
+	    fail=1; \
+	  fi; \
+	  if ! grep -qE '^[[:space:]]*(run: )?bats[[:space:]]' "$$wf"; then \
+	    echo "ERROR: $$wf installs bats but never runs it; add a 'run: bats <path>/*.bats' step."; \
+	    fail=1; \
+	  fi; \
+	done; \
+	if [ "$$fail" -eq 1 ]; then exit 1; fi; \
+	echo "Every workflow that installs bats runs a suite."
 
 # Reusable workflow tests (test-*.yaml for workflow_call workflows) run in CI only.
 # They require GitHub event context and cannot be executed locally.

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -56,8 +56,26 @@ requirements. The table below captures current status and guidance:
 - Testing frameworks: **vitest** for TypeScript, **uv + pytest** for Python,
   standard `go test` for Go, **[bats](https://github.com/bats-core/bats-core)**
   for Bash scripts. CI uses
-  [`bats-core/bats-action`](https://github.com/bats-core/bats-action); locally
-  install bats with your package manager:
+  [`bats-core/bats-action`](https://github.com/bats-core/bats-action) to install
+  bats, then runs the suite in an explicit step:
+  ```yaml
+  - uses: bats-core/bats-action@<sha> # 4.0.0
+    with:
+      support-install: false
+      assert-install: false
+      detik-install: false
+      file-install: false
+  - name: Run <action-name> tests
+    run: bats .github/actions/<action-name>/test/*.bats
+  ```
+  `bats-action` only installs bats. It does not run anything, and it has no
+  `tests` input. Handing it a path is an unknown input, which is a warning
+  rather than an error, so a job that stops there passes without executing a
+  single test. `make check-bats-jobs` (run by `make lint` and by CI) fails the
+  build on that shape.
+- Every test workflow's `paths` filter MUST include the workflow file itself, so
+  a change to the test harness is exercised by the PR that makes it.
+- Locally, install bats with your package manager:
   ```bash
   # macOS
   brew install bats-core


### PR DESCRIPTION
22 test workflows handed a `tests:` input to `bats-core/bats-action`, which has no such input. It installs bats and stops, so those jobs went green having run nothing: 853 tests that never executed in CI. Each one now installs bats and invokes it in its own step.

Two things came with it: six workflows didn't list their own file in `paths`, so a change to the test harness never triggered the suite it changes, and `make check-bats-jobs` (wired into `make lint` and CI) now fails the build on either dead shape.

Closes DEVOPS-1344

## Test plan

- All 24 bats suites pass locally with a scrubbed `HOME`, no global or system gitconfig, and mikefarah/yq v4.53.3 on PATH: 0 failures, 0 skips
- `make check-bats-jobs` fails on both shapes (verified against the pre-fix `test-cve-scan.yaml`)
- `make lint` and `make check-docs` clean