### PR TITLE
fix(ai-step): grace-retry the stop_reason lookup after idle

### DIFF
--- a/.github/actions/ai-step/src/run.py
+++ b/.github/actions/ai-step/src/run.py
@@ -37,6 +37,11 @@ import time
 # loft-sh/ai-agents.
 BETA_HEADER = "managed-agents-2026-04-01"
 POLL_INTERVAL_S = 10
+# sessions.retrieve flips to idle slightly before the session.status_idle
+# event is visible in the event log (observed live on the DEVOPS-1352 wif
+# smoke, ai-agents run 32252874325), so the stop_reason lookup retries for
+# a bounded grace window instead of failing on the first empty read.
+STOP_REASON_GRACE_S = 60
 
 
 def enforce_strict(node):
@@ -241,11 +246,22 @@ def run_session(agent_name: str, user_content: str, api_key: str,
         if status == "terminated":
             fail_soft("session terminated before producing output")
 
-        idle = latest_event(client, session.id, "session.status_idle")
-        stop = getattr(getattr(idle, "stop_reason", None), "type", None)
+        stop = None
+        grace_deadline = time.time() + STOP_REASON_GRACE_S
+        while True:
+            idle = latest_event(client, session.id, "session.status_idle")
+            sr = getattr(idle, "stop_reason", None)
+            stop = sr if isinstance(sr, str) else getattr(sr, "type", None)
+            if stop is not None or time.time() >= grace_deadline:
+                break
+            time.sleep(POLL_INTERVAL_S)
         if stop != "end_turn":
+            recent = [getattr(e, "type", "?") for e in
+                      client.beta.sessions.events.list(session.id,
+                                                       order="desc", limit=10)]
             fail_soft(f"session stopped with stop_reason '{stop}' instead of "
-                      "end_turn — the agent did not complete its turn")
+                      f"end_turn — the agent did not complete its turn "
+                      f"(recent events: {recent})")
 
         msg = latest_event(client, session.id, "agent.message")
         if msg is None:

--- a/.github/actions/ai-step/test/test_run_session.py
+++ b/.github/actions/ai-step/test/test_run_session.py
@@ -36,11 +36,16 @@ class FakeClient:
 
     def __init__(self, *, agents=("sre-memory-curator",),
                  statuses=("idle",), stop_reason="end_turn",
-                 final_text='{"ok": true}', create_raises=None):
+                 final_text='{"ok": true}', create_raises=None,
+                 idle_event_delay=0, stop_is_str=False):
         self._statuses = list(statuses)
         self._stop = stop_reason
         self._final = final_text
         self._create_raises = create_raises
+        # status_idle event lags the status flip in the live API; this
+        # many lookups return empty before the event becomes visible
+        self._idle_delay = idle_event_delay
+        self._stop_is_str = stop_is_str
         self.deleted = {"sessions": [], "environments": []}
         self.sent = []
 
@@ -52,8 +57,13 @@ class FakeClient:
 
             def list(self, sid, types=None, order=None, limit=None):
                 if types == ["session.status_idle"]:
-                    stop = None if client._stop is None else _obj(type=client._stop)
-                    return iter([] if stop is None else [_obj(stop_reason=stop)])
+                    if client._idle_delay > 0:
+                        client._idle_delay -= 1
+                        return iter([])
+                    if client._stop is None:
+                        return iter([])
+                    stop = client._stop if client._stop_is_str else _obj(type=client._stop)
+                    return iter([_obj(stop_reason=stop)])
                 if types == ["agent.message"]:
                     if client._final is None:
                         return iter([])
@@ -107,6 +117,7 @@ def run_mod(monkeypatch, tmp_path):
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
     monkeypatch.setattr(mod, "POLL_INTERVAL_S", 0)
+    monkeypatch.setattr(mod, "STOP_REASON_GRACE_S", 0.3)
     mod._out_path = out
     mod._fake = fake
     return mod
@@ -168,6 +179,31 @@ def test_non_end_turn_stop_fails_soft(run_mod):
     assert e.value.code == 0
     _assert_failed(run_mod)
     assert client.deleted["sessions"] == ["sess_test"]
+
+
+def test_late_status_idle_event_is_awaited(run_mod):
+    # the live race (ai-agents run 32252874325): status flips to idle
+    # before the status_idle event is listable; the grace loop must
+    # absorb the lag instead of failing on the first empty read
+    client = FakeClient(idle_event_delay=2)
+    text = _run(run_mod, client)
+    assert text == '{"ok": true}'
+    assert client.deleted["sessions"] == ["sess_test"]
+
+
+def test_status_idle_event_never_appears_fails_soft(run_mod):
+    client = FakeClient(stop_reason=None)
+    with pytest.raises(SystemExit) as e:
+        _run(run_mod, client)
+    assert e.value.code == 0
+    _assert_failed(run_mod)
+    assert client.deleted["sessions"] == ["sess_test"]
+
+
+def test_string_stop_reason_is_accepted(run_mod):
+    client = FakeClient(stop_is_str=True)
+    text = _run(run_mod, client)
+    assert text == '{"ok": true}'
 
 
 def test_idle_without_message_fails_soft(run_mod):


### PR DESCRIPTION
## Summary
First live keyless session run (DEVOPS-1352 wif smoke, [ai-agents run 32252874325](https://github.com/loft-sh/ai-agents/actions/runs/32252874325)) surfaced a race the stubbed tests could not: `sessions.retrieve` flips to `idle` slightly before the `session.status_idle` event is visible in the event log, and the completion gate read the log exactly once, immediately, so every live session failed with `stop_reason 'None'` despite the agent completing.

## Key Changes
- `src/run.py`: after status leaves running, retry the `session.status_idle` lookup for a bounded grace window (`STOP_REASON_GRACE_S`, 60s) before giving up; accept `stop_reason` as typed object or plain string; on failure print the 10 newest event types so the next unknown failure names itself in the CI log.
- `test/test_run_session.py`: fake event log grew a lag knob; 3 new cases (late event absorbed, event never appears fails soft with deletes, string stop_reason accepted). 15 pytest green.

## Dependencies
- Follows #227. The wif smoke on loft-sh/ai-agents#100 re-runs against `main` once this merges and is the gate for rolling `ai-step/v1`.

## TODO
- [ ] green wif smoke on ai-agents#100 after merge

References DEVOPS-1352