### PR TITLE
fix(ai-step): unwrap markdown-fenced json from session output

### DIFF
--- a/.github/actions/ai-step/src/run.py
+++ b/.github/actions/ai-step/src/run.py
@@ -295,6 +295,21 @@ def run_session(agent_name: str, user_content: str, api_key: str,
                   f"{env.id}: {e} — delete it in the Console")
 
 
+def strip_fence(text: str) -> str:
+    """Sessions have no provider-side structured-output binding, and
+    agents habitually wrap their JSON in a markdown code fence (observed
+    live: sre-memory-curator on the DEVOPS-1352 wif smoke). Strip one
+    outer fence when present; anything else is returned as-is."""
+    t = text.strip()
+    if not t.startswith("```"):
+        return t
+    parts = t.split("\n", 1)
+    if len(parts) != 2 or not parts[1].rstrip().endswith("```"):
+        return t
+    inner = parts[1].rstrip()
+    return inner[: inner.rfind("```")].strip()
+
+
 def validate_output(parsed, schema, text: str) -> None:
     """Sessions have no provider-side structured-output binding, so the
     schema contract is enforced here instead."""
@@ -337,8 +352,8 @@ def main() -> None:
         except ValueError:
             fail_soft("session-timeout-seconds must be an integer")
         vault_id = os.environ.get("INPUT_VAULT_ID", "").strip()
-        text = run_session(agent_name, user_content, api_key, vault_id,
-                           timeout_s)
+        text = strip_fence(run_session(agent_name, user_content, api_key,
+                                       vault_id, timeout_s))
         try:
             parsed = json.loads(text)
         except json.JSONDecodeError:

--- a/.github/actions/ai-step/test/test_run_session.py
+++ b/.github/actions/ai-step/test/test_run_session.py
@@ -267,6 +267,17 @@ def test_happy_path_returns_text_and_deletes(run_mod):
     assert client.sent, "user.message was never sent"
 
 
+def test_strip_fence_unwraps_and_preserves(run_mod):
+    # observed live: agents fence their JSON since sessions have no
+    # provider-side structured-output binding
+    fenced = '```json\n{"ok": true}\n```'
+    assert run_mod.strip_fence(fenced) == '{"ok": true}'
+    assert run_mod.strip_fence('{"ok": true}') == '{"ok": true}'
+    assert run_mod.strip_fence("just prose") == "just prose"
+    unclosed = '```json\n{"ok": true}'
+    assert run_mod.strip_fence(unclosed) == unclosed
+
+
 def test_validate_output_rejects_schema_violation(run_mod):
     pytest.importorskip("jsonschema")
     with pytest.raises(SystemExit) as e:


### PR DESCRIPTION
## Summary
The wif smoke ([ai-agents run 32252874325](https://github.com/loft-sh/ai-agents/actions/runs/32252874325), rerun after #229) got the session all the way to output parsing, and the agent returned schema-perfect JSON wrapped in a ```json markdown fence, which `json.loads` rejects. Sessions have no provider-side structured-output binding and agents habitually fence JSON, so every session caller trips on this.

## Key Changes
- `src/run.py`: `strip_fence()` removes one outer markdown fence from session output before parsing; non-fenced and malformed-fence text passes through untouched so raw-output diagnostics stay faithful. Single-call mode is unaffected (provider-side binding never fences).
- `test/test_run_session.py`: fence unwrap, passthrough, prose, and unclosed-fence cases. 16 pytest green.

## Dependencies
- Follows #227 and #229. The wif smoke on loft-sh/ai-agents#100 is one layer from green; this is that layer.

## TODO
- [ ] green wif smoke on ai-agents#100 after merge, then roll `ai-step/v1`

References DEVOPS-1352