### PR TITLE
fix(auto-approve): guard merges with the tested head

### DIFF
--- a/.github/actions/auto-approve-bot-prs/README.md
+++ b/.github/actions/auto-approve-bot-prs/README.md
@@ -80,12 +80,23 @@ rerun that was still coming. That stalled the `v0.34.7` cut
 With `auto-merge: true` the action tries a **plain merge first**, and uses
 GitHub's auto-merge queue (`--auto`) only as a fallback.
 
-The action binds approval and merging to the pull request head SHA from the
-triggering event. It checks that SHA once before polling CI and again after CI
-passes. If Renovate or another actor updates the branch while an older run is
-still polling, that run skips approval. Both the direct and queued merge calls
-also pass `--match-head-commit`, so GitHub refuses the merge if the head changes
-after the final check. The new head must be handled by its own workflow run.
+The action carries the pull request head SHA from the triggering event through
+the run. It checks that SHA once before polling CI and again after CI passes. If
+Renovate or another actor updates the branch while an older run is still
+polling, that run skips approval.
+
+Both merge calls pass `--match-head-commit`. For a direct merge, GitHub checks
+the SHA atomically when it merges, so that path can only land the commit this
+run tested. For the `--auto` fallback, GitHub CLI forwards the SHA as
+`expectedHeadOid` when it enables auto-merge, which guards enqueueing only.
+GitHub can leave auto-merge enabled after a later push by an actor with write
+permission; any eventual merge then relies on the repository's required checks
+and stale-approval settings for the new head, not on this run's original SHA.
+
+The approval is submitted immediately after the second head check, but the
+approval action does not bind its review to that SHA. Repositories that require
+approvals to be invalidated after a push must enforce that through their branch
+protection or ruleset settings.
 
 The merge step uses `merge-token` when supplied, otherwise it keeps the existing
 behavior and uses `github-token`. This lets a caller approve with an identity

--- a/.github/actions/auto-approve-bot-prs/README.md
+++ b/.github/actions/auto-approve-bot-prs/README.md
@@ -80,6 +80,13 @@ rerun that was still coming. That stalled the `v0.34.7` cut
 With `auto-merge: true` the action tries a **plain merge first**, and uses
 GitHub's auto-merge queue (`--auto`) only as a fallback.
 
+The action binds approval and merging to the pull request head SHA from the
+triggering event. It checks that SHA once before polling CI and again after CI
+passes. If Renovate or another actor updates the branch while an older run is
+still polling, that run skips approval. Both the direct and queued merge calls
+also pass `--match-head-commit`, so GitHub refuses the merge if the head changes
+after the final check. The new head must be handled by its own workflow run.
+
 The merge step uses `merge-token` when supplied, otherwise it keeps the existing
 behavior and uses `github-token`. This lets a caller approve with an identity
 that differs from the PR author, then merge with an identity that has a path

--- a/.github/actions/auto-approve-bot-prs/README.md
+++ b/.github/actions/auto-approve-bot-prs/README.md
@@ -85,6 +85,12 @@ the run. It checks that SHA once before polling CI and again after CI passes. If
 Renovate or another actor updates the branch while an older run is still
 polling, that run skips approval.
 
+The post-CI check is deliberately narrower than the preflight. It rejects a
+moved head or a definitive merge conflict, but does not repeat the approver
+identity lookup and does not wait for transient `mergeable: null` metadata.
+Those checks already passed before the CI wait, and repeating them here can
+strand a release on an unrelated API blip after all CI has completed.
+
 Both merge calls pass `--match-head-commit`. For a direct merge, GitHub checks
 the SHA atomically when it merges, so that path can only land the commit this
 run tested. For the `--auto` fallback, GitHub CLI forwards the SHA as
@@ -165,7 +171,7 @@ split:
 
 | Step | Token |
 |------|-------|
-| `check-pr-ready`, *Approve PR* | `github-token` (PAT) |
+| `check-pr-ready`, `check-pr-after-ci`, *Approve PR* | `github-token` (PAT) |
 | *Wait for other CI to pass* | `ci-read-token`, defaulting to `GITHUB_TOKEN` |
 | *Merge PR* | `merge-token`, defaulting to `github-token` |
 

--- a/.github/actions/auto-approve-bot-prs/action.yml
+++ b/.github/actions/auto-approve-bot-prs/action.yml
@@ -92,9 +92,8 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.github-token }}
         PR_NUMBER: ${{ github.event.pull_request.number }}
-        PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         EXPECTED_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-      run: ${{ github.action_path }}/src/check-pr-ready.sh
+      run: ${{ github.action_path }}/src/check-pr-after-ci.sh
 
     - name: Approve PR
       if: steps.recheck.outputs.proceed == 'true'

--- a/.github/actions/auto-approve-bot-prs/action.yml
+++ b/.github/actions/auto-approve-bot-prs/action.yml
@@ -63,6 +63,7 @@ runs:
         GH_TOKEN: ${{ inputs.github-token }}
         PR_NUMBER: ${{ github.event.pull_request.number }}
         PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        EXPECTED_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       run: ${{ github.action_path }}/src/check-pr-ready.sh
 
     - name: Wait for other CI to pass
@@ -84,8 +85,19 @@ runs:
         WAIT_SLEEP_SECONDS: ${{ inputs.wait-sleep-seconds }}
       run: ${{ github.action_path }}/src/wait-for-ci.sh
 
-    - name: Approve PR
+    - name: Re-check PR ready after CI
       if: steps.ci.outputs.ci_green == 'true'
+      id: recheck
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        EXPECTED_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      run: ${{ github.action_path }}/src/check-pr-ready.sh
+
+    - name: Approve PR
+      if: steps.recheck.outputs.proceed == 'true'
       continue-on-error: true
       uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363 # v4.0.0
       with:
@@ -96,10 +108,11 @@ runs:
           For more information, see https://github.com/loft-sh/github-actions?tab=readme-ov-file#auto-approve-bot-prs.
 
     - name: Merge PR
-      if: steps.ci.outputs.ci_green == 'true' && inputs.auto-merge == 'true'
+      if: steps.recheck.outputs.proceed == 'true' && inputs.auto-merge == 'true'
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.merge-token || inputs.github-token }}
         PR_NUMBER: ${{ github.event.pull_request.number }}
+        PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         MERGE_METHOD: ${{ inputs.merge-method }}
       run: ${{ github.action_path }}/src/enable-auto-merge.sh

--- a/.github/actions/auto-approve-bot-prs/src/check-pr-after-ci.sh
+++ b/.github/actions/auto-approve-bot-prs/src/check-pr-after-ci.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Narrow post-CI gate. The full preflight already proved the approver identity
+# and waited for mergeability metadata. After CI, only a moved head or a
+# definitive conflict should discard the run.
+#
+# Required env: GH_TOKEN, GITHUB_REPOSITORY, PR_NUMBER, EXPECTED_HEAD_SHA
+# Writes: proceed=true|false to $GITHUB_OUTPUT (and stdout).
+# Always exits 0 after validating required env.
+set -euo pipefail
+
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY required}"
+: "${PR_NUMBER:?PR_NUMBER required}"
+: "${EXPECTED_HEAD_SHA:?EXPECTED_HEAD_SHA required}"
+
+# shellcheck source=.github/actions/auto-approve-bot-prs/src/lib/log.sh
+. "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/lib/log.sh"
+
+emit() {
+  local k="$1" v="$2"
+  [ -n "${GITHUB_OUTPUT:-}" ] && printf '%s=%s\n' "$k" "$v" >> "$GITHUB_OUTPUT"
+  printf '%s=%s\n' "$k" "$v"
+}
+
+if ! pr_state=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" \
+  --jq '[
+    (.mergeable | if . == null then "null" else tostring end),
+    (.head.sha // "")
+  ] | @tsv' 2>/dev/null); then
+  echo "::error::could not read PR #${PR_NUMBER} after CI; not approving because the tested head cannot be verified"
+  emit proceed false
+  exit 0
+fi
+
+IFS=$'\t' read -r mergeable current_head <<< "$pr_state"
+if [ -z "$current_head" ]; then
+  echo "::error::could not resolve the current head SHA for PR #${PR_NUMBER} after CI; not approving because the tested commit cannot be verified"
+  emit proceed false
+  exit 0
+fi
+if [ "$current_head" != "$EXPECTED_HEAD_SHA" ]; then
+  echo "::error::PR #${PR_NUMBER} head changed from tested SHA '$(safe "$EXPECTED_HEAD_SHA")' to '$(safe "$current_head")'; not approving. The synchronize run for the new head must verify CI instead"
+  emit proceed false
+  exit 0
+fi
+
+if [ "$mergeable" = "false" ]; then
+  echo "::warning::PR #${PR_NUMBER} developed merge conflicts while CI was running; not approving. It needs a rebase before this can proceed"
+  emit proceed false
+  exit 0
+fi
+
+if [ "$mergeable" = "null" ]; then
+  echo "::notice::GitHub is still computing mergeability for PR #${PR_NUMBER}; continuing because the tested head is unchanged and the merge API will enforce conflicts"
+fi
+emit proceed true

--- a/.github/actions/auto-approve-bot-prs/src/check-pr-ready.sh
+++ b/.github/actions/auto-approve-bot-prs/src/check-pr-ready.sh
@@ -39,8 +39,31 @@ mergeable="null"
 mergeable_attempts="${MERGEABLE_MAX_ATTEMPTS:-10}"
 mergeable_sleep="${MERGEABLE_SLEEP_SECONDS:-3}"
 for _ in $(seq 1 "$mergeable_attempts"); do
-  mergeable=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" \
-    --jq '.mergeable | if . == null then "null" else tostring end' 2>/dev/null || echo "null")
+  if ! pr_state=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" \
+    --jq '[
+      (.mergeable | if . == null then "null" else tostring end),
+      (.head.sha // "")
+    ] | @tsv' 2>/dev/null); then
+    mergeable="null"
+    sleep "$mergeable_sleep"
+    continue
+  fi
+  IFS=$'\t' read -r mergeable current_head <<< "$pr_state"
+
+  # A synchronize event can move the PR while this workflow is polling. Check
+  # the event SHA before waiting for GitHub to recompute mergeability so a
+  # force-push reports the real reason immediately instead of timing out.
+  if [ -z "$current_head" ]; then
+    echo "::error::could not resolve the current head SHA for PR #${PR_NUMBER}; not approving because the tested commit cannot be verified"
+    emit proceed false
+    exit 0
+  fi
+  if [ "$current_head" != "$EXPECTED_HEAD_SHA" ]; then
+    echo "::error::PR #${PR_NUMBER} head changed from tested SHA '$(safe "$EXPECTED_HEAD_SHA")' to '$(safe "$current_head")'; not approving. The synchronize run for the new head must verify CI instead"
+    emit proceed false
+    exit 0
+  fi
+
   [ "$mergeable" != "null" ] && break
   sleep "$mergeable_sleep"
 done
@@ -56,22 +79,6 @@ if [ "$mergeable" = "false" ]; then
 fi
 if [ "$mergeable" != "true" ]; then
   echo "::warning::GitHub did not report mergeability for PR #${PR_NUMBER} within ${mergeable_attempts} attempts (last value '$(safe "$mergeable")'); not approving. This is usually transient - a re-run should resolve it"
-  emit proceed false
-  exit 0
-fi
-
-# The workflow can spend many minutes polling CI. A synchronize event may move
-# the PR to a new commit while an older run is still alive, so confirm that the
-# SHA this run is about to approve is still the SHA whose CI it observed.
-current_head=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" \
-  --jq '.head.sha // ""' 2>/dev/null || echo "")
-if [ -z "$current_head" ]; then
-  echo "::error::could not resolve the current head SHA for PR #${PR_NUMBER}; not approving because the tested commit cannot be verified"
-  emit proceed false
-  exit 0
-fi
-if [ "$current_head" != "$EXPECTED_HEAD_SHA" ]; then
-  echo "::error::PR #${PR_NUMBER} head changed from tested SHA '$(safe "$EXPECTED_HEAD_SHA")' to '$(safe "$current_head")'; not approving. The synchronize run for the new head must verify CI instead"
   emit proceed false
   exit 0
 fi

--- a/.github/actions/auto-approve-bot-prs/src/check-pr-ready.sh
+++ b/.github/actions/auto-approve-bot-prs/src/check-pr-ready.sh
@@ -2,7 +2,8 @@
 # Combines two gates: merge-conflict check and approver-identity check.
 # Only writes proceed=true if BOTH pass.
 #
-# Required env: GH_TOKEN, GITHUB_REPOSITORY, PR_NUMBER, PR_AUTHOR
+# Required env: GH_TOKEN, GITHUB_REPOSITORY, PR_NUMBER, PR_AUTHOR,
+#               EXPECTED_HEAD_SHA
 # Writes: proceed=true|false to $GITHUB_OUTPUT (and stdout).
 # Always exits 0.
 set -euo pipefail
@@ -10,6 +11,7 @@ set -euo pipefail
 : "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY required}"
 : "${PR_NUMBER:?PR_NUMBER required}"
 : "${PR_AUTHOR:?PR_AUTHOR required}"
+: "${EXPECTED_HEAD_SHA:?EXPECTED_HEAD_SHA required}"
 
 # The authenticated login below is API-derived and reaches a log line. The API
 # answers in JSON, and a `\r` escape inside a JSON string decodes to a real CR
@@ -54,6 +56,22 @@ if [ "$mergeable" = "false" ]; then
 fi
 if [ "$mergeable" != "true" ]; then
   echo "::warning::GitHub did not report mergeability for PR #${PR_NUMBER} within ${mergeable_attempts} attempts (last value '$(safe "$mergeable")'); not approving. This is usually transient - a re-run should resolve it"
+  emit proceed false
+  exit 0
+fi
+
+# The workflow can spend many minutes polling CI. A synchronize event may move
+# the PR to a new commit while an older run is still alive, so confirm that the
+# SHA this run is about to approve is still the SHA whose CI it observed.
+current_head=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" \
+  --jq '.head.sha // ""' 2>/dev/null || echo "")
+if [ -z "$current_head" ]; then
+  echo "::error::could not resolve the current head SHA for PR #${PR_NUMBER}; not approving because the tested commit cannot be verified"
+  emit proceed false
+  exit 0
+fi
+if [ "$current_head" != "$EXPECTED_HEAD_SHA" ]; then
+  echo "::error::PR #${PR_NUMBER} head changed from tested SHA '$(safe "$EXPECTED_HEAD_SHA")' to '$(safe "$current_head")'; not approving. The synchronize run for the new head must verify CI instead"
   emit proceed false
   exit 0
 fi

--- a/.github/actions/auto-approve-bot-prs/src/enable-auto-merge.sh
+++ b/.github/actions/auto-approve-bot-prs/src/enable-auto-merge.sh
@@ -88,6 +88,10 @@ esac
 
 echo "::notice::plain merge of PR #${PR_NUMBER} was refused, falling back to auto-merge. Reason: $(safe "$direct_err")"
 
+# This SHA protects the enable-auto-merge mutation, not the eventual queued
+# merge. GitHub may keep auto-merge enabled after a later push by an actor with
+# write permission; the new head is then governed by repository protections.
+# See README "Merging" for the direct-versus-queued guarantee.
 if auto_err=$(try_merge gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
   --auto --"$MERGE_METHOD" --match-head-commit "$PR_HEAD_SHA"); then
   # Deliberately does NOT promise this lands on its own. Queueing succeeded, but

--- a/.github/actions/auto-approve-bot-prs/src/enable-auto-merge.sh
+++ b/.github/actions/auto-approve-bot-prs/src/enable-auto-merge.sh
@@ -19,11 +19,13 @@
 # ::error:: level so the cause is visible in the run summary instead of being
 # buried in a notice.
 #
-# Required env: GH_TOKEN, GITHUB_REPOSITORY, PR_NUMBER, MERGE_METHOD
+# Required env: GH_TOKEN, GITHUB_REPOSITORY, PR_NUMBER, PR_HEAD_SHA,
+#               MERGE_METHOD
 set -euo pipefail
 
 : "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY required}"
 : "${PR_NUMBER:?PR_NUMBER required}"
+: "${PR_HEAD_SHA:?PR_HEAD_SHA required}"
 : "${MERGE_METHOD:?MERGE_METHOD required}"
 
 # Every interpolated value below is externally controlled — gh's output is
@@ -63,7 +65,8 @@ try_merge() {
   return "$rc"
 }
 
-if direct_err=$(try_merge gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --"$MERGE_METHOD"); then
+if direct_err=$(try_merge gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+  --"$MERGE_METHOD" --match-head-commit "$PR_HEAD_SHA"); then
   echo "Merged PR #${PR_NUMBER} (${MERGE_METHOD})"
   exit 0
 fi
@@ -85,7 +88,8 @@ esac
 
 echo "::notice::plain merge of PR #${PR_NUMBER} was refused, falling back to auto-merge. Reason: $(safe "$direct_err")"
 
-if auto_err=$(try_merge gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --auto --"$MERGE_METHOD"); then
+if auto_err=$(try_merge gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+  --auto --"$MERGE_METHOD" --match-head-commit "$PR_HEAD_SHA"); then
   # Deliberately does NOT promise this lands on its own. Queueing succeeded, but
   # that only means GitHub accepted the request — several refusals reach here
   # with equal confidence and need a human, not patience: a strict

--- a/.github/actions/auto-approve-bot-prs/test/check-pr-after-ci.bats
+++ b/.github/actions/auto-approve-bot-prs/test/check-pr-after-ci.bats
@@ -1,0 +1,63 @@
+#!/usr/bin/env bats
+
+SCRIPT="$BATS_TEST_DIRNAME/../src/check-pr-after-ci.sh"
+load gh_mock
+
+setup() {
+  setup_gh_mock
+  export GITHUB_OUTPUT; GITHUB_OUTPUT="$(mktemp)"
+  export GITHUB_REPOSITORY="owner/repo"
+  export PR_NUMBER=42
+  export EXPECTED_HEAD_SHA="tested-head-sha"
+  export GH_MOCK_HEAD_SHA="tested-head-sha"
+}
+teardown() { rm -f "$GITHUB_OUTPUT"; teardown_gh_mock; }
+
+kv() { grep "^$1=" "$GITHUB_OUTPUT" | tail -n1; }
+
+@test "same mergeable head proceeds" {
+  GH_MOCK_MERGEABLE=true run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv proceed)" = "proceed=true" ]
+}
+
+@test "unresolved mergeability does not discard a tested head" {
+  GH_MOCK_MERGEABLE=null run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv proceed)" = "proceed=true" ]
+}
+
+@test "definitive merge conflict blocks approval" {
+  GH_MOCK_MERGEABLE=false run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv proceed)" = "proceed=false" ]
+  [[ "$output" == *"merge conflicts"* ]]
+}
+
+@test "moved mergeable head blocks approval" {
+  GH_MOCK_MERGEABLE=true GH_MOCK_HEAD_SHA="new-head-sha" run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv proceed)" = "proceed=false" ]
+  [[ "$output" == *"head changed"* ]]
+}
+
+@test "head mismatch takes precedence over a conflict" {
+  GH_MOCK_MERGEABLE=false GH_MOCK_HEAD_SHA="new-head-sha" run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv proceed)" = "proceed=false" ]
+  [[ "$output" == *"head changed"* ]]
+  [[ "$output" != *"merge conflicts"* ]]
+}
+
+@test "unreadable PR state fails closed" {
+  GH_MOCK_PULL_FAIL=always run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv proceed)" = "proceed=false" ]
+  [[ "$output" == *"could not read PR #42"* ]]
+}
+
+@test "missing EXPECTED_HEAD_SHA fails" {
+  run env -u EXPECTED_HEAD_SHA GITHUB_OUTPUT="$GITHUB_OUTPUT" \
+    GITHUB_REPOSITORY=o/r PR_NUMBER=1 "$SCRIPT"
+  [ "$status" -ne 0 ]
+}

--- a/.github/actions/auto-approve-bot-prs/test/check-pr-ready.bats
+++ b/.github/actions/auto-approve-bot-prs/test/check-pr-ready.bats
@@ -10,6 +10,8 @@ setup() {
   export GITHUB_REPOSITORY="owner/repo"
   export PR_NUMBER=42
   export PR_AUTHOR="dependabot[bot]"
+  export EXPECTED_HEAD_SHA="tested-head-sha"
+  export GH_MOCK_HEAD_SHA="tested-head-sha"
   # Keep retry budget bounded so tests don't stall the suite.
   export MERGEABLE_MAX_ATTEMPTS=2
   export MERGEABLE_SLEEP_SECONDS=0
@@ -67,6 +69,16 @@ kv() { grep "^$1=" "$GITHUB_OUTPUT" | tail -n1; }
   [[ "$output" != *"self-approval"* ]]
 }
 
+@test "head changed after the run started → proceed=false" {
+  GH_MOCK_MERGEABLE=true GH_MOCK_APPROVER="loft-bot" \
+    GH_MOCK_HEAD_SHA="new-head-sha" run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv proceed)" = "proceed=false" ]
+  [[ "$output" == *"head changed"* ]]
+  [[ "$output" == *"tested-head-sha"* ]]
+  [[ "$output" == *"new-head-sha"* ]]
+}
+
 @test "regression: a CR in the authenticated login cannot forge a workflow command" {
   # "GitHub logins cannot contain control characters" does not close this
   # channel: the API answers in JSON, and a \r escape inside a JSON string
@@ -92,6 +104,12 @@ kv() { grep "^$1=" "$GITHUB_OUTPUT" | tail -n1; }
 
 @test "missing PR_NUMBER fails" {
   run env -u PR_NUMBER GITHUB_OUTPUT="$GITHUB_OUTPUT" GITHUB_REPOSITORY=o/r PR_AUTHOR=x "$SCRIPT"
+  [ "$status" -ne 0 ]
+}
+
+@test "missing EXPECTED_HEAD_SHA fails" {
+  run env -u EXPECTED_HEAD_SHA GITHUB_OUTPUT="$GITHUB_OUTPUT" \
+    GITHUB_REPOSITORY=o/r PR_NUMBER=1 PR_AUTHOR=x "$SCRIPT"
   [ "$status" -ne 0 ]
 }
 

--- a/.github/actions/auto-approve-bot-prs/test/check-pr-ready.bats
+++ b/.github/actions/auto-approve-bot-prs/test/check-pr-ready.bats
@@ -80,6 +80,24 @@ kv() { grep "^$1=" "$GITHUB_OUTPUT" | tail -n1; }
   [[ "$output" == *"new-head-sha"* ]]
 }
 
+@test "a moved head blocks even when the PR is definitively mergeable" {
+  GH_MOCK_MERGEABLE=true GH_MOCK_APPROVER="loft-bot" \
+    GH_MOCK_HEAD_SHA="new-head-sha" run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv proceed)" = "proceed=false" ]
+  [[ "$output" == *"head changed"* ]]
+  [[ "$output" == *"new-head-sha"* ]]
+}
+
+@test "a moved head takes precedence over a definitive conflict" {
+  GH_MOCK_MERGEABLE=false GH_MOCK_APPROVER="loft-bot" \
+    GH_MOCK_HEAD_SHA="new-head-sha" run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(kv proceed)" = "proceed=false" ]
+  [[ "$output" == *"head changed"* ]]
+  [[ "$output" != *"merge conflicts"* ]]
+}
+
 @test "regression: a CR in the authenticated login cannot forge a workflow command" {
   # "GitHub logins cannot contain control characters" does not close this
   # channel: the API answers in JSON, and a \r escape inside a JSON string

--- a/.github/actions/auto-approve-bot-prs/test/check-pr-ready.bats
+++ b/.github/actions/auto-approve-bot-prs/test/check-pr-ready.bats
@@ -70,10 +70,11 @@ kv() { grep "^$1=" "$GITHUB_OUTPUT" | tail -n1; }
 }
 
 @test "head changed after the run started → proceed=false" {
-  GH_MOCK_MERGEABLE=true GH_MOCK_APPROVER="loft-bot" \
+  GH_MOCK_MERGEABLE=null GH_MOCK_APPROVER="loft-bot" \
     GH_MOCK_HEAD_SHA="new-head-sha" run "$SCRIPT"
   [ "$status" -eq 0 ]
   [ "$(kv proceed)" = "proceed=false" ]
+  [ "$(grep -c 'pulls/42' "$GH_MOCK_CALLS")" -eq 1 ]
   [[ "$output" == *"head changed"* ]]
   [[ "$output" == *"tested-head-sha"* ]]
   [[ "$output" == *"new-head-sha"* ]]

--- a/.github/actions/auto-approve-bot-prs/test/enable-auto-merge.bats
+++ b/.github/actions/auto-approve-bot-prs/test/enable-auto-merge.bats
@@ -9,6 +9,7 @@ setup() {
   export GITHUB_REPOSITORY="owner/repo"
   export PR_NUMBER=42
   export MERGE_METHOD="squash"
+  export PR_HEAD_SHA="tested-head-sha"
   # Every refusal path retries once. Keep the backoff out of the suite runtime —
   # at the 5s default the failure-path tests alone add over a minute.
   export MERGE_RETRY_SLEEP_SECONDS=0
@@ -150,6 +151,13 @@ auto_merge_count() { grep -c '^pr merge .*--auto' "$GH_MOCK_CALLS" || true; }
   done
 }
 
+@test "every direct and queued merge attempt requires the tested head SHA" {
+  GH_MOCK_PR_MERGE_EXIT=1 GH_MOCK_PR_MERGE_AUTO_EXIT=0 GH_MOCK_PR_STATE=OPEN run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  merge_calls="$(grep '^pr merge ' "$GH_MOCK_CALLS")"
+  [ "$(printf '%s\n' "$merge_calls" | grep -c -- '--match-head-commit tested-head-sha')" -eq 3 ]
+}
+
 @test "missing PR_NUMBER fails" {
   run env -u PR_NUMBER GITHUB_REPOSITORY=o/r MERGE_METHOD=squash "$SCRIPT"
   [ "$status" -ne 0 ]
@@ -157,6 +165,11 @@ auto_merge_count() { grep -c '^pr merge .*--auto' "$GH_MOCK_CALLS" || true; }
 
 @test "missing MERGE_METHOD fails" {
   run env -u MERGE_METHOD GITHUB_REPOSITORY=o/r PR_NUMBER=1 "$SCRIPT"
+  [ "$status" -ne 0 ]
+}
+
+@test "missing PR_HEAD_SHA fails" {
+  run env -u PR_HEAD_SHA GITHUB_REPOSITORY=o/r PR_NUMBER=1 MERGE_METHOD=squash "$SCRIPT"
   [ "$status" -ne 0 ]
 }
 

--- a/.github/actions/auto-approve-bot-prs/test/enable-auto-merge.bats
+++ b/.github/actions/auto-approve-bot-prs/test/enable-auto-merge.bats
@@ -155,7 +155,9 @@ auto_merge_count() { grep -c '^pr merge .*--auto' "$GH_MOCK_CALLS" || true; }
   GH_MOCK_PR_MERGE_EXIT=1 GH_MOCK_PR_MERGE_AUTO_EXIT=0 GH_MOCK_PR_STATE=OPEN run "$SCRIPT"
   [ "$status" -eq 0 ]
   merge_calls="$(grep '^pr merge ' "$GH_MOCK_CALLS")"
-  [ "$(printf '%s\n' "$merge_calls" | grep -c -- '--match-head-commit tested-head-sha')" -eq 3 ]
+  merge_call_count="$(printf '%s\n' "$merge_calls" | grep -c '^pr merge ')"
+  guarded_call_count="$(printf '%s\n' "$merge_calls" | grep -c -- '--match-head-commit tested-head-sha')"
+  [ "$guarded_call_count" -eq "$merge_call_count" ]
 }
 
 @test "missing PR_NUMBER fails" {

--- a/.github/actions/auto-approve-bot-prs/test/gh_mock.bash
+++ b/.github/actions/auto-approve-bot-prs/test/gh_mock.bash
@@ -14,6 +14,7 @@ setup_gh_mock() {
 set -o pipefail
 #
 # GH_MOCK_MERGEABLE          → response for `gh api ...pulls/N`
+# GH_MOCK_HEAD_SHA           → PR head SHA returned by `gh api ...pulls/N`
 # GH_MOCK_APPROVER           → response for `gh api user`
 # GH_MOCK_CHECK_RUNS_JSON    → response for `gh api .../check-runs` (full object)
 # GH_MOCK_STATUSES_JSON      → response for `gh api .../status` (combined status)
@@ -72,7 +73,8 @@ emit_api_response() {
     *"/pulls/"*)
       local m="${GH_MOCK_MERGEABLE:-null}"
       case "$m" in true|false) ;; *) m=null ;; esac
-      printf '{"mergeable":%s}\n' "$m"
+      printf '{"mergeable":%s,"head":{"sha":"%s"}}\n' \
+        "$m" "${GH_MOCK_HEAD_SHA:-tested-head-sha}"
       ;;
     *"/check-runs"*)
       if [ "${GH_MOCK_CHECK_RUNS_FAIL:-}" = "always" ]; then

--- a/.github/actions/auto-approve-bot-prs/test/gh_mock.bash
+++ b/.github/actions/auto-approve-bot-prs/test/gh_mock.bash
@@ -15,6 +15,7 @@ set -o pipefail
 #
 # GH_MOCK_MERGEABLE          → response for `gh api ...pulls/N`
 # GH_MOCK_HEAD_SHA           → PR head SHA returned by `gh api ...pulls/N`
+# GH_MOCK_PULL_FAIL          → if 'always', /pulls/N exits non-zero
 # GH_MOCK_APPROVER           → response for `gh api user`
 # GH_MOCK_CHECK_RUNS_JSON    → response for `gh api .../check-runs` (full object)
 # GH_MOCK_STATUSES_JSON      → response for `gh api .../status` (combined status)
@@ -71,6 +72,10 @@ emit_api_response() {
       printf '{"login":"%s"}\n' "${GH_MOCK_APPROVER:-}"
       ;;
     *"/pulls/"*)
+      if [ "${GH_MOCK_PULL_FAIL:-}" = "always" ]; then
+        emit_err "mock: pull request forced failure"
+        exit 22
+      fi
       local m="${GH_MOCK_MERGEABLE:-null}"
       case "$m" in true|false) ;; *) m=null ;; esac
       printf '{"mergeable":%s,"head":{"sha":"%s"}}\n' \

--- a/.github/actions/auto-approve-bot-prs/test/token-contract.bats
+++ b/.github/actions/auto-approve-bot-prs/test/token-contract.bats
@@ -28,6 +28,8 @@ WORKFLOW="$BATS_TEST_DIRNAME/../../../workflows/auto-approve-bot-prs.yaml"
   [ "$(grep -Fc 'EXPECTED_HEAD_SHA: ${{ github.event.pull_request.head.sha }}' "$ACTION")" -eq 2 ]
   run grep -F "id: recheck" "$ACTION"
   [ "$status" -eq 0 ]
+  run grep -F 'run: ${{ github.action_path }}/src/check-pr-after-ci.sh' "$ACTION"
+  [ "$status" -eq 0 ]
   [ "$(grep -Fc "steps.recheck.outputs.proceed == 'true'" "$ACTION")" -eq 2 ]
   run grep -F 'PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}' "$ACTION"
   [ "$status" -eq 0 ]

--- a/.github/actions/auto-approve-bot-prs/test/token-contract.bats
+++ b/.github/actions/auto-approve-bot-prs/test/token-contract.bats
@@ -23,3 +23,12 @@ WORKFLOW="$BATS_TEST_DIRNAME/../../../workflows/auto-approve-bot-prs.yaml"
   run grep -F 'github-token: ${{ secrets.gh-access-token }}' "$WORKFLOW"
   [ "$status" -eq 0 ]
 }
+
+@test "the tested head is rechecked after CI and pinned during merge" {
+  [ "$(grep -Fc 'EXPECTED_HEAD_SHA: ${{ github.event.pull_request.head.sha }}' "$ACTION")" -eq 2 ]
+  run grep -F "id: recheck" "$ACTION"
+  [ "$status" -eq 0 ]
+  [ "$(grep -Fc "steps.recheck.outputs.proceed == 'true'" "$ACTION")" -eq 2 ]
+  run grep -F 'PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}' "$ACTION"
+  [ "$status" -eq 0 ]
+}

--- a/.github/actions/auto-approve-bot-prs/test/token-contract.bats
+++ b/.github/actions/auto-approve-bot-prs/test/token-contract.bats
@@ -24,7 +24,7 @@ WORKFLOW="$BATS_TEST_DIRNAME/../../../workflows/auto-approve-bot-prs.yaml"
   [ "$status" -eq 0 ]
 }
 
-@test "the tested head is rechecked after CI and pinned during merge" {
+@test "the tested head is rechecked after CI and passed to every merge request" {
   [ "$(grep -Fc 'EXPECTED_HEAD_SHA: ${{ github.event.pull_request.head.sha }}' "$ACTION")" -eq 2 ]
   run grep -F "id: recheck" "$ACTION"
   [ "$status" -eq 0 ]


### PR DESCRIPTION
## Problem

The action can wait several minutes for CI. During that time, Renovate, Dependabot, or another bot can update the pull request branch.

That creates a race:

1. A workflow starts for commit **A** and waits for its CI results.
2. The bot rebases or pushes commit **B**.
3. The older workflow continues running.
4. Without another head check, it can approve or request a merge for **B** using the decision it made for **A**.

## Solution

This change carries the triggering commit SHA through the workflow:

1. Verify the pull request still points to that SHA before waiting for CI.
2. Wait for CI on that SHA.
3. Verify the SHA again immediately before approval and reject a definitive merge conflict.
4. Pass the SHA to every merge request with `--match-head-commit`.

The post-CI check does not repeat the approver lookup or wait for transient mergeability metadata. Those checks already passed before CI, and repeating them could strand a completed release on an unrelated API blip.

If the bot updates the branch, the old workflow stops. The new `synchronize` workflow is responsible for testing and merging the new commit. For direct merges, GitHub checks the SHA as part of the merge operation, which also closes the small race between the final check and the merge API call.

## Auto-merge fallback

The action already falls back to GitHub auto-merge when a direct merge is temporarily blocked. This PR keeps that behavior because the vCluster release flow and the `loft-enterprise` Renovate-sync job use it.

`--match-head-commit` prevents the action from enabling auto-merge for the wrong SHA at that moment. It does not permanently bind the queue to that SHA. If an actor with write access pushes another commit afterward, GitHub can keep auto-merge enabled and will evaluate the repository checks and review rules for the new head. A strictly SHA-bound queued merge would require a separate design.

The approval step also remains unchanged. The final head check narrows its race window, while repository stale-approval settings determine whether that approval survives a later push.

## Verification

- `make test-auto-approve-bot-prs` — 127 tests
- `make lint`
- `shellcheck -S warning` on the modified scripts
- `git diff --check`

References DEVOPS-1360