### PR TITLE
fix(cve-scan): surface the scanner's error output on an inconclusive scan

### DIFF
--- a/.github/actions/cve-scan/run.sh
+++ b/.github/actions/cve-scan/run.sh
@@ -259,9 +259,9 @@ if [ "$ADAPTER_EXIT" -eq 2 ]; then
 fi
 
 if [ "$ADAPTER_EXIT" -ne 0 ]; then
-  # No exit code in the Slack summary: ADAPTER_EXIT is always 1 for an
-  # inconclusive scan, so it read as a detail while saying nothing, and
-  # contradicted the scanner's own code in the log.
+  # No exit code in the Slack summary: it named the adapter's exit, not the
+  # scanner's, so it contradicted the log. Any non-zero lands here, including a
+  # jq or OOM death under the adapter's set -e, so it is not even stable.
   finish_with_no_result true \
     "scanner '${SCANNER}' failed to complete (exit ${ADAPTER_EXIT}) — treating as inconclusive, not a finding" \
     "scanner error, see job log" ":warning:"

--- a/.github/actions/cve-scan/run.sh
+++ b/.github/actions/cve-scan/run.sh
@@ -259,9 +259,12 @@ if [ "$ADAPTER_EXIT" -eq 2 ]; then
 fi
 
 if [ "$ADAPTER_EXIT" -ne 0 ]; then
+  # No exit code in the Slack summary: ADAPTER_EXIT is always 1 for an
+  # inconclusive scan, so it read as a detail while saying nothing, and
+  # contradicted the scanner's own code in the log.
   finish_with_no_result true \
     "scanner '${SCANNER}' failed to complete (exit ${ADAPTER_EXIT}) — treating as inconclusive, not a finding" \
-    "scanner error (exit ${ADAPTER_EXIT}), see job log" ":warning:"
+    "scanner error, see job log" ":warning:"
 fi
 
 # --- 5. Gate + report --------------------------------------------------------

--- a/.github/actions/cve-scan/src/scanners/snyk.sh
+++ b/.github/actions/cve-scan/src/scanners/snyk.sh
@@ -165,6 +165,13 @@ fi
 
 if [ "$EXIT_CODE" -ne 0 ] && [ "$EXIT_CODE" -ne 1 ]; then
   echo "snyk container test exited ${EXIT_CODE} (expected 0 or 1)" >&2
+  # Under --json snyk puts its error on stdout, so stderr is empty here and
+  # returning without this left no statement of the cause anywhere.
+  if [ -s "$RAW_JSON_FILE" ]; then
+    echo "snyk stdout:" >&2
+    head -c 4000 "$RAW_JSON_FILE" >&2
+    echo >&2
+  fi
   exit 1
 fi
 

--- a/.github/actions/cve-scan/src/scanners/snyk.sh
+++ b/.github/actions/cve-scan/src/scanners/snyk.sh
@@ -166,11 +166,12 @@ fi
 if [ "$EXIT_CODE" -ne 0 ] && [ "$EXIT_CODE" -ne 1 ]; then
   echo "snyk container test exited ${EXIT_CODE} (expected 0 or 1)" >&2
   # Under --json snyk puts its error on stdout, so stderr is empty here and
-  # returning without this left no statement of the cause anywhere.
-  if [ -s "$RAW_JSON_FILE" ]; then
-    echo "snyk stdout:" >&2
-    head -c 4000 "$RAW_JSON_FILE" >&2
-    echo >&2
+  # returning without this left no statement of the cause anywhere. Only the
+  # error field is printed: the payload can also carry scan results, and a
+  # private image's dependency inventory is not what a failure needs to say.
+  ERR=$(jq -r '[.error?, .path?] | map(select(. != null and . != "")) | join(" — ")' "$RAW_JSON_FILE" 2>/dev/null | head -c 500 || true)
+  if [ -n "$ERR" ]; then
+    echo "snyk error: ${ERR}" >&2
   fi
   exit 1
 fi

--- a/.github/actions/cve-scan/test/run.bats
+++ b/.github/actions/cve-scan/test/run.bats
@@ -350,6 +350,18 @@ MOCK
   [ ! -f "$PROCESS_CALLED" ]
 }
 
+# The adapter's exit code is always 1 here, so quoting it in the Slack-facing
+# summary read as a detail while saying nothing, and contradicted the scanner's
+# real code in the log.
+@test "the summary names no exit code, only the scanner's own is meaningful" {
+  echo "1" > "$ADAPTER_EXIT_FILE"
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  summary=$(grab_output summary)
+  [[ "$summary" == *"scanner error, see job log"* ]]
+  [[ "$summary" != *"exit"* ]]
+}
+
 # --- Adapter setup error DOES fail the job --------------------------------------
 # Exit 2 from an adapter means it could not be set up (missing CLI, missing
 # credential). Folding that into the scanner-error path is what made the action

--- a/.github/actions/cve-scan/test/run.bats
+++ b/.github/actions/cve-scan/test/run.bats
@@ -350,9 +350,8 @@ MOCK
   [ ! -f "$PROCESS_CALLED" ]
 }
 
-# The adapter's exit code is always 1 here, so quoting it in the Slack-facing
-# summary read as a detail while saying nothing, and contradicted the scanner's
-# real code in the log.
+# The summary named the adapter's exit rather than the scanner's, contradicting
+# the log. This asserts on the stubbed 1, but any non-zero reaches that branch.
 @test "the summary names no exit code, only the scanner's own is meaningful" {
   echo "1" > "$ADAPTER_EXIT_FILE"
   run bash "$SCRIPT"

--- a/.github/actions/cve-scan/test/scanners_snyk.bats
+++ b/.github/actions/cve-scan/test/scanners_snyk.bats
@@ -389,12 +389,28 @@ JSON
 
 # A real exit 2 reported nothing anywhere: --json sends the error to stdout, so
 # stderr was empty and this path returned before the invalid-JSON dump.
-@test "exit 2 surfaces snyk's own stdout so the cause is recoverable" {
-  echo '{"ok":false,"error":"Authentication error"}' > "$SNYK_OUTPUT"
+@test "exit 2 surfaces snyk's own error so the cause is recoverable" {
+  echo '{"ok":false,"error":"You are not associated with any org. ","path":"node:18-slim"}' > "$SNYK_OUTPUT"
+  echo "2" > "$SNYK_EXIT"
+  run bash "$SCRIPT"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"not associated with any org"* ]]
+  [[ "$output" == *"node:18-slim"* ]]
+}
+
+# The error field only. An unexpected exit code does not guarantee the payload
+# is an error object, and a private image's package list is not a diagnostic.
+@test "exit 2 does not print the scan payload alongside the error" {
+  cat > "$SNYK_OUTPUT" <<'JSON'
+{"ok":false,"error":"Authentication error","vulnerabilities":[
+  {"id":"SNYK-1","packageName":"internal-secret-lib","version":"1.2.3"}
+]}
+JSON
   echo "2" > "$SNYK_EXIT"
   run bash "$SCRIPT"
   [ "$status" -eq 1 ]
   [[ "$output" == *"Authentication error"* ]]
+  [[ "$output" != *"internal-secret-lib"* ]]
 }
 
 @test "clean exit 0 with invalid JSON is still a scanner error" {

--- a/.github/actions/cve-scan/test/scanners_snyk.bats
+++ b/.github/actions/cve-scan/test/scanners_snyk.bats
@@ -387,6 +387,16 @@ JSON
   [ "$status" -eq 1 ]
 }
 
+# A real exit 2 reported nothing anywhere: --json sends the error to stdout, so
+# stderr was empty and this path returned before the invalid-JSON dump.
+@test "exit 2 surfaces snyk's own stdout so the cause is recoverable" {
+  echo '{"ok":false,"error":"Authentication error"}' > "$SNYK_OUTPUT"
+  echo "2" > "$SNYK_EXIT"
+  run bash "$SCRIPT"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Authentication error"* ]]
+}
+
 @test "clean exit 0 with invalid JSON is still a scanner error" {
   echo 'not json at all' > "$SNYK_OUTPUT"
   echo "0" > "$SNYK_EXIT"


### PR DESCRIPTION
## Which issue(s) does this PR fix

References DEVOPS-1292

## Special notes for your reviewer

### Problem

A release scan can fail without saying why. On `vcluster-pro` `v0.37.0-alpha.2` the scan reported `snyk container test exited 2`, produced no SARIF, left the job green as designed, and posted `scanner error (exit 1), see job log` to Slack. The job log did not contain the cause either, so the message pointed at a log that could not answer it.

Two mechanisms combine to lose it. Under `--json` snyk writes its error to stdout, so `RAW_STDERR_FILE` is empty and the existing stderr passthrough prints nothing; the captured stdout is then discarded, because the exit-code check returns before the invalid-JSON dump that would have shown it. Separately, the exit code in the Slack summary is `ADAPTER_EXIT`, which is always `1` for an inconclusive scan, so it reads as a detail while carrying no information and contradicting the scanner's real code in the log.

### Root cause of the incident that exposed this

The discarded payload was:

```json
{ "ok": false, "error": "You are not associated with any org. ", "path": "node:18-slim" }
```

The CI service-account token authenticates but belongs to no Snyk org, so snyk has nothing to run a test against and never reaches the image. That is why it failed identically for `node:18-slim` and for `vcluster-pro:0.37.0-alpha.2`, in two different repositories, and why the ~9 to 25 second runtime looked like an authenticated call rather than a rejected invocation.

That is a provisioning fault, fixed by re-associating the token rather than by any code change. After the token was updated, the same image scanned clean through the same action: `critical=0 high=6 medium=26 low=0`, SARIF validated and uploaded. This PR does not fix the credential. It fixes the reason the credential took several runs and a branch pin to identify.

### What changes

1. **Print the scanner's own error.** On a non-0/1 exit the snyk adapter dumps the captured stdout, truncated to 4000 bytes, so a failure states its cause where it happened.
2. **Stop quoting a constant.** The Slack summary no longer names an exit code. The scanner's real code is already in the adapter's stderr line in the log.

### Resulting behavior

| Outcome | Job | Log | Slack |
|---|---|---|---|
| Findings at or above threshold | green unless `block-on-findings` | counts and report | counts, plus the Security tab link when a SARIF exists |
| Scanner error, transient | green | scanner exit code **and now its message** | `scanner error, see job log` |
| Scanner error, permanent (org, auth) | green | scanner exit code **and now its message** | `scanner error, see job log` |
| Config error | fails | the authoring or provisioning mistake | `CONFIGURATION ERROR` |

### Tradeoffs and safeguards

- Classification is untouched. A scanner error is still inconclusive, still leaves the job green, and still never becomes a finding, so a flaky scanner cannot block a release.
- The dump is bounded at 4000 bytes, so a large or malformed payload cannot flood the log.
- No credential reaches the output. The token is masked before the scan and does not appear in snyk's error body; the dumped payload carries the image ref and the error text.
- **Known gap, deliberately not fixed here.** Row three of that table is the problem this incident revealed: a permanent org or auth fault is classified as an inconclusive scan, so it reports green on every release forever. The action's README names that exact outcome as what the config-error class exists to prevent. Fixing it means treating known-permanent snyk errors as adapter exit 2 while leaving genuine transients inconclusive, and snyk returns exit 2 for both, so it has to match on the error text. That is a classification change and belongs in its own PR rather than one already reviewed as a diagnostics change.

### Verification

- `1..111` bats tests in CI, zero failures, including two new cases: snyk's stdout reaching the log on exit 2, and the summary carrying no exit code.
- shellcheck, actionlint, zizmor and `make check-docs` clean.
- Live, through the `github-actions-test` caller: [the failure with no cause](https://github.com/vClusterLabs-Experiments/github-actions-test/actions/runs/32383872284), [the same failure on a public image](https://github.com/vClusterLabs-Experiments/github-actions-test/actions/runs/32384336896), [the run that printed the reason](https://github.com/vClusterLabs-Experiments/github-actions-test/actions/runs/32384622852), and [a clean scan after the token fix](https://github.com/vClusterLabs-Experiments/github-actions-test/actions/runs/32401328152).

Worth knowing when reading the test count: on macOS bash 3.2 a failing intermediate `[[ ]]` does not fail a bats test, so both new assertions are only genuinely enforced by CI on bash 5. Each was also checked against its real value directly.
