### PR TITLE
fix(backport): link legacy prs to linear sub-issues

### DIFF
--- a/.github/actions/backport-legacy-split/README.md
+++ b/.github/actions/backport-legacy-split/README.md
@@ -147,11 +147,10 @@ below.
 
 - Backport branches use the `backport/` prefix so `auto-approve-bot-prs` and
   `cleanup-backport-branches` keep working.
-- **Linear linking:** these PRs are **not** auto-linked to Linear sub-issues.
-  `link-backport-prs` runs in the reusable workflow's `backport` job against the
-  caller repo keyed on the source PR, and only matches sorenlouv-created PRs; it
-  does not cover the cross-repo PRs this action opens. Cross-repo linking is a
-  separate follow-up (see DEVOPS-1051); link these PRs manually for now.
+- Linear linking runs after the full legacy matrix settles. `link-backport-prs`
+  searches both configured repos for this action's
+  `backport/<target>/<short-sha>` branches and adds the same `Fixes <sub-issue>`
+  reference to every matching pro and OSS PR.
 - Re-runs are idempotent and safe for the conflicted-PR flow: once a PR is open
   for the head->base pair, a re-run leaves the branch **and** PR untouched, so a
   human's manual conflict resolution on that branch is never clobbered. The

--- a/.github/actions/backport-legacy-split/run.sh
+++ b/.github/actions/backport-legacy-split/run.sh
@@ -140,11 +140,11 @@ emit backport-branch "$BACKPORT_BRANCH"
 #              it links correctly even on the OSS half, whose target repo differs
 #              from the monorepo. Empty (e.g. tests, no origin) -> bare "#N".
 #
-# Linear linking is deliberately NOT done here: link-backport-prs owns it (resolve
-# the source PR's parent issue -> match the per-release-line "[X.Y] Copy of ..."
-# sub-issue -> append "Fixes <sub-issue>"). A "resolves <PARENT-KEY>" here would
-# both duplicate that and close the WRONG issue (the parent, not the line's
-# sub-issue). See the README note on the legacy-linking gap.
+# Linear linking is deliberately NOT done here: the reusable workflow runs
+# link-backport-prs after this matrix settles, resolves the source PR's parent
+# issue, matches the per-release-line "[X.Y] Copy of ..." sub-issue, and appends
+# "Fixes <sub-issue>" to every matching pro and OSS PR. A
+# "resolves <PARENT-KEY>" here would close the wrong issue.
 SUBJECT="$(git log -1 --format=%s "$SHA")"
 SOURCE_REPO="$( { git config --get remote.origin.url 2>/dev/null || true; } \
   | sed -E 's#^git@[^:]+:##; s#^https?://[^/]+/##; s#\.git$##' )"

--- a/.github/actions/link-backport-prs/README.md
+++ b/.github/actions/link-backport-prs/README.md
@@ -9,14 +9,14 @@ When a merged source PR carries `backport-to-<branch>` labels, the shared workfl
 1. Resolves the source PR's Linear issue (the parent) via Linear's `attachmentsForURL` reverse lookup, falling back to a `TEAM-123` identifier parsed from the branch name or body.
 2. Finds the sub-issue whose title carries the release-line prefix for that target, e.g. `[0.34] Copy of ENGCP-906` for a backport to `v0.34` (a leading `v`, as in `[v0.34]`, is also accepted).
 3. Verifies the release attached to the matched sub-issue agrees with the backport target line, warning on a missing or mismatched release (see below). Linking proceeds either way.
-4. Finds the modern `backport/<target>/pr-<source>` PR in the source repo and any legacy `backport/<target>/<short-sha>` PRs in the configured pro and OSS repos.
+4. Finds the modern `backport/<target>/pr-<source>` PR in the source repo and any legacy `backport/<target>/<short-sha>` PRs in the configured pro and OSS repos. A match must come from the repository being searched, so a fork cannot copy the branch name and body to receive a privileged edit.
 5. Appends `Fixes <sub-issue-id>` to every matching PR body, unless it already references the issue.
 
 The match is by title prefix, not milestone: the `[X.Y] Copy of ...` sub-issues created for a backport family do not reliably carry a patch milestone, so the title is the dependable key.
 
 The release check exists because a title match alone cannot catch a sub-issue attached to the wrong release. After a title match, the action reads the Releases attached to the sub-issue via Linear and derives each release's `X.Y` line from its version field, falling back to the leading version in the release name (`0.33.5 - Security Only` parses to `0.33`). No release attached, or no attached release on the target's line, produces a remedy warning. A matching release stays silent. If the releases query itself fails, verification degrades to a single warning and linking continues.
 
-It is advisory and idempotent: it never fails the backport job (every problem is a warning and it exits 0) and re-runs do not add duplicate `Fixes` lines.
+It is advisory and idempotent: it never fails the backport job (every problem is a warning and it exits 0) and re-runs do not add duplicate `Fixes` lines. A lookup failure in one repository is reported without discarding matches found in another repository.
 
 Every skip that a human can fix is loud. When a source PR carries backport labels but linking hits a dead end, the action emits a GitHub `::warning::` annotation and a job-summary line naming the remedy. This covers an empty `linear-token` (fix the repository secret), an unresolved parent Linear issue (attach the PR to its issue), a release line with no matching `[X.Y]` sub-issue (create or rename the sub-issue), a matched sub-issue with no release attached (attach the line's In Progress release), a matched sub-issue whose release is on a different line (fix the release attachment or the sub-issue title), and a target whose producer opened no PR (backport it manually after the conflict). A source PR with no backport labels stays a plain notice, since there is nothing to fix. The step always publishes a `linked-count` output, 0 when it skips.
 
@@ -87,4 +87,4 @@ Run the unit tests:
 make test-link-backport-prs
 ```
 
-The tests cover modern and legacy PR discovery, mixed pro and OSS results, repository parsing, workflow ordering, release-line extraction, title-prefix matching, sub-issue selection, idempotency of the `Fixes` line, release verification, remedy-warning rendering, and the `linked-count` / job-summary writers.
+The tests cover modern and legacy PR discovery, trusted head-repository checks, partial repository lookup failures, mixed pro and OSS edits, repository parsing, workflow ordering, release-line extraction, title-prefix matching, sub-issue selection, idempotency of the `Fixes` line, release verification, remedy-warning rendering, and the `linked-count` / job-summary writers.

--- a/.github/actions/link-backport-prs/README.md
+++ b/.github/actions/link-backport-prs/README.md
@@ -1,15 +1,16 @@
 # Link Backport PRs to Linear
 
-A GitHub Action that links sorenlouv-created backport pull requests to the matching Linear sub-issue, so each backport closes the right per-release-line issue when it merges.
+A GitHub Action that links modern and legacy backport pull requests to the matching Linear sub-issue, so each backport closes the right per-release-line issue when it merges.
 
 ## What it does
 
-When a merged source PR carries `backport-to-<branch>` labels, the [sorenlouv backport action](https://github.com/sorenlouv/backport-github-action) opens one backport PR per label. This action runs right after and, for each backport target:
+When a merged source PR carries `backport-to-<branch>` labels, the shared workflow creates modern backports with [sorenlouv](https://github.com/sorenlouv/backport-github-action) and optional pre-monorepo backports with `backport-legacy-split`. This action runs after both producers settle and, for each backport target:
 
 1. Resolves the source PR's Linear issue (the parent) via Linear's `attachmentsForURL` reverse lookup, falling back to a `TEAM-123` identifier parsed from the branch name or body.
 2. Finds the sub-issue whose title carries the release-line prefix for that target, e.g. `[0.34] Copy of ENGCP-906` for a backport to `v0.34` (a leading `v`, as in `[v0.34]`, is also accepted).
 3. Verifies the release attached to the matched sub-issue agrees with the backport target line, warning on a missing or mismatched release (see below). Linking proceeds either way.
-4. Appends `Fixes <sub-issue-id>` to that backport PR's body, unless it already references the issue.
+4. Finds the modern `backport/<target>/pr-<source>` PR in the source repo and any legacy `backport/<target>/<short-sha>` PRs in the configured pro and OSS repos.
+5. Appends `Fixes <sub-issue-id>` to every matching PR body, unless it already references the issue.
 
 The match is by title prefix, not milestone: the `[X.Y] Copy of ...` sub-issues created for a backport family do not reliably carry a patch milestone, so the title is the dependable key.
 
@@ -17,7 +18,7 @@ The release check exists because a title match alone cannot catch a sub-issue at
 
 It is advisory and idempotent: it never fails the backport job (every problem is a warning and it exits 0) and re-runs do not add duplicate `Fixes` lines.
 
-Every skip that a human can fix is loud. When a source PR carries backport labels but linking hits a dead end, the action emits a GitHub `::warning::` annotation and a job-summary line naming the remedy. This covers an empty `linear-token` (fix the repository secret), an unresolved parent Linear issue (attach the PR to its issue), a release line with no matching `[X.Y]` sub-issue (create or rename the sub-issue), a matched sub-issue with no release attached (attach the line's In Progress release), a matched sub-issue whose release is on a different line (fix the release attachment or the sub-issue title), and a backport PR that sorenlouv never opened (backport it manually after the conflict). A source PR with no backport labels stays a plain notice, since there is nothing to fix. The step always publishes a `linked-count` output, 0 when it skips.
+Every skip that a human can fix is loud. When a source PR carries backport labels but linking hits a dead end, the action emits a GitHub `::warning::` annotation and a job-summary line naming the remedy. This covers an empty `linear-token` (fix the repository secret), an unresolved parent Linear issue (attach the PR to its issue), a release line with no matching `[X.Y]` sub-issue (create or rename the sub-issue), a matched sub-issue with no release attached (attach the line's In Progress release), a matched sub-issue whose release is on a different line (fix the release attachment or the sub-issue title), and a target whose producer opened no PR (backport it manually after the conflict). A source PR with no backport labels stays a plain notice, since there is nothing to fix. The step always publishes a `linked-count` output, 0 when it skips.
 
 ## Usage
 
@@ -40,6 +41,7 @@ To run it directly:
     source-pr: ${{ github.event.pull_request.number }}
     repo-owner: ${{ github.repository_owner }}
     repo-name: ${{ github.event.repository.name }}
+    additional-repos: loft-sh/vcluster,loft-sh/vcluster-pro
     github-token: ${{ secrets.GH_ACCESS_TOKEN }}
     linear-token: ${{ secrets.LINEAR_API_TOKEN }}
 ```
@@ -50,15 +52,16 @@ The `github-token` must be the same PAT that created the backport PRs (a PAT, no
 
 <!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
 
-|    INPUT     |  TYPE  | REQUIRED |     DEFAULT      |                                                                                                                                                                                     DESCRIPTION                                                                                                                                                                                     |
-|--------------|--------|----------|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-|   dry-run    | string |  false   |    `"false"`     |                                                                                                                                                                      Log intended edits without applying them                                                                                                                                                                       |
-| github-token | string |   true   |                  |                                                                                                                                GitHub token with permission to read <br>and edit pull requests (must be the same PAT that created the backport PRs)                                                                                                                                 |
-| label-prefix | string |  false   | `"backport-to-"` |                                                                                                                                                                 Prefix of the backport labels on <br>the source PR                                                                                                                                                                  |
-| linear-token | string |  false   |                  | Linear API token for resolving the <br>issue family and verifying release attachments. <br>Optional: the step always exits 0, <br>so callers can adopt the backport <br>workflow before a token is wired <br>up. When it is empty but <br>the source PR carries backport labels, <br>the step emits a warning naming <br>the missing secret instead of silently <br>doing nothing.  |
-|  repo-name   | string |   true   |                  |                                                                                                                                                                             The name of the repository                                                                                                                                                                              |
-|  repo-owner  | string |   true   |                  |                                                                                                                                                                             The owner of the repository                                                                                                                                                                             |
-|  source-pr   | string |   true   |                  |                                                                                                                                                           The merged source pull request number <br>that was backported                                                                                                                                                             |
+|      INPUT       |  TYPE  | REQUIRED |     DEFAULT      |                                                                                                                                                                                     DESCRIPTION                                                                                                                                                                                     |
+|------------------|--------|----------|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| additional-repos | string |  false   |                  |                                                                                                       Comma-separated owner/repo list to search for <br>cross-repo legacy backport PRs. The source <br>repository is always searched and duplicate <br>entries are ignored.                                                                                                         |
+|     dry-run      | string |  false   |    `"false"`     |                                                                                                                                                                      Log intended edits without applying them                                                                                                                                                                       |
+|   github-token   | string |   true   |                  |                                                                                                                                GitHub token with permission to read <br>and edit pull requests (must be the same PAT that created the backport PRs)                                                                                                                                 |
+|   label-prefix   | string |  false   | `"backport-to-"` |                                                                                                                                                                 Prefix of the backport labels on <br>the source PR                                                                                                                                                                  |
+|   linear-token   | string |  false   |                  | Linear API token for resolving the <br>issue family and verifying release attachments. <br>Optional: the step always exits 0, <br>so callers can adopt the backport <br>workflow before a token is wired <br>up. When it is empty but <br>the source PR carries backport labels, <br>the step emits a warning naming <br>the missing secret instead of silently <br>doing nothing.  |
+|    repo-name     | string |   true   |                  |                                                                                                                                                                             The name of the repository                                                                                                                                                                              |
+|    repo-owner    | string |   true   |                  |                                                                                                                                                                             The owner of the repository                                                                                                                                                                             |
+|    source-pr     | string |   true   |                  |                                                                                                                                                           The merged source pull request number <br>that was backported                                                                                                                                                             |
 
 <!-- AUTO-DOC-INPUT:END -->
 
@@ -84,4 +87,4 @@ Run the unit tests:
 make test-link-backport-prs
 ```
 
-The tests cover the pure matching logic (release-line extraction from a target branch, title-prefix matching for `[0.34]` and `[v0.34]`, sub-issue selection within an issue family, idempotency of the `Fixes` line, and identifier extraction fallback), the release verification (line derivation from the version field with name fallback, and the missing / mismatched / matching outcomes), plus the remedy-warning rendering and the `linked-count` / job-summary writers.
+The tests cover modern and legacy PR discovery, mixed pro and OSS results, repository parsing, workflow ordering, release-line extraction, title-prefix matching, sub-issue selection, idempotency of the `Fixes` line, release verification, remedy-warning rendering, and the `linked-count` / job-summary writers.

--- a/.github/actions/link-backport-prs/action.yml
+++ b/.github/actions/link-backport-prs/action.yml
@@ -1,5 +1,5 @@
 name: 'Link Backport PRs to Linear'
-description: 'Links sorenlouv-created backport PRs to the matching Linear sub-issue by adding "Fixes <id>" to the backport PR body, and verifies the sub-issue carries a release on the backport target line'
+description: 'Links modern and legacy backport PRs to the matching Linear sub-issue by adding "Fixes <id>" to each PR body, and verifies the sub-issue carries a release on the backport target line'
 
 inputs:
   source-pr:
@@ -22,6 +22,10 @@ inputs:
     description: 'Prefix of the backport labels on the source PR'
     required: false
     default: 'backport-to-'
+  additional-repos:
+    description: 'Comma-separated owner/repo list to search for cross-repo legacy backport PRs. The source repository is always searched and duplicate entries are ignored.'
+    required: false
+    default: ''
   dry-run:
     description: 'Log intended edits without applying them'
     required: false
@@ -51,6 +55,7 @@ runs:
         INPUT_REPO_OWNER: ${{ inputs.repo-owner }}
         INPUT_REPO_NAME: ${{ inputs.repo-name }}
         INPUT_LABEL_PREFIX: ${{ inputs.label-prefix }}
+        INPUT_ADDITIONAL_REPOS: ${{ inputs.additional-repos }}
         INPUT_DRY_RUN: ${{ inputs.dry-run }}
       run: |
         cd "$ACTION_PATH/src"
@@ -60,6 +65,7 @@ runs:
           -repo-owner="$INPUT_REPO_OWNER" \
           -repo-name="$INPUT_REPO_NAME" \
           -label-prefix="$INPUT_LABEL_PREFIX" \
+          -additional-repos="$INPUT_ADDITIONAL_REPOS" \
           -dry-run="$INPUT_DRY_RUN"
 
 branding:

--- a/.github/actions/link-backport-prs/src/main.go
+++ b/.github/actions/link-backport-prs/src/main.go
@@ -168,7 +168,6 @@ func run() error {
 		bps, err := findBackportPRs(ctx, gh, repos, target, *sourcePR, src.GetMergeCommitSHA(), *repoOwner+"/"+*repoName)
 		if err != nil {
 			warnf("looking up backport PRs for %s: %v", target, err)
-			continue
 		}
 		if len(bps) == 0 {
 			remedyWarning{
@@ -178,26 +177,10 @@ func run() error {
 			continue
 		}
 
-		for _, bp := range bps {
-			if bodyReferencesIssue(bp.PullRequest.GetBody(), sub.Identifier) {
-				noticef("backport PR %s#%d already references %s, skipping", bp.Repository, bp.PullRequest.GetNumber(), sub.Identifier)
-				continue
-			}
-
-			newBody := appendFixes(bp.PullRequest.GetBody(), sub.Identifier)
-			if *dryRun {
-				noticef("[dry-run] would add 'Fixes %s' to backport PR %s#%d (%s)", sub.Identifier, bp.Repository, bp.PullRequest.GetNumber(), target)
-				linked++
-				continue
-			}
-
-			if _, _, err := gh.PullRequests.Edit(ctx, bp.Repository.Owner, bp.Repository.Name, bp.PullRequest.GetNumber(), &github.PullRequest{Body: &newBody}); err != nil {
-				warnf("updating backport PR %s#%d body: %v", bp.Repository, bp.PullRequest.GetNumber(), err)
-				continue
-			}
-			noticef("linked backport PR %s#%d (%s) to %s via 'Fixes %s'", bp.Repository, bp.PullRequest.GetNumber(), target, sub.Identifier, sub.Identifier)
-			linked++
-		}
+		linked += linkPullRequests(bps, sub.Identifier, *dryRun, func(repo repository, number int, body string) error {
+			_, _, err := gh.PullRequests.Edit(ctx, repo.Owner, repo.Name, number, &github.PullRequest{Body: &body})
+			return err
+		})
 	}
 
 	noticef("link-backport-prs: linked %d PR(s) across %d backport target(s)", linked, len(targets))
@@ -362,6 +345,35 @@ func appendFixes(body, identifier string) string {
 	return trimmed + "\n\nFixes " + identifier
 }
 
+// linkPullRequests appends the closing reference to every matching PR. An
+// already-linked or failed PR does not stop the remaining repositories from
+// being processed.
+func linkPullRequests(bps []locatedPullRequest, identifier string, dryRun bool, edit func(repository, int, string) error) int {
+	linked := 0
+	for _, bp := range bps {
+		if bodyReferencesIssue(bp.PullRequest.GetBody(), identifier) {
+			noticef("backport PR %s#%d already references %s, skipping", bp.Repository, bp.PullRequest.GetNumber(), identifier)
+			continue
+		}
+
+		newBody := appendFixes(bp.PullRequest.GetBody(), identifier)
+		target := bp.PullRequest.GetBase().GetRef()
+		if dryRun {
+			noticef("[dry-run] would add 'Fixes %s' to backport PR %s#%d (%s)", identifier, bp.Repository, bp.PullRequest.GetNumber(), target)
+			linked++
+			continue
+		}
+
+		if err := edit(bp.Repository, bp.PullRequest.GetNumber(), newBody); err != nil {
+			warnf("updating backport PR %s#%d body: %v", bp.Repository, bp.PullRequest.GetNumber(), err)
+			continue
+		}
+		noticef("linked backport PR %s#%d (%s) to %s via 'Fixes %s'", bp.Repository, bp.PullRequest.GetNumber(), target, identifier, identifier)
+		linked++
+	}
+	return linked
+}
+
 type repository struct {
 	Owner string
 	Name  string
@@ -408,6 +420,7 @@ func repositoryNames(repos []repository) string {
 // repo, so callers pass every configured repository and all matches are kept.
 func findBackportPRs(ctx context.Context, gh *github.Client, repos []repository, target string, sourcePR int, mergeSHA, sourceRepo string) ([]locatedPullRequest, error) {
 	var found []locatedPullRequest
+	var lookupErrors []string
 	for _, repo := range repos {
 		opts := &github.PullRequestListOptions{
 			State:       "all",
@@ -417,9 +430,10 @@ func findBackportPRs(ctx context.Context, gh *github.Client, repos []repository,
 		for {
 			prs, resp, err := gh.PullRequests.List(ctx, repo.Owner, repo.Name, opts)
 			if err != nil {
-				return nil, fmt.Errorf("list %s pull requests: %w", repo, err)
+				lookupErrors = append(lookupErrors, fmt.Sprintf("list %s pull requests: %v", repo, err))
+				break
 			}
-			for _, pr := range matchingBackportPRs(prs, target, sourcePR, mergeSHA, sourceRepo, repo.String() == sourceRepo) {
+			for _, pr := range matchingBackportPRs(prs, target, sourcePR, mergeSHA, sourceRepo, repo.String(), repo.String() == sourceRepo) {
 				found = append(found, locatedPullRequest{Repository: repo, PullRequest: pr})
 			}
 			if resp == nil || resp.NextPage == 0 {
@@ -428,19 +442,26 @@ func findBackportPRs(ctx context.Context, gh *github.Client, repos []repository,
 			opts.Page = resp.NextPage
 		}
 	}
+	if len(lookupErrors) > 0 {
+		return found, fmt.Errorf("one or more repository lookups failed: %s", strings.Join(lookupErrors, "; "))
+	}
 	return found, nil
 }
 
 // matchingBackportPRs accepts sorenlouv's deterministic branch or the legacy
 // split branch. The legacy match checks both the merge SHA prefix and the
-// fully-qualified source PR reference from the producer's body so another PR
-// on the same release branch cannot be linked by accident.
-func matchingBackportPRs(prs []*github.PullRequest, target string, sourcePR int, mergeSHA, sourceRepo string, allowModern bool) []*github.PullRequest {
+// fully-qualified source PR reference from the producer's body. It also
+// requires the PR head repository to match the repository being searched, so a
+// fork cannot copy those public values and receive a privileged edit.
+func matchingBackportPRs(prs []*github.PullRequest, target string, sourcePR int, mergeSHA, sourceRepo, expectedRepo string, allowModern bool) []*github.PullRequest {
 	modernHead := backportHeadBranch(target, sourcePR)
 	legacyPrefix := "backport/" + target + "/"
 	sourceRef := regexp.MustCompile(regexp.QuoteMeta(fmt.Sprintf("%s#%d", sourceRepo, sourcePR)) + `\b`)
 	var matches []*github.PullRequest
 	for _, pr := range prs {
+		if pr.GetHead().GetRepo().GetFullName() != expectedRepo {
+			continue
+		}
 		if pr.GetBase().GetRef() != target {
 			continue
 		}

--- a/.github/actions/link-backport-prs/src/main.go
+++ b/.github/actions/link-backport-prs/src/main.go
@@ -1,4 +1,4 @@
-// Command link-backport-prs links sorenlouv-created backport pull requests to
+// Command link-backport-prs links modern and legacy backport pull requests to
 // the matching Linear sub-issue.
 //
 // On the shared backport workflow, after sorenlouv opens the backport PRs for a
@@ -80,11 +80,16 @@ func run() error {
 	repoOwner := flag.String("repo-owner", "", "repository owner")
 	repoName := flag.String("repo-name", "", "repository name")
 	labelPrefix := flag.String("label-prefix", "backport-to-", "prefix of backport labels")
+	additionalRepos := flag.String("additional-repos", "", "comma-separated owner/repo list for cross-repo legacy backports")
 	dryRun := flag.Bool("dry-run", false, "log intended edits without applying them")
 	flag.Parse()
 
 	if *sourcePR == 0 || *repoOwner == "" || *repoName == "" {
 		return fmt.Errorf("source-pr, repo-owner and repo-name are required")
+	}
+	repos, err := parseRepositories(*additionalRepos, repository{Owner: *repoOwner, Name: *repoName})
+	if err != nil {
+		return err
 	}
 
 	githubToken := os.Getenv("GITHUB_TOKEN")
@@ -160,41 +165,42 @@ func run() error {
 		// Fixes-line linking below proceeds unchanged.
 		verifyRelease(linearToken, sub, version, target)
 
-		headBranch := backportHeadBranch(target, *sourcePR)
-		bp, err := findBackportPR(ctx, gh, *repoOwner, *repoName, headBranch, target)
+		bps, err := findBackportPRs(ctx, gh, repos, target, *sourcePR, src.GetMergeCommitSHA(), *repoOwner+"/"+*repoName)
 		if err != nil {
-			warnf("looking up backport PR %s: %v", headBranch, err)
+			warnf("looking up backport PRs for %s: %v", target, err)
 			continue
 		}
-		if bp == nil {
+		if len(bps) == 0 {
 			remedyWarning{
-				problem: fmt.Sprintf("no backport PR found for %s (base %s); sorenlouv likely skipped it after a merge conflict or empty diff", headBranch, target),
+				problem: fmt.Sprintf("no backport PR found for target %s in %s; the producer likely hit a merge conflict, empty diff, or failed before opening the PR", target, repositoryNames(repos)),
 				remedy:  fmt.Sprintf("backport to %s manually and add 'Fixes %s' to that PR's body", target, sub.Identifier),
 			}.emit()
 			continue
 		}
 
-		if bodyReferencesIssue(bp.GetBody(), sub.Identifier) {
-			noticef("backport PR #%d already references %s, skipping", bp.GetNumber(), sub.Identifier)
-			continue
-		}
+		for _, bp := range bps {
+			if bodyReferencesIssue(bp.PullRequest.GetBody(), sub.Identifier) {
+				noticef("backport PR %s#%d already references %s, skipping", bp.Repository, bp.PullRequest.GetNumber(), sub.Identifier)
+				continue
+			}
 
-		newBody := appendFixes(bp.GetBody(), sub.Identifier)
-		if *dryRun {
-			noticef("[dry-run] would add 'Fixes %s' to backport PR #%d (%s)", sub.Identifier, bp.GetNumber(), target)
+			newBody := appendFixes(bp.PullRequest.GetBody(), sub.Identifier)
+			if *dryRun {
+				noticef("[dry-run] would add 'Fixes %s' to backport PR %s#%d (%s)", sub.Identifier, bp.Repository, bp.PullRequest.GetNumber(), target)
+				linked++
+				continue
+			}
+
+			if _, _, err := gh.PullRequests.Edit(ctx, bp.Repository.Owner, bp.Repository.Name, bp.PullRequest.GetNumber(), &github.PullRequest{Body: &newBody}); err != nil {
+				warnf("updating backport PR %s#%d body: %v", bp.Repository, bp.PullRequest.GetNumber(), err)
+				continue
+			}
+			noticef("linked backport PR %s#%d (%s) to %s via 'Fixes %s'", bp.Repository, bp.PullRequest.GetNumber(), target, sub.Identifier, sub.Identifier)
 			linked++
-			continue
 		}
-
-		if _, _, err := gh.PullRequests.Edit(ctx, *repoOwner, *repoName, bp.GetNumber(), &github.PullRequest{Body: &newBody}); err != nil {
-			warnf("updating backport PR #%d body: %v", bp.GetNumber(), err)
-			continue
-		}
-		noticef("linked backport PR #%d (%s) to %s via 'Fixes %s'", bp.GetNumber(), target, sub.Identifier, sub.Identifier)
-		linked++
 	}
 
-	noticef("link-backport-prs: linked %d of %d backport target(s)", linked, len(targets))
+	noticef("link-backport-prs: linked %d PR(s) across %d backport target(s)", linked, len(targets))
 	writeLinkedCount(linked)
 	return nil
 }
@@ -356,25 +362,102 @@ func appendFixes(body, identifier string) string {
 	return trimmed + "\n\nFixes " + identifier
 }
 
-// findBackportPR returns the backport PR with the expected head branch, or nil
-// if none exists yet.
-func findBackportPR(ctx context.Context, gh *github.Client, owner, repo, headBranch, baseBranch string) (*github.PullRequest, error) {
-	opts := &github.PullRequestListOptions{
-		State:       "all",
-		Head:        owner + ":" + headBranch,
-		Base:        baseBranch,
-		ListOptions: github.ListOptions{PerPage: 20},
-	}
-	prs, _, err := gh.PullRequests.List(ctx, owner, repo, opts)
-	if err != nil {
-		return nil, err
-	}
-	for _, pr := range prs {
-		if pr.GetHead().GetRef() == headBranch {
-			return pr, nil
+type repository struct {
+	Owner string
+	Name  string
+}
+
+func (r repository) String() string { return r.Owner + "/" + r.Name }
+
+type locatedPullRequest struct {
+	Repository  repository
+	PullRequest *github.PullRequest
+}
+
+func parseRepositories(additional string, primary repository) ([]repository, error) {
+	repos := []repository{primary}
+	seen := map[string]bool{primary.String(): true}
+	for _, raw := range strings.Split(additional, ",") {
+		raw = strings.TrimSpace(raw)
+		if raw == "" {
+			continue
+		}
+		owner, name, ok := strings.Cut(raw, "/")
+		if !ok || owner == "" || name == "" || strings.Contains(name, "/") {
+			return nil, fmt.Errorf("additional-repos entry %q must be owner/repo", raw)
+		}
+		r := repository{Owner: owner, Name: name}
+		if !seen[r.String()] {
+			repos = append(repos, r)
+			seen[r.String()] = true
 		}
 	}
-	return nil, nil
+	return repos, nil
+}
+
+func repositoryNames(repos []repository) string {
+	names := make([]string, 0, len(repos))
+	for _, repo := range repos {
+		names = append(names, repo.String())
+	}
+	return strings.Join(names, ", ")
+}
+
+// findBackportPRs returns every modern or legacy PR produced for a target.
+// Legacy split backports may produce one PR in the pro repo and one in the OSS
+// repo, so callers pass every configured repository and all matches are kept.
+func findBackportPRs(ctx context.Context, gh *github.Client, repos []repository, target string, sourcePR int, mergeSHA, sourceRepo string) ([]locatedPullRequest, error) {
+	var found []locatedPullRequest
+	for _, repo := range repos {
+		opts := &github.PullRequestListOptions{
+			State:       "all",
+			Base:        target,
+			ListOptions: github.ListOptions{PerPage: 100},
+		}
+		for {
+			prs, resp, err := gh.PullRequests.List(ctx, repo.Owner, repo.Name, opts)
+			if err != nil {
+				return nil, fmt.Errorf("list %s pull requests: %w", repo, err)
+			}
+			for _, pr := range matchingBackportPRs(prs, target, sourcePR, mergeSHA, sourceRepo, repo.String() == sourceRepo) {
+				found = append(found, locatedPullRequest{Repository: repo, PullRequest: pr})
+			}
+			if resp == nil || resp.NextPage == 0 {
+				break
+			}
+			opts.Page = resp.NextPage
+		}
+	}
+	return found, nil
+}
+
+// matchingBackportPRs accepts sorenlouv's deterministic branch or the legacy
+// split branch. The legacy match checks both the merge SHA prefix and the
+// fully-qualified source PR reference from the producer's body so another PR
+// on the same release branch cannot be linked by accident.
+func matchingBackportPRs(prs []*github.PullRequest, target string, sourcePR int, mergeSHA, sourceRepo string, allowModern bool) []*github.PullRequest {
+	modernHead := backportHeadBranch(target, sourcePR)
+	legacyPrefix := "backport/" + target + "/"
+	sourceRef := regexp.MustCompile(regexp.QuoteMeta(fmt.Sprintf("%s#%d", sourceRepo, sourcePR)) + `\b`)
+	var matches []*github.PullRequest
+	for _, pr := range prs {
+		if pr.GetBase().GetRef() != target {
+			continue
+		}
+		head := pr.GetHead().GetRef()
+		if allowModern && head == modernHead {
+			matches = append(matches, pr)
+			continue
+		}
+		shortSHA := strings.TrimPrefix(head, legacyPrefix)
+		if shortSHA == head || shortSHA == "" || mergeSHA == "" || !strings.HasPrefix(mergeSHA, shortSHA) {
+			continue
+		}
+		if sourceRef.MatchString(pr.GetBody()) {
+			matches = append(matches, pr)
+		}
+	}
+	return matches
 }
 
 var identifierRe = regexp.MustCompile(`(?i)\b([A-Z][A-Z0-9]+)-(\d+)\b`)

--- a/.github/actions/link-backport-prs/src/main_test.go
+++ b/.github/actions/link-backport-prs/src/main_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/google/go-github/v88/github"
 )
 
 func TestVersionFromBranch(t *testing.T) {
@@ -31,6 +33,98 @@ func TestBackportHeadBranch(t *testing.T) {
 	}
 	if got := backportHeadBranch("release-4.2", 12); got != "backport/release-4.2/pr-12" {
 		t.Errorf("got %q", got)
+	}
+}
+
+func TestMatchingBackportPRs(t *testing.T) {
+	modern := testPullRequest(41, "backport/v0.35/pr-2285", "v0.35", "")
+	legacyPro := testPullRequest(42, "backport/v0.35/4e5f9884e", "v0.35", "Backport of loft-sh/vcluster-pro#2285 to `v0.35` (pro half).")
+	legacyOSS := testPullRequest(43, "backport/v0.35/4e5f9884e", "v0.35", "Backport of loft-sh/vcluster-pro#2285 to `v0.35` (oss half).")
+	wrongSource := testPullRequest(44, "backport/v0.35/4e5f9884e", "v0.35", "Backport of loft-sh/vcluster-pro#9999 to `v0.35`.")
+	wrongCommit := testPullRequest(45, "backport/v0.35/deadbeef", "v0.35", "Backport of loft-sh/vcluster-pro#2285 to `v0.35`.")
+	wrongBase := testPullRequest(46, "backport/v0.35/4e5f9884e", "v0.36", "Backport of loft-sh/vcluster-pro#2285 to `v0.36`.")
+	prefixSource := testPullRequest(47, "backport/v0.35/4e5f9884e", "v0.35", "Backport of loft-sh/vcluster-pro#22850 to `v0.35`.")
+
+	cases := []struct {
+		name        string
+		prs         []*github.PullRequest
+		allowModern bool
+		want        []int
+	}{
+		{name: "modern branch in source repo", prs: []*github.PullRequest{modern}, allowModern: true, want: []int{41}},
+		{name: "legacy pro and oss", prs: []*github.PullRequest{legacyPro, legacyOSS}, allowModern: true, want: []int{42, 43}},
+		{name: "modern branch rejected in additional repo", prs: []*github.PullRequest{modern}, allowModern: false, want: nil},
+		{name: "reject unrelated legacy PRs", prs: []*github.PullRequest{wrongSource, wrongCommit, wrongBase, prefixSource}, allowModern: true, want: nil},
+	}
+
+	for _, c := range cases {
+		got := matchingBackportPRs(c.prs, "v0.35", 2285, "4e5f9884e43439736405e2d7ab6de0b8d03e6460", "loft-sh/vcluster-pro", c.allowModern)
+		if len(got) != len(c.want) {
+			t.Fatalf("%s: got %d PRs, want %d", c.name, len(got), len(c.want))
+		}
+		for i, want := range c.want {
+			if got[i].GetNumber() != want {
+				t.Errorf("%s: PR %d = #%d, want #%d", c.name, i, got[i].GetNumber(), want)
+			}
+		}
+	}
+}
+
+func TestParseRepositories(t *testing.T) {
+	got, err := parseRepositories("loft-sh/vcluster, loft-sh/vcluster-pro,loft-sh/vcluster", repository{Owner: "loft-sh", Name: "vcluster-pro"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []repository{{Owner: "loft-sh", Name: "vcluster-pro"}, {Owner: "loft-sh", Name: "vcluster"}}
+	if len(got) != len(want) {
+		t.Fatalf("got %+v, want %+v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("repository %d = %+v, want %+v", i, got[i], want[i])
+		}
+	}
+
+	if _, err := parseRepositories("vcluster", repository{Owner: "loft-sh", Name: "vcluster-pro"}); err == nil {
+		t.Fatal("invalid owner/repo should fail")
+	}
+}
+
+func TestWorkflowRunsLinkerAfterAllProducers(t *testing.T) {
+	b, err := os.ReadFile("../../../workflows/backport.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	workflow := string(b)
+
+	backportStart := strings.Index(workflow, "\n  backport:\n")
+	legacyStart := strings.Index(workflow, "\n  legacy-classify:\n")
+	if backportStart < 0 || legacyStart < 0 || legacyStart <= backportStart {
+		t.Fatal("could not isolate backport job")
+	}
+	if strings.Contains(workflow[backportStart:legacyStart], "/link-backport-prs@") {
+		t.Fatal("backport job still runs the linker before the legacy matrix settles")
+	}
+
+	linkStart := strings.Index(workflow, "\n  link-backports:\n")
+	if linkStart < 0 {
+		t.Fatal("link-backports job is missing")
+	}
+	linkJob := workflow[linkStart:]
+	if !strings.Contains(linkJob, "needs: [backport, legacy-backport]") {
+		t.Fatal("link-backports must wait for modern and legacy producers")
+	}
+	if !strings.Contains(linkJob, "/link-backport-prs@") {
+		t.Fatal("link-backports job does not invoke link-backport-prs")
+	}
+}
+
+func testPullRequest(number int, head, base, body string) *github.PullRequest {
+	return &github.PullRequest{
+		Number: github.Ptr(number),
+		Body:   github.Ptr(body),
+		Head:   &github.PullRequestBranch{Ref: github.Ptr(head)},
+		Base:   &github.PullRequestBranch{Ref: github.Ptr(base)},
 	}
 }
 

--- a/.github/actions/link-backport-prs/src/main_test.go
+++ b/.github/actions/link-backport-prs/src/main_test.go
@@ -1,6 +1,10 @@
 package main
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -37,28 +41,34 @@ func TestBackportHeadBranch(t *testing.T) {
 }
 
 func TestMatchingBackportPRs(t *testing.T) {
-	modern := testPullRequest(41, "backport/v0.35/pr-2285", "v0.35", "")
-	legacyPro := testPullRequest(42, "backport/v0.35/4e5f9884e", "v0.35", "Backport of loft-sh/vcluster-pro#2285 to `v0.35` (pro half).")
-	legacyOSS := testPullRequest(43, "backport/v0.35/4e5f9884e", "v0.35", "Backport of loft-sh/vcluster-pro#2285 to `v0.35` (oss half).")
-	wrongSource := testPullRequest(44, "backport/v0.35/4e5f9884e", "v0.35", "Backport of loft-sh/vcluster-pro#9999 to `v0.35`.")
-	wrongCommit := testPullRequest(45, "backport/v0.35/deadbeef", "v0.35", "Backport of loft-sh/vcluster-pro#2285 to `v0.35`.")
-	wrongBase := testPullRequest(46, "backport/v0.35/4e5f9884e", "v0.36", "Backport of loft-sh/vcluster-pro#2285 to `v0.36`.")
-	prefixSource := testPullRequest(47, "backport/v0.35/4e5f9884e", "v0.35", "Backport of loft-sh/vcluster-pro#22850 to `v0.35`.")
+	modern := testPullRequest(41, "loft-sh/vcluster-pro", "backport/v0.35/pr-2285", "v0.35", "")
+	legacyPro := testPullRequest(42, "loft-sh/vcluster-pro", "backport/v0.35/4e5f9884e", "v0.35", "Backport of loft-sh/vcluster-pro#2285 to `v0.35` (pro half).")
+	legacyOSS := testPullRequest(43, "loft-sh/vcluster", "backport/v0.35/4e5f9884e", "v0.35", "Backport of loft-sh/vcluster-pro#2285 to `v0.35` (oss half).")
+	foreignHead := testPullRequest(44, "outside-contributor/vcluster", "backport/v0.35/4e5f9884e", "v0.35", "Backport of loft-sh/vcluster-pro#2285 to `v0.35` (copied body).")
+	foreignModern := testPullRequest(49, "outside-contributor/vcluster-pro", "backport/v0.35/pr-2285", "v0.35", "")
+	wrongSource := testPullRequest(45, "loft-sh/vcluster-pro", "backport/v0.35/4e5f9884e", "v0.35", "Backport of loft-sh/vcluster-pro#9999 to `v0.35`.")
+	wrongCommit := testPullRequest(46, "loft-sh/vcluster-pro", "backport/v0.35/deadbeef", "v0.35", "Backport of loft-sh/vcluster-pro#2285 to `v0.35`.")
+	wrongBase := testPullRequest(47, "loft-sh/vcluster-pro", "backport/v0.35/4e5f9884e", "v0.36", "Backport of loft-sh/vcluster-pro#2285 to `v0.36`.")
+	prefixSource := testPullRequest(48, "loft-sh/vcluster-pro", "backport/v0.35/4e5f9884e", "v0.35", "Backport of loft-sh/vcluster-pro#22850 to `v0.35`.")
 
 	cases := []struct {
-		name        string
-		prs         []*github.PullRequest
-		allowModern bool
-		want        []int
+		name         string
+		prs          []*github.PullRequest
+		expectedRepo string
+		allowModern  bool
+		want         []int
 	}{
-		{name: "modern branch in source repo", prs: []*github.PullRequest{modern}, allowModern: true, want: []int{41}},
-		{name: "legacy pro and oss", prs: []*github.PullRequest{legacyPro, legacyOSS}, allowModern: true, want: []int{42, 43}},
-		{name: "modern branch rejected in additional repo", prs: []*github.PullRequest{modern}, allowModern: false, want: nil},
-		{name: "reject unrelated legacy PRs", prs: []*github.PullRequest{wrongSource, wrongCommit, wrongBase, prefixSource}, allowModern: true, want: nil},
+		{name: "modern branch in source repo", prs: []*github.PullRequest{modern}, expectedRepo: "loft-sh/vcluster-pro", allowModern: true, want: []int{41}},
+		{name: "legacy pro", prs: []*github.PullRequest{legacyPro}, expectedRepo: "loft-sh/vcluster-pro", allowModern: true, want: []int{42}},
+		{name: "legacy oss", prs: []*github.PullRequest{legacyOSS}, expectedRepo: "loft-sh/vcluster", allowModern: false, want: []int{43}},
+		{name: "foreign head repo rejected", prs: []*github.PullRequest{foreignHead}, expectedRepo: "loft-sh/vcluster", allowModern: false, want: nil},
+		{name: "foreign modern head repo rejected", prs: []*github.PullRequest{foreignModern}, expectedRepo: "loft-sh/vcluster-pro", allowModern: true, want: nil},
+		{name: "modern branch rejected in additional repo", prs: []*github.PullRequest{modern}, expectedRepo: "loft-sh/vcluster-pro", allowModern: false, want: nil},
+		{name: "reject unrelated legacy PRs", prs: []*github.PullRequest{wrongSource, wrongCommit, wrongBase, prefixSource}, expectedRepo: "loft-sh/vcluster-pro", allowModern: true, want: nil},
 	}
 
 	for _, c := range cases {
-		got := matchingBackportPRs(c.prs, "v0.35", 2285, "4e5f9884e43439736405e2d7ab6de0b8d03e6460", "loft-sh/vcluster-pro", c.allowModern)
+		got := matchingBackportPRs(c.prs, "v0.35", 2285, "4e5f9884e43439736405e2d7ab6de0b8d03e6460", "loft-sh/vcluster-pro", c.expectedRepo, c.allowModern)
 		if len(got) != len(c.want) {
 			t.Fatalf("%s: got %d PRs, want %d", c.name, len(got), len(c.want))
 		}
@@ -67,6 +77,110 @@ func TestMatchingBackportPRs(t *testing.T) {
 				t.Errorf("%s: PR %d = #%d, want #%d", c.name, i, got[i].GetNumber(), want)
 			}
 		}
+	}
+}
+
+func TestFindBackportPRsKeepsMatchesWhenAnotherRepoFails(t *testing.T) {
+	tests := []struct {
+		name        string
+		failedRepo  string
+		successRepo string
+		number      int
+	}{
+		{name: "later repo fails", failedRepo: "loft-sh/vcluster", successRepo: "loft-sh/vcluster-pro", number: 42},
+		{name: "continues after first repo fails", failedRepo: "loft-sh/vcluster-pro", successRepo: "loft-sh/vcluster", number: 43},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mux := http.NewServeMux()
+			for _, repoName := range []string{"loft-sh/vcluster-pro", "loft-sh/vcluster"} {
+				repoName := repoName
+				mux.HandleFunc("/repos/"+repoName+"/pulls", func(w http.ResponseWriter, _ *http.Request) {
+					if repoName == tt.failedRepo {
+						http.Error(w, "temporary failure", http.StatusInternalServerError)
+						return
+					}
+					w.Header().Set("Content-Type", "application/json")
+					if err := json.NewEncoder(w).Encode([]*github.PullRequest{
+						testPullRequest(tt.number, tt.successRepo, "backport/v0.35/4e5f9884e", "v0.35", "Backport of loft-sh/vcluster-pro#2285 to `v0.35`."),
+					}); err != nil {
+						t.Fatal(err)
+					}
+				})
+			}
+			server := httptest.NewServer(mux)
+			defer server.Close()
+
+			baseURL := server.URL + "/"
+			client, err := github.NewClient(github.WithURLs(&baseURL, &baseURL))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			got, err := findBackportPRs(
+				context.Background(),
+				client,
+				[]repository{{Owner: "loft-sh", Name: "vcluster-pro"}, {Owner: "loft-sh", Name: "vcluster"}},
+				"v0.35",
+				2285,
+				"4e5f9884e43439736405e2d7ab6de0b8d03e6460",
+				"loft-sh/vcluster-pro",
+			)
+			if err == nil {
+				t.Fatal("expected the failed repository lookup to be reported")
+			}
+			if len(got) != 1 || got[0].Repository.String() != tt.successRepo || got[0].PullRequest.GetNumber() != tt.number {
+				t.Fatalf("partial matches = %+v, want %s#%d", got, tt.successRepo, tt.number)
+			}
+		})
+	}
+}
+
+func TestLinkPullRequestsAcrossRepositories(t *testing.T) {
+	pro := repository{Owner: "loft-sh", Name: "vcluster-pro"}
+	oss := repository{Owner: "loft-sh", Name: "vcluster"}
+
+	tests := []struct {
+		name      string
+		bps       []locatedPullRequest
+		wantEdits []string
+	}{
+		{
+			name: "links every matching PR",
+			bps: []locatedPullRequest{
+				{Repository: pro, PullRequest: testPullRequest(42, pro.String(), "backport/v0.35/4e5f9884e", "v0.35", "pro body")},
+				{Repository: oss, PullRequest: testPullRequest(43, oss.String(), "backport/v0.35/4e5f9884e", "v0.35", "oss body")},
+			},
+			wantEdits: []string{"loft-sh/vcluster-pro#42", "loft-sh/vcluster#43"},
+		},
+		{
+			name: "already linked PR does not skip the next repo",
+			bps: []locatedPullRequest{
+				{Repository: pro, PullRequest: testPullRequest(42, pro.String(), "backport/v0.35/4e5f9884e", "v0.35", "Fixes ENGCP-1335")},
+				{Repository: oss, PullRequest: testPullRequest(43, oss.String(), "backport/v0.35/4e5f9884e", "v0.35", "oss body")},
+			},
+			wantEdits: []string{"loft-sh/vcluster#43"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var edits []string
+			linked := linkPullRequests(tt.bps, "ENGCP-1335", false, func(repo repository, number int, body string) error {
+				edits = append(edits, repo.String()+"#"+github.Stringify(number))
+				if !strings.Contains(body, "Fixes ENGCP-1335") {
+					t.Errorf("edited body %q does not contain closing reference", body)
+				}
+				return nil
+			})
+			if linked != len(tt.wantEdits) {
+				t.Errorf("linked = %d, want %d", linked, len(tt.wantEdits))
+			}
+			if strings.Join(edits, ",") != strings.Join(tt.wantEdits, ",") {
+				t.Errorf("edits = %v, want %v", edits, tt.wantEdits)
+			}
+		})
 	}
 }
 
@@ -119,12 +233,15 @@ func TestWorkflowRunsLinkerAfterAllProducers(t *testing.T) {
 	}
 }
 
-func testPullRequest(number int, head, base, body string) *github.PullRequest {
+func testPullRequest(number int, headRepo, head, base, body string) *github.PullRequest {
 	return &github.PullRequest{
 		Number: github.Ptr(number),
 		Body:   github.Ptr(body),
-		Head:   &github.PullRequestBranch{Ref: github.Ptr(head)},
-		Base:   &github.PullRequestBranch{Ref: github.Ptr(base)},
+		Head: &github.PullRequestBranch{
+			Ref:  github.Ptr(head),
+			Repo: &github.Repository{FullName: github.Ptr(headRepo)},
+		},
+		Base: &github.PullRequestBranch{Ref: github.Ptr(base)},
 	}
 }
 

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -83,21 +83,6 @@ jobs:
           # collapses when x is the empty string.
           auto_backport_label_prefix: ${{ inputs.legacy-split == false && 'backport-to-' || '' }}
 
-      # Link each backport PR to the matching Linear sub-issue ([X.Y] Copy of ...)
-      # so it closes on merge. Advisory: never fails the job, and is skipped when
-      # no linear-token is configured by the caller. Runs even if some backports
-      # hit merge conflicts (sorenlouv ignores those by default).
-      - name: Link backport PRs to Linear sub-issues
-        if: ${{ !cancelled() }}
-        continue-on-error: true
-        uses: loft-sh/github-actions/.github/actions/link-backport-prs@link-backport-prs/v1 # zizmor: ignore[unpinned-uses] -- internal loft-sh/github-actions ref; reusable workflows check out the CALLER repo, so a local ./.github/actions path is not present here. @link-backport-prs/v1 is the floating coordination tag kept aligned with backport/v1 (see DEVOPS-923 pin-drift class).
-        with:
-          source-pr: ${{ github.event.pull_request.number }}
-          repo-owner: ${{ github.repository_owner }}
-          repo-name: ${{ github.event.repository.name }}
-          github-token: ${{ secrets.gh-access-token }}
-          linear-token: ${{ secrets.linear-token }}
-
       - name: Info log
         if: ${{ success() }}
         run: cat ~/.backport/backport.info.log
@@ -217,3 +202,31 @@ jobs:
           pr-number: ${{ github.event.pull_request.number }}
           github-token: ${{ secrets.gh-access-token }}
           expected-author: ${{ steps.pat.outputs.login }}
+
+  # Both producers run independently. Wait for the sorenlouv job and the full
+  # legacy matrix so legacy PR discovery cannot race PR creation. always() lets
+  # successful targets link even when another target conflicts or is skipped.
+  link-backports:
+    name: Link backport PRs to Linear sub-issues
+    needs: [backport, legacy-backport]
+    if: |
+      always() &&
+      !cancelled() &&
+      github.event.pull_request.merged == true &&
+      contains(join(github.event.pull_request.labels.*.name, ','), 'backport-to-') &&
+      (github.event.action == 'closed' || startsWith(github.event.label.name, 'backport-to-'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Link backport PRs to Linear sub-issues
+        continue-on-error: true
+        uses: loft-sh/github-actions/.github/actions/link-backport-prs@link-backport-prs/v1 # zizmor: ignore[unpinned-uses] -- internal loft-sh/github-actions ref; reusable workflows check out the CALLER repo, so a local ./.github/actions path is not present here. @link-backport-prs/v1 is the floating coordination tag kept aligned with backport/v1 (see DEVOPS-923 pin-drift class).
+        with:
+          source-pr: ${{ github.event.pull_request.number }}
+          repo-owner: ${{ github.repository_owner }}
+          repo-name: ${{ github.event.repository.name }}
+          additional-repos: ${{ inputs.legacy-split && format('{0},{1}', inputs.oss-repo, inputs.pro-repo) || '' }}
+          github-token: ${{ secrets.gh-access-token }} # zizmor: ignore[secrets-outside-env] -- PAT passed through workflow_call and required for cross-repo PR edits
+          linear-token: ${{ secrets.linear-token }} # zizmor: ignore[secrets-outside-env] -- optional token passed through workflow_call

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ See [linear-release-sync README](./.github/actions/linear-release-sync/README.md
 
 ### Link Backport PRs Action
 
-Links sorenlouv-created backport PRs to the matching Linear sub-issue (`[X.Y] Copy of ...`) by adding `Fixes <id>` to the backport PR body, so the per-release-line issue closes when the backport merges. Wired into the [`backport.yaml`](./docs/workflows/backport.md) reusable workflow and runs automatically after backports are created; advisory and skipped when no `linear-token` is configured.
+Links modern and legacy backport PRs to the matching Linear sub-issue (`[X.Y] Copy of ...`) by adding `Fixes <id>` to every matching PR body, so the per-release-line issue closes when the backport merges. Wired into the [`backport.yaml`](./docs/workflows/backport.md) reusable workflow and runs after both producer paths settle; advisory and skipped when no `linear-token` is configured.
 
 **Location:** `.github/actions/link-backport-prs`
 
@@ -72,6 +72,7 @@ Links sorenlouv-created backport PRs to the matching Linear sub-issue (`[X.Y] Co
     source-pr: ${{ github.event.pull_request.number }}
     repo-owner: ${{ github.repository_owner }}
     repo-name: ${{ github.event.repository.name }}
+    additional-repos: loft-sh/vcluster,loft-sh/vcluster-pro
     github-token: ${{ secrets.GH_ACCESS_TOKEN }}
     linear-token: ${{ secrets.LINEAR_API_TOKEN }}
 ```


### PR DESCRIPTION
## Summary

- wait for modern and legacy backport producers before running the Linear linker
- discover legacy PRs by target, merge SHA, and exact source PR across the configured pro and OSS repos
- keep advisory failures and idempotent retries, and document the full flow

## Test plan

- `make test-link-backport-prs`
- `make test-backport-legacy-split`
- `make lint`
- `shellcheck .github/actions/backport-legacy-split/run.sh`
- `go vet ./...`
- generated docs are stable across repeated `make generate-docs` runs

## Rollout

After merge, move `link-backport-prs/v1` and `backport/v1` to the same commit before validating one new backport event.

Closes DEVOPS-1374